### PR TITLE
parser: Do not `OK` on recoverable errors

### DIFF
--- a/compiler/ast/src/tests.rs
+++ b/compiler/ast/src/tests.rs
@@ -5,11 +5,7 @@ use crate::{AnalysisResult, convert};
 
 fn get_ast(src: &str) -> AnalysisResult<String> {
     let tokens: Vec<_> = Lexer::from(src).collect();
-    let (program, parsing_errors) = parse_program(&tokens).expect("Failed to parse");
-    assert!(
-        parsing_errors.is_empty(),
-        "Parsing errors: {parsing_errors:?}"
-    );
+    let program = parse_program(&tokens).expect("Failed to parse");
     convert(&program).map(|res| format!("{res:#?}\n"))
 }
 

--- a/compiler/common/src/lib.rs
+++ b/compiler/common/src/lib.rs
@@ -41,7 +41,7 @@ impl Display for Identifier {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Position {
     pub line: usize,
     pub column: usize,
@@ -76,7 +76,7 @@ impl Display for Position {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Extent {
     pub start: Position,
     pub end: Position,

--- a/compiler/compiler/src/main.rs
+++ b/compiler/compiler/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use ast::convert;
 use interpreter::interpret;
 use lexer::Lexer;
+use parser::ParserError;
 use parser::parse_program;
 
 // TODO: create a Driver module
@@ -19,14 +20,17 @@ fn main() -> anyhow::Result<()> {
         println!("{token}")
     }
 
-    let (program, errs) = parse_program(tokens.as_slice()).context("Parsing error")?;
-
-    if !errs.is_empty() {
-        eprintln!("Following errors occurred:");
-        for err in errs {
-            eprintln!("\t{err}");
+    let program = match parse_program(tokens.as_slice()) {
+        Ok(program) => program,
+        Err(ParserError::Recoverable { errors, parsed }) => {
+            eprintln!("Following errors occurred:");
+            for err in errors {
+                eprintln!("\t{err}");
+            }
+            parsed
         }
-    }
+        Err(ParserError::Unrecoverable { error }) => Err(error).context("Parsing error")?,
+    };
 
     for decl in &program.0 {
         println!("{decl:?}");

--- a/compiler/interpreter/src/tests.rs
+++ b/compiler/interpreter/src/tests.rs
@@ -11,11 +11,7 @@ impl<T: fmt::Display> fmt::Debug for DebugDisplay<T> {
 
 fn interpret(src: &str) -> Result<String, DebugDisplay<String>> {
     let tokens: Vec<_> = lexer::Lexer::from(src).collect();
-    let (program, parsing_errors) = parser::parse_program(&tokens).expect("Failed to parse");
-    assert!(
-        parsing_errors.is_empty(),
-        "Parsing errors: {parsing_errors:?}"
-    );
+    let program = parser::parse_program(&tokens).expect("Failed to parse");
     let (program, _) = ast::convert(&program).expect("Failed to typecheck");
     let mut output: Vec<u8> = vec![];
     let result = crate::interpret(&mut output, &program);

--- a/compiler/lexer/src/tokens.rs
+++ b/compiler/lexer/src/tokens.rs
@@ -171,7 +171,7 @@ impl fmt::Display for TokenKind<'_> {
 }
 
 // Token description
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Token<'a> {
     pub extent: Extent,
     pub lexeme: &'a str,

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -23,9 +23,10 @@ pub use crate::{
     types::{ArrayDescription, FieldDescription, RecordDescription, Type},
 };
 
-trait TokenIterator<'a, 'b: 'a>: Clone + Copy {
+pub trait TokenIterator<'a, 'b: 'a>: Clone + Copy {
     fn current(&self) -> Option<&'a Token<'b>>;
     fn position(&self) -> Position;
+    #[must_use]
     fn next(&self) -> Self;
 }
 
@@ -85,13 +86,12 @@ impl fmt::Display for ParsingError {
 
 impl core::error::Error for ParsingError {}
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Parser {
     pub recovered_errors: Vec<ParsingError>,
 }
 
-pub type ParsingResult<'a, 'b, T> = Result<(T, IndexedIterator<'a, 'b>), ParsingError>; // For hard errors
-pub type PureParsingResult<T> = Result<T, ParsingError>;
+type ParsingResult<'a, 'b, T> = Result<(T, IndexedIterator<'a, 'b>), ParsingError>; // For hard errors
 
 trait ParsingFunction<'a, 'b: 'a, T>:
     FnMut(&mut Parser, IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, T>
@@ -103,18 +103,10 @@ impl<'a, 'b: 'a, T, F> ParsingFunction<'a, 'b, T> for F where
 {
 }
 
-impl Default for Parser {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Parser {
     #[must_use]
     pub fn new() -> Self {
-        Parser {
-            recovered_errors: vec![],
-        }
+        Self::default()
     }
 
     fn report_recovered(&mut self, reason: String, position: Position) {
@@ -1277,12 +1269,60 @@ impl Parser {
             }),
         }
     }
+
+    pub fn finish<T>(self, parsed: T) -> ParserResult<T> {
+        let Self { recovered_errors } = self;
+        if recovered_errors.is_empty() {
+            Ok(parsed)
+        } else {
+            Err(ParserError::Recoverable {
+                errors: recovered_errors,
+                parsed,
+            })
+        }
+    }
 }
 
-pub fn parse_program(tokens: &[Token<'_>]) -> PureParsingResult<(Program, Vec<ParsingError>)> {
+#[derive(Debug)]
+pub enum ParserError<T> {
+    Unrecoverable {
+        error: ParsingError,
+    },
+    Recoverable {
+        errors: Vec<ParsingError>,
+        parsed: T,
+    },
+}
+
+pub type ParserResult<T> = Result<T, ParserError<T>>;
+
+impl<T> From<ParsingError> for ParserError<T> {
+    fn from(error: ParsingError) -> Self {
+        Self::Unrecoverable { error }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Display for ParserError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unrecoverable { error } => write!(f, "unrecoverable error: {error}"),
+            Self::Recoverable { errors, parsed } => {
+                writeln!(f, "Some recoverable errors occurred during parsing:")?;
+                for err in errors {
+                    writeln!(f, "- {err}")?
+                }
+                writeln!(f, "But managed to parse: {parsed:#?}")
+            }
+        }
+    }
+}
+
+impl<T: fmt::Debug> core::error::Error for ParserError<T> {}
+
+pub fn parse_program(tokens: &[Token<'_>]) -> ParserResult<Program> {
     let mut parser = Parser::new();
     let start = parser.skip_unused(IndexedIterator::from(tokens));
-    let (decls, _) = parser.parse_all(Parser::parse_declaration, start)?;
-
-    Ok((Program(decls), parser.recovered_errors))
+    let (decls, tail) = parser.parse_all(Parser::parse_declaration, start)?;
+    debug_assert_eq!(tail.current(), None, "EOF not reached during parsing");
+    parser.finish(Program(decls))
 }

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -1,10 +1,10 @@
 use lexer::Lexer;
 
-use crate::{PureParsingResult, parse_program};
+use crate::{ParserError, Program, parse_program};
 
-fn parse(src: &str) -> PureParsingResult<String> {
+fn parse(src: &str) -> Result<String, ParserError<Program>> {
     let tokens: Vec<_> = Lexer::from(src).collect();
-    parse_program(&tokens).map(|res| format!("{res:#?}\n"))
+    parse_program(&tokens).map(|program| format!("{program:#?}"))
 }
 
 testing::tests! {

--- a/compiler/repl/src/main.rs
+++ b/compiler/repl/src/main.rs
@@ -4,13 +4,15 @@ use std::{
 };
 
 use lexer::Lexer;
-use parser::{Expression, IndexedIterator, Parser, PureParsingResult};
+use parser::{Expression, IndexedIterator, Parser, ParserResult, TokenIterator as _};
 
-fn parse_expr_from_line(str: &str) -> PureParsingResult<Rc<Expression>> {
+fn parse_expr_from_line(str: &str) -> ParserResult<Rc<Expression>> {
     let tokens: Vec<_> = Lexer::from(str).collect();
     let mut parser = Parser::new();
     let start = IndexedIterator::from(tokens.as_slice());
-    parser.parse_expr(start).map(|(val, _)| val)
+    let (result, tail) = parser.parse_expr(start)?;
+    assert_eq!(tail.current(), None, "Unparsed tokens");
+    parser.finish(result)
 }
 
 fn main() -> io::Result<()> {
@@ -24,7 +26,7 @@ fn main() -> io::Result<()> {
 
         match parse_expr_from_line(&buffer) {
             Ok(expr) => println!("{:?}", *expr),
-            Err(err) => println!("error: {} @ {}", err.what, err.position),
+            Err(err) => println!("error: {err}"),
         }
     }
 }

--- a/tests/parser/fail/invalid.txt
+++ b/tests/parser/fail/invalid.txt
@@ -1,7 +1,9 @@
-ParsingError {
-    what: "Declaration expected, \";\" @ 3:3-3:4 is SEMICOLON found",
-    position: Position {
-        line: 3,
-        column: 3,
+Unrecoverable {
+    error: ParsingError {
+        what: "Declaration expected, \";\" @ 3:3-3:4 is SEMICOLON found",
+        position: Position {
+            line: 3,
+            column: 3,
+        },
     },
 }

--- a/tests/parser/fail/lexer_invalid.txt
+++ b/tests/parser/fail/lexer_invalid.txt
@@ -1,7 +1,9 @@
-ParsingError {
-    what: "Token of kind KEYWORD(End) expected, token \"var\" @ 2:2-2:5 is KEYWORD(Var) found",
-    position: Position {
-        line: 2,
-        column: 2,
+Unrecoverable {
+    error: ParsingError {
+        what: "Token of kind KEYWORD(End) expected, token \"var\" @ 2:2-2:5 is KEYWORD(Var) found",
+        position: Position {
+            line: 2,
+            column: 2,
+        },
     },
 }

--- a/tests/parser/pass/arithmetic_operations.txt
+++ b/tests/parser/pass/arithmetic_operations.txt
@@ -1,399 +1,396 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "7",
-                                                        value: 7,
-                                                    },
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "7",
+                                                    value: 7,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"x",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "5.5",
+                                                    value: 5.5,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"y",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "2.0",
+                                                    value: 2.0,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "3",
-                                                        value: 3,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Minus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"x",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "5.5",
-                                                        value: 5.5,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mul,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"y",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "2.0",
-                                                        value: 2.0,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Div,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mod,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Minus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Div,
+                                            lhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "-7",
+                                                    value: -7,
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mul,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mod,
+                                            lhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "-7",
+                                                    value: -7,
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Div,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Div,
+                                            lhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "7",
+                                                    value: 7,
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "-3",
+                                                    value: -3,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mod,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mod,
+                                            lhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "7",
+                                                    value: 7,
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "-3",
+                                                    value: -3,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Div,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "-7",
-                                                        value: -7,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "3",
-                                                        value: 3,
-                                                    },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mod,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "-7",
-                                                        value: -7,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Minus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "3",
-                                                        value: 3,
-                                                    },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Div,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "7",
-                                                        value: 7,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mul,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "-3",
-                                                        value: -3,
-                                                    },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mod,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "7",
-                                                        value: 7,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Div,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "-3",
-                                                        value: -3,
-                                                    },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Minus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mul,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mul,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Div,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Minus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: UnOp {
+                                            op: Minus,
+                                            operand: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
-                                                ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: UnOp {
+                                            op: Minus,
+                                            operand: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mul,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Minus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: UnOp {
-                                                op: Minus,
-                                                operand: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: UnOp {
-                                                op: Minus,
-                                                operand: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/arrays_and_records.txt
+++ b/tests/parser/pass/arrays_and_records.txt
@@ -1,488 +1,274 @@
-(
-    Program(
-        [
-            Type(
-                TypeDecl {
-                    name: r"point",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"x",
-                                    t: Real,
-                                },
-                                FieldDescription {
-                                    name: r"y",
-                                    t: Real,
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"triangle",
-                    t: Array(
-                        ArrayDescription {
-                            t: Alias(
-                                r"point",
-                            ),
-                            length: Some(
-                                BinOp {
-                                    op: Plus,
-                                    lhs: IntegerLiteral(
-                                        IntegerLiteral {
-                                            repr: "1",
-                                            value: 1,
-                                        },
-                                    ),
-                                    rhs: IntegerLiteral(
-                                        IntegerLiteral {
-                                            repr: "2",
-                                            value: 2,
-                                        },
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"EPS",
-                    t: None,
-                    initialiser: Some(
-                        RealLiteral(
-                            RealLiteral {
-                                repr: "0.0000001",
-                                value: 1e-7,
+Program(
+    [
+        Type(
+            TypeDecl {
+                name: r"point",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"x",
+                                t: Real,
+                            },
+                            FieldDescription {
+                                name: r"y",
+                                t: Real,
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"triangle",
+                t: Array(
+                    ArrayDescription {
+                        t: Alias(
+                            r"point",
+                        ),
+                        length: Some(
+                            BinOp {
+                                op: Plus,
+                                lhs: IntegerLiteral(
+                                    IntegerLiteral {
+                                        repr: "1",
+                                        value: 1,
+                                    },
+                                ),
+                                rhs: IntegerLiteral(
+                                    IntegerLiteral {
+                                        repr: "2",
+                                        value: 2,
+                                    },
+                                ),
                             },
                         ),
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"EPS",
+                t: None,
+                initialiser: Some(
+                    RealLiteral(
+                        RealLiteral {
+                            repr: "0.0000001",
+                            value: 1e-7,
+                        },
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"approximately_eq",
-                    arguments: [
-                        (
-                            r"a",
-                            Real,
-                        ),
-                        (
-                            r"b",
-                            Real,
-                        ),
-                        (
-                            r"eps",
-                            Real,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            BinOp {
-                                op: Lt,
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"approximately_eq",
+                arguments: [
+                    (
+                        r"a",
+                        Real,
+                    ),
+                    (
+                        r"b",
+                        Real,
+                    ),
+                    (
+                        r"eps",
+                        Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        BinOp {
+                            op: Lt,
+                            lhs: BinOp {
+                                op: Mul,
                                 lhs: BinOp {
-                                    op: Mul,
-                                    lhs: BinOp {
-                                        op: Minus,
-                                        lhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"a",
-                                            ),
-                                        ),
-                                        rhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"b",
-                                            ),
-                                        ),
-                                    },
-                                    rhs: BinOp {
-                                        op: Minus,
-                                        lhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"a",
-                                            ),
-                                        ),
-                                        rhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"b",
-                                            ),
-                                        ),
-                                    },
-                                },
-                                rhs: BinOp {
-                                    op: Mul,
+                                    op: Minus,
                                     lhs: LvalueToRvalue(
                                         Identifier(
-                                            r"eps",
+                                            r"a",
                                         ),
                                     ),
                                     rhs: LvalueToRvalue(
                                         Identifier(
-                                            r"eps",
+                                            r"b",
+                                        ),
+                                    ),
+                                },
+                                rhs: BinOp {
+                                    op: Minus,
+                                    lhs: LvalueToRvalue(
+                                        Identifier(
+                                            r"a",
+                                        ),
+                                    ),
+                                    rhs: LvalueToRvalue(
+                                        Identifier(
+                                            r"b",
                                         ),
                                     ),
                                 },
                             },
+                            rhs: BinOp {
+                                op: Mul,
+                                lhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"eps",
+                                    ),
+                                ),
+                                rhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"eps",
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"squared_distance",
+                arguments: [
+                    (
+                        r"from",
+                        Alias(
+                            r"point",
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"squared_distance",
-                    arguments: [
-                        (
-                            r"from",
-                            Alias(
-                                r"point",
-                            ),
+                    (
+                        r"to",
+                        Alias(
+                            r"point",
                         ),
-                        (
-                            r"to",
-                            Alias(
-                                r"point",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Real,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Return {
-                                            value: BinOp {
-                                                op: Plus,
+                            [
+                                Stmt(
+                                    Return {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: BinOp {
+                                                op: Mul,
                                                 lhs: BinOp {
-                                                    op: Mul,
-                                                    lhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"from",
-                                                                ),
-                                                                member_name: r"x",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"to",
-                                                                ),
-                                                                member_name: r"x",
-                                                            },
-                                                        ),
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"from",
-                                                                ),
-                                                                member_name: r"x",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"to",
-                                                                ),
-                                                                member_name: r"x",
-                                                            },
-                                                        ),
-                                                    },
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"from",
+                                                            ),
+                                                            member_name: r"x",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"to",
+                                                            ),
+                                                            member_name: r"x",
+                                                        },
+                                                    ),
                                                 },
                                                 rhs: BinOp {
-                                                    op: Mul,
-                                                    lhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"from",
-                                                                ),
-                                                                member_name: r"y",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"to",
-                                                                ),
-                                                                member_name: r"y",
-                                                            },
-                                                        ),
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"from",
-                                                                ),
-                                                                member_name: r"y",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"to",
-                                                                ),
-                                                                member_name: r"y",
-                                                            },
-                                                        ),
-                                                    },
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"from",
+                                                            ),
+                                                            member_name: r"x",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"to",
+                                                            ),
+                                                            member_name: r"x",
+                                                        },
+                                                    ),
+                                                },
+                                            },
+                                            rhs: BinOp {
+                                                op: Mul,
+                                                lhs: BinOp {
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"from",
+                                                            ),
+                                                            member_name: r"y",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"to",
+                                                            ),
+                                                            member_name: r"y",
+                                                        },
+                                                    ),
+                                                },
+                                                rhs: BinOp {
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"from",
+                                                            ),
+                                                            member_name: r"y",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"to",
+                                                            ),
+                                                            member_name: r"y",
+                                                        },
+                                                    ),
                                                 },
                                             },
                                         },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"is_right",
-                    arguments: [
-                        (
-                            r"t",
-                            Alias(
-                                r"triangle",
-                            ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"is_right",
+                arguments: [
+                    (
+                        r"t",
+                        Alias(
+                            r"triangle",
                         ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            BinOp {
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        BinOp {
+                            op: Or,
+                            lhs: BinOp {
                                 op: Or,
-                                lhs: BinOp {
-                                    op: Or,
-                                    lhs: Call {
-                                        callee: r"approximately_eq",
-                                        args: [
-                                            BinOp {
-                                                op: Plus,
-                                                lhs: Call {
-                                                    callee: r"squared_distance",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Index {
-                                                                lhs: Identifier(
-                                                                    r"t",
-                                                                ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                        LvalueToRvalue(
-                                                            Index {
-                                                                lhs: Identifier(
-                                                                    r"t",
-                                                                ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "2",
-                                                                        value: 2,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"squared_distance",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Index {
-                                                                lhs: Identifier(
-                                                                    r"t",
-                                                                ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "2",
-                                                                        value: 2,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                        LvalueToRvalue(
-                                                            Index {
-                                                                lhs: Identifier(
-                                                                    r"t",
-                                                                ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "3",
-                                                                        value: 3,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            },
-                                            Call {
-                                                callee: r"squared_distance",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Index {
-                                                            lhs: Identifier(
-                                                                r"t",
-                                                            ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "1",
-                                                                    value: 1,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                    LvalueToRvalue(
-                                                        Index {
-                                                            lhs: Identifier(
-                                                                r"t",
-                                                            ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "3",
-                                                                    value: 3,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            },
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"EPS",
-                                                ),
-                                            ),
-                                        ],
-                                    },
-                                    rhs: Call {
-                                        callee: r"approximately_eq",
-                                        args: [
-                                            BinOp {
-                                                op: Plus,
-                                                lhs: Call {
-                                                    callee: r"squared_distance",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Index {
-                                                                lhs: Identifier(
-                                                                    r"t",
-                                                                ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                        LvalueToRvalue(
-                                                            Index {
-                                                                lhs: Identifier(
-                                                                    r"t",
-                                                                ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "3",
-                                                                        value: 3,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"squared_distance",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Index {
-                                                                lhs: Identifier(
-                                                                    r"t",
-                                                                ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                        LvalueToRvalue(
-                                                            Index {
-                                                                lhs: Identifier(
-                                                                    r"t",
-                                                                ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "2",
-                                                                        value: 2,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            },
-                                            Call {
-                                                callee: r"squared_distance",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Index {
-                                                            lhs: Identifier(
-                                                                r"t",
-                                                            ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "2",
-                                                                    value: 2,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                    LvalueToRvalue(
-                                                        Index {
-                                                            lhs: Identifier(
-                                                                r"t",
-                                                            ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "3",
-                                                                    value: 3,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            },
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"EPS",
-                                                ),
-                                            ),
-                                        ],
-                                    },
-                                },
-                                rhs: Call {
+                                lhs: Call {
                                     callee: r"approximately_eq",
                                     args: [
                                         BinOp {
@@ -497,8 +283,8 @@
                                                             ),
                                                             index: IntegerLiteral(
                                                                 IntegerLiteral {
-                                                                    repr: "3",
-                                                                    value: 3,
+                                                                    repr: "1",
+                                                                    value: 1,
                                                                 },
                                                             ),
                                                         },
@@ -510,8 +296,8 @@
                                                             ),
                                                             index: IntegerLiteral(
                                                                 IntegerLiteral {
-                                                                    repr: "1",
-                                                                    value: 1,
+                                                                    repr: "2",
+                                                                    value: 2,
                                                                 },
                                                             ),
                                                         },
@@ -528,8 +314,8 @@
                                                             ),
                                                             index: IntegerLiteral(
                                                                 IntegerLiteral {
-                                                                    repr: "3",
-                                                                    value: 3,
+                                                                    repr: "2",
+                                                                    value: 2,
                                                                 },
                                                             ),
                                                         },
@@ -541,8 +327,8 @@
                                                             ),
                                                             index: IntegerLiteral(
                                                                 IntegerLiteral {
-                                                                    repr: "2",
-                                                                    value: 2,
+                                                                    repr: "3",
+                                                                    value: 3,
                                                                 },
                                                             ),
                                                         },
@@ -573,8 +359,114 @@
                                                         ),
                                                         index: IntegerLiteral(
                                                             IntegerLiteral {
+                                                                repr: "3",
+                                                                value: 3,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"EPS",
+                                            ),
+                                        ),
+                                    ],
+                                },
+                                rhs: Call {
+                                    callee: r"approximately_eq",
+                                    args: [
+                                        BinOp {
+                                            op: Plus,
+                                            lhs: Call {
+                                                callee: r"squared_distance",
+                                                args: [
+                                                    LvalueToRvalue(
+                                                        Index {
+                                                            lhs: Identifier(
+                                                                r"t",
+                                                            ),
+                                                            index: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    LvalueToRvalue(
+                                                        Index {
+                                                            lhs: Identifier(
+                                                                r"t",
+                                                            ),
+                                                            index: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "3",
+                                                                    value: 3,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                            rhs: Call {
+                                                callee: r"squared_distance",
+                                                args: [
+                                                    LvalueToRvalue(
+                                                        Index {
+                                                            lhs: Identifier(
+                                                                r"t",
+                                                            ),
+                                                            index: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    LvalueToRvalue(
+                                                        Index {
+                                                            lhs: Identifier(
+                                                                r"t",
+                                                            ),
+                                                            index: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "2",
+                                                                    value: 2,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        },
+                                        Call {
+                                            callee: r"squared_distance",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Index {
+                                                        lhs: Identifier(
+                                                            r"t",
+                                                        ),
+                                                        index: IntegerLiteral(
+                                                            IntegerLiteral {
                                                                 repr: "2",
                                                                 value: 2,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                LvalueToRvalue(
+                                                    Index {
+                                                        lhs: Identifier(
+                                                            r"t",
+                                                        ),
+                                                        index: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "3",
+                                                                value: 3,
                                                             },
                                                         ),
                                                     },
@@ -589,39 +481,168 @@
                                     ],
                                 },
                             },
-                        ),
+                            rhs: Call {
+                                callee: r"approximately_eq",
+                                args: [
+                                    BinOp {
+                                        op: Plus,
+                                        lhs: Call {
+                                            callee: r"squared_distance",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Index {
+                                                        lhs: Identifier(
+                                                            r"t",
+                                                        ),
+                                                        index: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "3",
+                                                                value: 3,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                LvalueToRvalue(
+                                                    Index {
+                                                        lhs: Identifier(
+                                                            r"t",
+                                                        ),
+                                                        index: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "1",
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                        rhs: Call {
+                                            callee: r"squared_distance",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Index {
+                                                        lhs: Identifier(
+                                                            r"t",
+                                                        ),
+                                                        index: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "3",
+                                                                value: 3,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                LvalueToRvalue(
+                                                    Index {
+                                                        lhs: Identifier(
+                                                            r"t",
+                                                        ),
+                                                        index: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "2",
+                                                                value: 2,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                    Call {
+                                        callee: r"squared_distance",
+                                        args: [
+                                            LvalueToRvalue(
+                                                Index {
+                                                    lhs: Identifier(
+                                                        r"t",
+                                                    ),
+                                                    index: IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "1",
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            LvalueToRvalue(
+                                                Index {
+                                                    lhs: Identifier(
+                                                        r"t",
+                                                    ),
+                                                    index: IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "2",
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                    LvalueToRvalue(
+                                        Identifier(
+                                            r"EPS",
+                                        ),
+                                    ),
+                                ],
+                            },
+                        },
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"t",
-                                            t: Some(
-                                                Alias(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"t",
+                                        t: Some(
+                                            Alias(
+                                                r"triangle",
+                                            ),
+                                        ),
+                                        initialiser: Some(
+                                            New {
+                                                t: Alias(
                                                     r"triangle",
                                                 ),
+                                                fields: None,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"t",
                                             ),
-                                            initialiser: Some(
-                                                New {
-                                                    t: Alias(
-                                                        r"triangle",
-                                                    ),
-                                                    fields: None,
+                                            index: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
                                                 },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
+                                        rhs: New {
+                                            t: Alias(
+                                                r"point",
+                                            ),
+                                            fields: None,
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Member {
                                             lhs: Index {
                                                 lhs: Identifier(
                                                     r"t",
@@ -633,64 +654,64 @@
                                                     },
                                                 ),
                                             },
-                                            rhs: New {
-                                                t: Alias(
-                                                    r"point",
+                                            member_name: r"x",
+                                        },
+                                        rhs: RealLiteral(
+                                            RealLiteral {
+                                                repr: "0.0",
+                                                value: 0.0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Member {
+                                            lhs: Index {
+                                                lhs: Identifier(
+                                                    r"t",
                                                 ),
-                                                fields: None,
+                                                index: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
+                                                    },
+                                                ),
                                             },
+                                            member_name: r"y",
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Member {
-                                                lhs: Index {
-                                                    lhs: Identifier(
-                                                        r"t",
-                                                    ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                },
-                                                member_name: r"x",
+                                        rhs: RealLiteral(
+                                            RealLiteral {
+                                                repr: "0.0",
+                                                value: 0.0,
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "0.0",
-                                                    value: 0.0,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"t",
+                                            ),
+                                            index: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
                                                 },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Member {
-                                                lhs: Index {
-                                                    lhs: Identifier(
-                                                        r"t",
-                                                    ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                },
-                                                member_name: r"y",
-                                            },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "0.0",
-                                                    value: 0.0,
-                                                },
+                                        rhs: New {
+                                            t: Alias(
+                                                r"point",
                                             ),
+                                            fields: None,
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Member {
                                             lhs: Index {
                                                 lhs: Identifier(
                                                     r"t",
@@ -702,64 +723,64 @@
                                                     },
                                                 ),
                                             },
-                                            rhs: New {
-                                                t: Alias(
-                                                    r"point",
+                                            member_name: r"x",
+                                        },
+                                        rhs: RealLiteral(
+                                            RealLiteral {
+                                                repr: "3.0",
+                                                value: 3.0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Member {
+                                            lhs: Index {
+                                                lhs: Identifier(
+                                                    r"t",
                                                 ),
-                                                fields: None,
+                                                index: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "2",
+                                                        value: 2,
+                                                    },
+                                                ),
                                             },
+                                            member_name: r"y",
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Member {
-                                                lhs: Index {
-                                                    lhs: Identifier(
-                                                        r"t",
-                                                    ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                },
-                                                member_name: r"x",
+                                        rhs: RealLiteral(
+                                            RealLiteral {
+                                                repr: "0.0",
+                                                value: 0.0,
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "3.0",
-                                                    value: 3.0,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"t",
+                                            ),
+                                            index: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
                                                 },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Member {
-                                                lhs: Index {
-                                                    lhs: Identifier(
-                                                        r"t",
-                                                    ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                },
-                                                member_name: r"y",
-                                            },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "0.0",
-                                                    value: 0.0,
-                                                },
+                                        rhs: New {
+                                            t: Alias(
+                                                r"point",
                                             ),
+                                            fields: None,
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Member {
                                             lhs: Index {
                                                 lhs: Identifier(
                                                     r"t",
@@ -771,83 +792,59 @@
                                                     },
                                                 ),
                                             },
-                                            rhs: New {
-                                                t: Alias(
-                                                    r"point",
+                                            member_name: r"x",
+                                        },
+                                        rhs: RealLiteral(
+                                            RealLiteral {
+                                                repr: "0.0",
+                                                value: 0.0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Member {
+                                            lhs: Index {
+                                                lhs: Identifier(
+                                                    r"t",
                                                 ),
-                                                fields: None,
+                                                index: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "3",
+                                                        value: 3,
+                                                    },
+                                                ),
                                             },
+                                            member_name: r"y",
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Member {
-                                                lhs: Index {
-                                                    lhs: Identifier(
+                                        rhs: RealLiteral(
+                                            RealLiteral {
+                                                repr: "4.0",
+                                                value: 4.0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: Call {
+                                            callee: r"is_right",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
                                                         r"t",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "3",
-                                                            value: 3,
-                                                        },
-                                                    ),
-                                                },
-                                                member_name: r"x",
-                                            },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "0.0",
-                                                    value: 0.0,
-                                                },
-                                            ),
+                                                ),
+                                            ],
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Member {
-                                                lhs: Index {
-                                                    lhs: Identifier(
-                                                        r"t",
-                                                    ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "3",
-                                                            value: 3,
-                                                        },
-                                                    ),
-                                                },
-                                                member_name: r"y",
-                                            },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "4.0",
-                                                    value: 4.0,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: Call {
-                                                callee: r"is_right",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"t",
-                                                        ),
-                                                    ),
-                                                ],
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/assert.txt
+++ b/tests/parser/pass/assert.txt
@@ -1,79 +1,76 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Assert {
-                                            pos: Position {
-                                                line: 2,
-                                                column: 1,
-                                            },
-                                            value: BoolLiteral(
-                                                True,
-                                            ),
+                            [
+                                Stmt(
+                                    Assert {
+                                        pos: Position {
+                                            line: 2,
+                                            column: 1,
                                         },
-                                    ),
-                                    Stmt(
-                                        Assert {
-                                            pos: Position {
-                                                line: 3,
-                                                column: 1,
-                                            },
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "1",
-                                                    value: 1,
-                                                },
-                                            ),
+                                        value: BoolLiteral(
+                                            True,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assert {
+                                        pos: Position {
+                                            line: 3,
+                                            column: 1,
                                         },
-                                    ),
-                                    Stmt(
-                                        Assert {
-                                            pos: Position {
-                                                line: 4,
-                                                column: 1,
+                                        value: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "1",
+                                                value: 1,
                                             },
-                                            value: BinOp {
-                                                op: Eq,
-                                                lhs: BinOp {
-                                                    op: Plus,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assert {
+                                        pos: Position {
+                                            line: 4,
+                                            column: 1,
+                                        },
+                                        value: BinOp {
+                                            op: Eq,
+                                            lhs: BinOp {
+                                                op: Plus,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "2",
+                                                        value: 2,
+                                                    },
+                                                ),
                                                 rhs: IntegerLiteral(
                                                     IntegerLiteral {
-                                                        repr: "5",
-                                                        value: 5,
+                                                        repr: "2",
+                                                        value: 2,
                                                     },
                                                 ),
                                             },
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "5",
+                                                    value: 5,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/comparison_operators.txt
+++ b/tests/parser/pass/comparison_operators.txt
@@ -1,308 +1,305 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "5",
-                                                        value: 5,
-                                                    },
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "5",
+                                                    value: 5,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"x",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "2.5",
+                                                    value: 2.5,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"y",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "5.0",
+                                                    value: 5.0,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Lt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "3",
-                                                        value: 3,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Le,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"x",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "2.5",
-                                                        value: 2.5,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Gt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"y",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "5.0",
-                                                        value: 5.0,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Ge,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Lt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Le,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Ne,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Gt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Lt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Ge,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Le,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Gt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Ne,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Ge,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Lt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Le,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Ne,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Gt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
-                                                ),
-                                            },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Eq,
+                                            lhs: BoolLiteral(
+                                                True,
+                                            ),
+                                            rhs: BoolLiteral(
+                                                False,
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Ge,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
-                                                ),
-                                            },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Ne,
+                                            lhs: BoolLiteral(
+                                                True,
+                                            ),
+                                            rhs: BoolLiteral(
+                                                False,
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Ne,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Eq,
-                                                lhs: BoolLiteral(
-                                                    True,
-                                                ),
-                                                rhs: BoolLiteral(
-                                                    False,
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Ne,
-                                                lhs: BoolLiteral(
-                                                    True,
-                                                ),
-                                                rhs: BoolLiteral(
-                                                    False,
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/complex_expressions.txt
+++ b/tests/parser/pass/complex_expressions.txt
@@ -1,100 +1,129 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"add_one",
-                    arguments: [
-                        (
-                            r"n",
-                            Int,
-                        ),
-                    ],
-                    return_type: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"add_one",
+                arguments: [
+                    (
+                        r"n",
                         Int,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Return {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"n",
-                                                    ),
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
-                                                    },
+                            [
+                                Stmt(
+                                    Return {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"n",
                                                 ),
                                             ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"c",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "4",
+                                                    value: 4,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                            rhs: BinOp {
+                                                op: Mul,
+                                                lhs: IntegerLiteral(
                                                     IntegerLiteral {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"c",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
+                                                rhs: IntegerLiteral(
                                                     IntegerLiteral {
                                                         repr: "4",
                                                         value: 4,
                                                     },
                                                 ),
-                                            ),
+                                            },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mul,
+                                            lhs: BinOp {
                                                 op: Plus,
                                                 lhs: IntegerLiteral(
                                                     IntegerLiteral {
@@ -102,43 +131,49 @@
                                                         value: 2,
                                                     },
                                                 ),
-                                                rhs: BinOp {
-                                                    op: Mul,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "3",
-                                                            value: 3,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "4",
-                                                            value: 4,
-                                                        },
-                                                    ),
-                                                },
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "3",
+                                                        value: 3,
+                                                    },
+                                                ),
                                             },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mul,
-                                                lhs: BinOp {
-                                                    op: Plus,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "3",
-                                                            value: 3,
-                                                        },
-                                                    ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "4",
+                                                    value: 4,
                                                 },
+                                            ),
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Lt,
+                                            lhs: BinOp {
+                                                op: Plus,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
+                                                    },
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "2",
+                                                        value: 2,
+                                                    },
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Plus,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "3",
+                                                        value: 3,
+                                                    },
+                                                ),
                                                 rhs: IntegerLiteral(
                                                     IntegerLiteral {
                                                         repr: "4",
@@ -147,281 +182,243 @@
                                                 ),
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: BinOp {
                                                 op: Lt,
-                                                lhs: BinOp {
-                                                    op: Plus,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                },
-                                                rhs: BinOp {
-                                                    op: Plus,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "3",
-                                                            value: 3,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "4",
-                                                            value: 4,
-                                                        },
-                                                    ),
-                                                },
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
+                                                    },
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "2",
+                                                        value: 2,
+                                                    },
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Lt,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "3",
+                                                        value: 3,
+                                                    },
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "4",
+                                                        value: 4,
+                                                    },
+                                                ),
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: BinOp {
-                                                    op: Lt,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                },
-                                                rhs: BinOp {
-                                                    op: Lt,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "3",
-                                                            value: 3,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "4",
-                                                            value: 4,
-                                                        },
-                                                    ),
-                                                },
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mul,
-                                                lhs: BinOp {
-                                                    op: Plus,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"a",
-                                                        ),
-                                                    ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"b",
-                                                        ),
-                                                    ),
-                                                },
-                                                rhs: BinOp {
-                                                    op: Minus,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"c",
-                                                        ),
-                                                    ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"a",
-                                                        ),
-                                                    ),
-                                                },
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mul,
+                                            lhs: BinOp {
                                                 op: Plus,
                                                 lhs: LvalueToRvalue(
                                                     Identifier(
                                                         r"a",
                                                     ),
                                                 ),
-                                                rhs: BinOp {
-                                                    op: Mul,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"b",
-                                                        ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"b",
                                                     ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"c",
-                                                        ),
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Minus,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"c",
                                                     ),
-                                                },
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"a",
+                                                    ),
+                                                ),
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: Call {
-                                                    callee: r"add_one",
-                                                    args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "5",
-                                                                value: 5,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"add_one",
-                                                    args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "3",
-                                                                value: 3,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: BinOp {
+                                                op: Mul,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"b",
+                                                    ),
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"c",
+                                                    ),
+                                                ),
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: Call {
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: Call {
                                                 callee: r"add_one",
                                                 args: [
-                                                    Call {
-                                                        callee: r"add_one",
-                                                        args: [
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "2",
-                                                                    value: 2,
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "5",
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                            rhs: Call {
+                                                callee: r"add_one",
+                                                args: [
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "3",
+                                                            value: 3,
+                                                        },
+                                                    ),
                                                 ],
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: BinOp {
-                                                    op: Lt,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"a",
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: Call {
+                                            callee: r"add_one",
+                                            args: [
+                                                Call {
+                                                    callee: r"add_one",
+                                                    args: [
+                                                        IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "2",
+                                                                value: 2,
+                                                            },
                                                         ),
-                                                    ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"b",
-                                                        ),
-                                                    ),
+                                                    ],
                                                 },
-                                                rhs: BinOp {
-                                                    op: Lt,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"b",
-                                                        ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: BinOp {
+                                                op: Lt,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"a",
                                                     ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"c",
-                                                        ),
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"b",
                                                     ),
-                                                },
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Lt,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"b",
+                                                    ),
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"c",
+                                                    ),
+                                                ),
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Or,
-                                                lhs: BinOp {
-                                                    op: Gt,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"a",
-                                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Or,
+                                            lhs: BinOp {
+                                                op: Gt,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"a",
                                                     ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"b",
-                                                        ),
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"b",
                                                     ),
-                                                },
-                                                rhs: BinOp {
-                                                    op: Lt,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"b",
-                                                        ),
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Lt,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"b",
                                                     ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"c",
-                                                        ),
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"c",
                                                     ),
-                                                },
+                                                ),
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: UnOp {
-                                                op: Not,
-                                                operand: BinOp {
-                                                    op: Eq,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"a",
-                                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: UnOp {
+                                            op: Not,
+                                            operand: BinOp {
+                                                op: Eq,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"a",
                                                     ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"b",
-                                                        ),
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"b",
                                                     ),
-                                                },
+                                                ),
                                             },
                                         },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/conditionals.txt
+++ b/tests/parser/pass/conditionals.txt
@@ -1,191 +1,188 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"abs",
-                    arguments: [
-                        (
-                            r"value",
-                            Real,
-                        ),
-                    ],
-                    return_type: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"abs",
+                arguments: [
+                    (
+                        r"value",
                         Real,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Lt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"value",
-                                                    ),
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.0",
-                                                        value: 0.0,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"value",
-                                                            ),
-                                                            rhs: BinOp {
-                                                                op: Minus,
-                                                                lhs: RealLiteral(
-                                                                    RealLiteral {
-                                                                        repr: "0.0",
-                                                                        value: 0.0,
-                                                                    },
-                                                                ),
-                                                                rhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"value",
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
+                            [
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Lt,
+                                            lhs: LvalueToRvalue(
                                                 Identifier(
                                                     r"value",
                                                 ),
                                             ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "4",
-                                                        value: 4,
-                                                    },
-                                                ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.0",
+                                                    value: 0.0,
+                                                },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Eq,
-                                                lhs: BinOp {
-                                                    op: Mod,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"a",
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"value",
                                                         ),
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    VarDecl(
-                                                        VarDecl {
-                                                            name: r"dummy",
-                                                            t: None,
-                                                            initialiser: Some(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "0",
-                                                                        value: 0,
-                                                                    },
+                                                        rhs: BinOp {
+                                                            op: Minus,
+                                                            lhs: RealLiteral(
+                                                                RealLiteral {
+                                                                    repr: "0.0",
+                                                                    value: 0.0,
+                                                                },
+                                                            ),
+                                                            rhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"value",
                                                                 ),
                                                             ),
                                                         },
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"value",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "4",
+                                                    value: 4,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Eq,
+                                            lhs: BinOp {
+                                                op: Mod,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"a",
                                                     ),
-                                                    Stmt(
-                                                        Print {
-                                                            value: IntegerLiteral(
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "2",
+                                                        value: 2,
+                                                    },
+                                                ),
+                                            },
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                VarDecl(
+                                                    VarDecl {
+                                                        name: r"dummy",
+                                                        t: None,
+                                                        initialiser: Some(
+                                                            IntegerLiteral(
                                                                 IntegerLiteral {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
                                                             ),
-                                                        },
-                                                    ),
+                                                        ),
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    Print {
+                                                        value: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "0",
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    Print {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"dummy",
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: Some(
+                                            Block(
+                                                [
                                                     Stmt(
                                                         Print {
-                                                            value: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"dummy",
-                                                                ),
+                                                            value: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
                                                             ),
                                                         },
                                                     ),
                                                 ],
                                             ),
-                                            on_false: Some(
-                                                Block(
-                                                    [
-                                                        Stmt(
-                                                            Print {
-                                                                value: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/constant.txt
+++ b/tests/parser/pass/constant.txt
@@ -1,325 +1,322 @@
-(
-    Program(
-        [
-            Const(
-                ConstDecl {
-                    name: r"LENGTH",
-                    t: None,
-                    initialiser: IntegerLiteral(
+Program(
+    [
+        Const(
+            ConstDecl {
+                name: r"LENGTH",
+                t: None,
+                initialiser: IntegerLiteral(
+                    IntegerLiteral {
+                        repr: "100",
+                        value: 100,
+                    },
+                ),
+            },
+        ),
+        Const(
+            ConstDecl {
+                name: r"DOUBLE_LENGTH",
+                t: Some(
+                    Int,
+                ),
+                initialiser: BinOp {
+                    op: Mul,
+                    lhs: LvalueToRvalue(
+                        Identifier(
+                            r"LENGTH",
+                        ),
+                    ),
+                    rhs: IntegerLiteral(
                         IntegerLiteral {
-                            repr: "100",
-                            value: 100,
+                            repr: "2",
+                            value: 2,
                         },
                     ),
                 },
-            ),
-            Const(
-                ConstDecl {
-                    name: r"DOUBLE_LENGTH",
-                    t: Some(
-                        Int,
-                    ),
-                    initialiser: BinOp {
-                        op: Mul,
-                        lhs: LvalueToRvalue(
-                            Identifier(
-                                r"LENGTH",
-                            ),
-                        ),
-                        rhs: IntegerLiteral(
-                            IntegerLiteral {
-                                repr: "2",
-                                value: 2,
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"table",
+                t: Array(
+                    ArrayDescription {
+                        t: Int,
+                        length: Some(
+                            BinOp {
+                                op: Mul,
+                                lhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"LENGTH",
+                                    ),
+                                ),
+                                rhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"DOUBLE_LENGTH",
+                                    ),
+                                ),
                             },
                         ),
                     },
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"table",
-                    t: Array(
-                        ArrayDescription {
-                            t: Int,
-                            length: Some(
-                                BinOp {
-                                    op: Mul,
-                                    lhs: LvalueToRvalue(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"meow",
+                arguments: [
+                    (
+                        r"arr",
+                        Array(
+                            ArrayDescription {
+                                t: Real,
+                                length: Some(
+                                    LvalueToRvalue(
                                         Identifier(
                                             r"LENGTH",
                                         ),
                                     ),
-                                    rhs: LvalueToRvalue(
-                                        Identifier(
-                                            r"DOUBLE_LENGTH",
-                                        ),
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"meow",
-                    arguments: [
-                        (
-                            r"arr",
-                            Array(
-                                ArrayDescription {
-                                    t: Real,
-                                    length: Some(
-                                        LvalueToRvalue(
-                                            Identifier(
-                                                r"LENGTH",
-                                            ),
-                                        ),
-                                    ),
-                                },
-                            ),
+                                ),
+                            },
                         ),
-                    ],
-                    return_type: Some(
-                        Real,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Index {
-                                                    lhs: Identifier(
-                                                        r"arr",
+                            [
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Index {
+                                                lhs: Identifier(
+                                                    r"arr",
+                                                ),
+                                                index: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"table_receiver",
+                arguments: [
+                    (
+                        r"t",
+                        Alias(
+                            r"table",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Index {
+                                                lhs: Identifier(
+                                                    r"t",
+                                                ),
+                                                index: BinOp {
+                                                    op: Mul,
+                                                    lhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"LENGTH",
+                                                        ),
                                                     ),
-                                                    index: IntegerLiteral(
+                                                    rhs: IntegerLiteral(
                                                         IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
+                                                            repr: "2",
+                                                            value: 2,
                                                         },
                                                     ),
                                                 },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"table_receiver",
-                    arguments: [
-                        (
-                            r"t",
-                            Alias(
-                                r"table",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Int,
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Index {
-                                                    lhs: Identifier(
-                                                        r"t",
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Index {
+                                                lhs: Identifier(
+                                                    r"t",
+                                                ),
+                                                index: BinOp {
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"DOUBLE_LENGTH",
+                                                        ),
                                                     ),
-                                                    index: BinOp {
-                                                        op: Mul,
-                                                        lhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"LENGTH",
-                                                            ),
+                                                    rhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"LENGTH",
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "2",
-                                                                value: 2,
-                                                            },
-                                                        ),
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Index {
-                                                    lhs: Identifier(
-                                                        r"t",
                                                     ),
-                                                    index: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"DOUBLE_LENGTH",
-                                                            ),
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"LENGTH",
-                                                            ),
-                                                        ),
-                                                    },
                                                 },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: Some(
-                        Int,
-                    ),
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"t",
-                                            t: None,
-                                            initialiser: Some(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"t",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Alias(
+                                                    r"table",
+                                                ),
+                                                fields: None,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Expr(
+                                        Call {
+                                            callee: r"table_receiver",
+                                            args: [
                                                 New {
                                                     t: Alias(
                                                         r"table",
                                                     ),
                                                     fields: None,
                                                 },
-                                            ),
+                                            ],
                                         },
                                     ),
-                                    Stmt(
-                                        Expr(
-                                            Call {
-                                                callee: r"table_receiver",
-                                                args: [
-                                                    New {
-                                                        t: Alias(
-                                                            r"table",
-                                                        ),
-                                                        fields: None,
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Index {
+                                                lhs: Identifier(
+                                                    r"t",
+                                                ),
+                                                index: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
                                                     },
-                                                ],
+                                                ),
                                             },
                                         ),
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Index {
-                                                    lhs: Identifier(
-                                                        r"t",
-                                                    ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    ConstDecl(
-                                        ConstDecl {
-                                            name: r"LENGTH",
-                                            t: None,
-                                            initialiser: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "300",
-                                                    value: 300,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Gt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"LENGTH",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"DOUBLE_LENGTH",
-                                                    ),
-                                                ),
+                                    },
+                                ),
+                                ConstDecl(
+                                    ConstDecl {
+                                        name: r"LENGTH",
+                                        t: None,
+                                        initialiser: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "300",
+                                                value: 300,
                                             },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Print {
-                                                            value: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"LENGTH",
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                    ConstDecl(
-                                                        ConstDecl {
-                                                            name: r"LENGTH",
-                                                            t: None,
-                                                            initialiser: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "400",
-                                                                    value: 400,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                    Stmt(
-                                                        Print {
-                                                            value: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"LENGTH",
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Gt,
+                                            lhs: LvalueToRvalue(
                                                 Identifier(
                                                     r"LENGTH",
                                                 ),
                                             ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"DOUBLE_LENGTH",
+                                                ),
+                                            ),
                                         },
-                                    ),
-                                ],
-                            ),
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Print {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"LENGTH",
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                ConstDecl(
+                                                    ConstDecl {
+                                                        name: r"LENGTH",
+                                                        t: None,
+                                                        initialiser: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "400",
+                                                                value: 400,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    Print {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"LENGTH",
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"LENGTH",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/deep_conditionals.txt
+++ b/tests/parser/pass/deep_conditionals.txt
@@ -1,176 +1,251 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"c",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"d",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"e",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"f",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"g",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"c",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Print {
+                                                        value: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "1",
+                                                                value: 1,
+                                                            },
+                                                        ),
                                                     },
                                                 ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"d",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"e",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"f",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"g",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Print {
-                                                            value: IntegerLiteral(
+                                                Stmt(
+                                                    If {
+                                                        condition: BinOp {
+                                                            op: Eq,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"b",
+                                                                ),
+                                                            ),
+                                                            rhs: IntegerLiteral(
                                                                 IntegerLiteral {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
                                                             ),
                                                         },
-                                                    ),
-                                                    Stmt(
-                                                        If {
-                                                            condition: BinOp {
-                                                                op: Eq,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"b",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
+                                                        on_true: Block(
+                                                            [
+                                                                Stmt(
+                                                                    Print {
+                                                                        value: IntegerLiteral(
+                                                                            IntegerLiteral {
+                                                                                repr: "2",
+                                                                                value: 2,
+                                                                            },
+                                                                        ),
                                                                     },
                                                                 ),
-                                                            },
-                                                            on_true: Block(
-                                                                [
-                                                                    Stmt(
-                                                                        Print {
-                                                                            value: IntegerLiteral(
+                                                                Stmt(
+                                                                    If {
+                                                                        condition: BinOp {
+                                                                            op: Eq,
+                                                                            lhs: LvalueToRvalue(
+                                                                                Identifier(
+                                                                                    r"c",
+                                                                                ),
+                                                                            ),
+                                                                            rhs: IntegerLiteral(
                                                                                 IntegerLiteral {
-                                                                                    repr: "2",
-                                                                                    value: 2,
+                                                                                    repr: "1",
+                                                                                    value: 1,
                                                                                 },
                                                                             ),
                                                                         },
-                                                                    ),
+                                                                        on_true: Block(
+                                                                            [
+                                                                                Stmt(
+                                                                                    Print {
+                                                                                        value: IntegerLiteral(
+                                                                                            IntegerLiteral {
+                                                                                                repr: "3",
+                                                                                                value: 3,
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        ),
+                                                                        on_false: Some(
+                                                                            Block(
+                                                                                [
+                                                                                    Stmt(
+                                                                                        If {
+                                                                                            condition: BinOp {
+                                                                                                op: Eq,
+                                                                                                lhs: LvalueToRvalue(
+                                                                                                    Identifier(
+                                                                                                        r"d",
+                                                                                                    ),
+                                                                                                ),
+                                                                                                rhs: IntegerLiteral(
+                                                                                                    IntegerLiteral {
+                                                                                                        repr: "1",
+                                                                                                        value: 1,
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
+                                                                                            on_true: Block(
+                                                                                                [
+                                                                                                    Stmt(
+                                                                                                        Print {
+                                                                                                            value: IntegerLiteral(
+                                                                                                                IntegerLiteral {
+                                                                                                                    repr: "0",
+                                                                                                                    value: 0,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                            ),
+                                                                                            on_false: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
+                                                        on_false: Some(
+                                                            Block(
+                                                                [
                                                                     Stmt(
                                                                         If {
                                                                             condition: BinOp {
                                                                                 op: Eq,
                                                                                 lhs: LvalueToRvalue(
                                                                                     Identifier(
-                                                                                        r"c",
+                                                                                        r"e",
                                                                                     ),
                                                                                 ),
                                                                                 rhs: IntegerLiteral(
@@ -186,8 +261,8 @@
                                                                                         Print {
                                                                                             value: IntegerLiteral(
                                                                                                 IntegerLiteral {
-                                                                                                    repr: "3",
-                                                                                                    value: 3,
+                                                                                                    repr: "0",
+                                                                                                    value: 0,
                                                                                                 },
                                                                                             ),
                                                                                         },
@@ -203,7 +278,7 @@
                                                                                                     op: Eq,
                                                                                                     lhs: LvalueToRvalue(
                                                                                                         Identifier(
-                                                                                                            r"d",
+                                                                                                            r"f",
                                                                                                         ),
                                                                                                     ),
                                                                                                     rhs: IntegerLiteral(
@@ -237,120 +312,193 @@
                                                                     ),
                                                                 ],
                                                             ),
-                                                            on_false: Some(
-                                                                Block(
-                                                                    [
-                                                                        Stmt(
-                                                                            If {
-                                                                                condition: BinOp {
-                                                                                    op: Eq,
-                                                                                    lhs: LvalueToRvalue(
-                                                                                        Identifier(
-                                                                                            r"e",
-                                                                                        ),
-                                                                                    ),
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
-                                                                                            repr: "1",
-                                                                                            value: 1,
-                                                                                        },
-                                                                                    ),
-                                                                                },
-                                                                                on_true: Block(
-                                                                                    [
-                                                                                        Stmt(
-                                                                                            Print {
-                                                                                                value: IntegerLiteral(
-                                                                                                    IntegerLiteral {
-                                                                                                        repr: "0",
-                                                                                                        value: 0,
-                                                                                                    },
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                ),
-                                                                                on_false: Some(
-                                                                                    Block(
-                                                                                        [
-                                                                                            Stmt(
-                                                                                                If {
-                                                                                                    condition: BinOp {
-                                                                                                        op: Eq,
-                                                                                                        lhs: LvalueToRvalue(
-                                                                                                            Identifier(
-                                                                                                                r"f",
-                                                                                                            ),
-                                                                                                        ),
-                                                                                                        rhs: IntegerLiteral(
-                                                                                                            IntegerLiteral {
-                                                                                                                repr: "1",
-                                                                                                                value: 1,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    },
-                                                                                                    on_true: Block(
-                                                                                                        [
-                                                                                                            Stmt(
-                                                                                                                Print {
-                                                                                                                    value: IntegerLiteral(
-                                                                                                                        IntegerLiteral {
-                                                                                                                            repr: "0",
-                                                                                                                            value: 0,
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                },
-                                                                                                            ),
-                                                                                                        ],
-                                                                                                    ),
-                                                                                                    on_false: None,
-                                                                                                },
-                                                                                            ),
-                                                                                        ],
-                                                                                    ),
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    ],
+                                                        ),
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    If {
+                                                        condition: BinOp {
+                                                            op: Eq,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"d",
                                                                 ),
                                                             ),
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
                                                         },
-                                                    ),
-                                                    Stmt(
-                                                        If {
-                                                            condition: BinOp {
-                                                                op: Eq,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"d",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
+                                                        on_true: Block(
+                                                            [
+                                                                Stmt(
+                                                                    Print {
+                                                                        value: IntegerLiteral(
+                                                                            IntegerLiteral {
+                                                                                repr: "4",
+                                                                                value: 4,
+                                                                            },
+                                                                        ),
                                                                     },
                                                                 ),
-                                                            },
-                                                            on_true: Block(
-                                                                [
-                                                                    Stmt(
-                                                                        Print {
-                                                                            value: IntegerLiteral(
+                                                                Stmt(
+                                                                    If {
+                                                                        condition: BinOp {
+                                                                            op: Eq,
+                                                                            lhs: LvalueToRvalue(
+                                                                                Identifier(
+                                                                                    r"e",
+                                                                                ),
+                                                                            ),
+                                                                            rhs: IntegerLiteral(
                                                                                 IntegerLiteral {
-                                                                                    repr: "4",
-                                                                                    value: 4,
+                                                                                    repr: "1",
+                                                                                    value: 1,
                                                                                 },
                                                                             ),
                                                                         },
-                                                                    ),
+                                                                        on_true: Block(
+                                                                            [
+                                                                                Stmt(
+                                                                                    Print {
+                                                                                        value: IntegerLiteral(
+                                                                                            IntegerLiteral {
+                                                                                                repr: "5",
+                                                                                                value: 5,
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Stmt(
+                                                                                    If {
+                                                                                        condition: BinOp {
+                                                                                            op: Eq,
+                                                                                            lhs: LvalueToRvalue(
+                                                                                                Identifier(
+                                                                                                    r"f",
+                                                                                                ),
+                                                                                            ),
+                                                                                            rhs: IntegerLiteral(
+                                                                                                IntegerLiteral {
+                                                                                                    repr: "1",
+                                                                                                    value: 1,
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                        on_true: Block(
+                                                                                            [
+                                                                                                Stmt(
+                                                                                                    Print {
+                                                                                                        value: IntegerLiteral(
+                                                                                                            IntegerLiteral {
+                                                                                                                repr: "6",
+                                                                                                                value: 6,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                                Stmt(
+                                                                                                    If {
+                                                                                                        condition: BinOp {
+                                                                                                            op: Eq,
+                                                                                                            lhs: LvalueToRvalue(
+                                                                                                                Identifier(
+                                                                                                                    r"g",
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                            rhs: IntegerLiteral(
+                                                                                                                IntegerLiteral {
+                                                                                                                    repr: "1",
+                                                                                                                    value: 1,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        on_true: Block(
+                                                                                                            [
+                                                                                                                Stmt(
+                                                                                                                    Print {
+                                                                                                                        value: IntegerLiteral(
+                                                                                                                            IntegerLiteral {
+                                                                                                                                repr: "7",
+                                                                                                                                value: 7,
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ],
+                                                                                                        ),
+                                                                                                        on_false: Some(
+                                                                                                            Block(
+                                                                                                                [
+                                                                                                                    Stmt(
+                                                                                                                        Print {
+                                                                                                                            value: IntegerLiteral(
+                                                                                                                                IntegerLiteral {
+                                                                                                                                    repr: "0",
+                                                                                                                                    value: 0,
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                ],
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                            ],
+                                                                                        ),
+                                                                                        on_false: Some(
+                                                                                            Block(
+                                                                                                [
+                                                                                                    Stmt(
+                                                                                                        Print {
+                                                                                                            value: IntegerLiteral(
+                                                                                                                IntegerLiteral {
+                                                                                                                    repr: "0",
+                                                                                                                    value: 0,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        ),
+                                                                        on_false: Some(
+                                                                            Block(
+                                                                                [
+                                                                                    Stmt(
+                                                                                        Print {
+                                                                                            value: IntegerLiteral(
+                                                                                                IntegerLiteral {
+                                                                                                    repr: "0",
+                                                                                                    value: 0,
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
+                                                        on_false: Some(
+                                                            Block(
+                                                                [
                                                                     Stmt(
                                                                         If {
                                                                             condition: BinOp {
                                                                                 op: Eq,
                                                                                 lhs: LvalueToRvalue(
                                                                                     Identifier(
-                                                                                        r"e",
+                                                                                        r"b",
                                                                                     ),
                                                                                 ),
                                                                                 rhs: IntegerLiteral(
@@ -366,92 +514,34 @@
                                                                                         Print {
                                                                                             value: IntegerLiteral(
                                                                                                 IntegerLiteral {
-                                                                                                    repr: "5",
-                                                                                                    value: 5,
+                                                                                                    repr: "0",
+                                                                                                    value: 0,
                                                                                                 },
                                                                                             ),
                                                                                         },
                                                                                     ),
-                                                                                    Stmt(
-                                                                                        If {
-                                                                                            condition: BinOp {
-                                                                                                op: Eq,
-                                                                                                lhs: LvalueToRvalue(
-                                                                                                    Identifier(
-                                                                                                        r"f",
+                                                                                ],
+                                                                            ),
+                                                                            on_false: Some(
+                                                                                Block(
+                                                                                    [
+                                                                                        Stmt(
+                                                                                            If {
+                                                                                                condition: BinOp {
+                                                                                                    op: Eq,
+                                                                                                    lhs: LvalueToRvalue(
+                                                                                                        Identifier(
+                                                                                                            r"c",
+                                                                                                        ),
                                                                                                     ),
-                                                                                                ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
-                                                                                                        repr: "1",
-                                                                                                        value: 1,
-                                                                                                    },
-                                                                                                ),
-                                                                                            },
-                                                                                            on_true: Block(
-                                                                                                [
-                                                                                                    Stmt(
-                                                                                                        Print {
-                                                                                                            value: IntegerLiteral(
-                                                                                                                IntegerLiteral {
-                                                                                                                    repr: "6",
-                                                                                                                    value: 6,
-                                                                                                                },
-                                                                                                            ),
+                                                                                                    rhs: IntegerLiteral(
+                                                                                                        IntegerLiteral {
+                                                                                                            repr: "1",
+                                                                                                            value: 1,
                                                                                                         },
                                                                                                     ),
-                                                                                                    Stmt(
-                                                                                                        If {
-                                                                                                            condition: BinOp {
-                                                                                                                op: Eq,
-                                                                                                                lhs: LvalueToRvalue(
-                                                                                                                    Identifier(
-                                                                                                                        r"g",
-                                                                                                                    ),
-                                                                                                                ),
-                                                                                                                rhs: IntegerLiteral(
-                                                                                                                    IntegerLiteral {
-                                                                                                                        repr: "1",
-                                                                                                                        value: 1,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            },
-                                                                                                            on_true: Block(
-                                                                                                                [
-                                                                                                                    Stmt(
-                                                                                                                        Print {
-                                                                                                                            value: IntegerLiteral(
-                                                                                                                                IntegerLiteral {
-                                                                                                                                    repr: "7",
-                                                                                                                                    value: 7,
-                                                                                                                                },
-                                                                                                                            ),
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                ],
-                                                                                                            ),
-                                                                                                            on_false: Some(
-                                                                                                                Block(
-                                                                                                                    [
-                                                                                                                        Stmt(
-                                                                                                                            Print {
-                                                                                                                                value: IntegerLiteral(
-                                                                                                                                    IntegerLiteral {
-                                                                                                                                        repr: "0",
-                                                                                                                                        value: 0,
-                                                                                                                                    },
-                                                                                                                                ),
-                                                                                                                            },
-                                                                                                                        ),
-                                                                                                                    ],
-                                                                                                                ),
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ],
-                                                                                            ),
-                                                                                            on_false: Some(
-                                                                                                Block(
+                                                                                                },
+                                                                                                on_true: Block(
                                                                                                     [
                                                                                                         Stmt(
                                                                                                             Print {
@@ -465,26 +555,49 @@
                                                                                                         ),
                                                                                                     ],
                                                                                                 ),
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                            ),
-                                                                            on_false: Some(
-                                                                                Block(
-                                                                                    [
-                                                                                        Stmt(
-                                                                                            Print {
-                                                                                                value: IntegerLiteral(
-                                                                                                    IntegerLiteral {
-                                                                                                        repr: "0",
-                                                                                                        value: 0,
-                                                                                                    },
-                                                                                                ),
+                                                                                                on_false: None,
                                                                                             },
                                                                                         ),
                                                                                     ],
                                                                                 ),
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: Some(
+                                            Block(
+                                                [
+                                                    Stmt(
+                                                        If {
+                                                            condition: BinOp {
+                                                                op: Eq,
+                                                                lhs: LvalueToRvalue(
+                                                                    Identifier(
+                                                                        r"e",
+                                                                    ),
+                                                                ),
+                                                                rhs: IntegerLiteral(
+                                                                    IntegerLiteral {
+                                                                        repr: "1",
+                                                                        value: 1,
+                                                                    },
+                                                                ),
+                                                            },
+                                                            on_true: Block(
+                                                                [
+                                                                    Stmt(
+                                                                        Print {
+                                                                            value: IntegerLiteral(
+                                                                                IntegerLiteral {
+                                                                                    repr: "0",
+                                                                                    value: 0,
+                                                                                },
                                                                             ),
                                                                         },
                                                                     ),
@@ -499,7 +612,7 @@
                                                                                     op: Eq,
                                                                                     lhs: LvalueToRvalue(
                                                                                         Identifier(
-                                                                                            r"b",
+                                                                                            r"g",
                                                                                         ),
                                                                                     ),
                                                                                     rhs: IntegerLiteral(
@@ -523,45 +636,7 @@
                                                                                         ),
                                                                                     ],
                                                                                 ),
-                                                                                on_false: Some(
-                                                                                    Block(
-                                                                                        [
-                                                                                            Stmt(
-                                                                                                If {
-                                                                                                    condition: BinOp {
-                                                                                                        op: Eq,
-                                                                                                        lhs: LvalueToRvalue(
-                                                                                                            Identifier(
-                                                                                                                r"c",
-                                                                                                            ),
-                                                                                                        ),
-                                                                                                        rhs: IntegerLiteral(
-                                                                                                            IntegerLiteral {
-                                                                                                                repr: "1",
-                                                                                                                value: 1,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    },
-                                                                                                    on_true: Block(
-                                                                                                        [
-                                                                                                            Stmt(
-                                                                                                                Print {
-                                                                                                                    value: IntegerLiteral(
-                                                                                                                        IntegerLiteral {
-                                                                                                                            repr: "0",
-                                                                                                                            value: 0,
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                },
-                                                                                                            ),
-                                                                                                        ],
-                                                                                                    ),
-                                                                                                    on_false: None,
-                                                                                                },
-                                                                                            ),
-                                                                                        ],
-                                                                                    ),
-                                                                                ),
+                                                                                on_false: None,
                                                                             },
                                                                         ),
                                                                     ],
@@ -571,92 +646,14 @@
                                                     ),
                                                 ],
                                             ),
-                                            on_false: Some(
-                                                Block(
-                                                    [
-                                                        Stmt(
-                                                            If {
-                                                                condition: BinOp {
-                                                                    op: Eq,
-                                                                    lhs: LvalueToRvalue(
-                                                                        Identifier(
-                                                                            r"e",
-                                                                        ),
-                                                                    ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
-                                                                            repr: "1",
-                                                                            value: 1,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                                on_true: Block(
-                                                                    [
-                                                                        Stmt(
-                                                                            Print {
-                                                                                value: IntegerLiteral(
-                                                                                    IntegerLiteral {
-                                                                                        repr: "0",
-                                                                                        value: 0,
-                                                                                    },
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    ],
-                                                                ),
-                                                                on_false: Some(
-                                                                    Block(
-                                                                        [
-                                                                            Stmt(
-                                                                                If {
-                                                                                    condition: BinOp {
-                                                                                        op: Eq,
-                                                                                        lhs: LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"g",
-                                                                                            ),
-                                                                                        ),
-                                                                                        rhs: IntegerLiteral(
-                                                                                            IntegerLiteral {
-                                                                                                repr: "1",
-                                                                                                value: 1,
-                                                                                            },
-                                                                                        ),
-                                                                                    },
-                                                                                    on_true: Block(
-                                                                                        [
-                                                                                            Stmt(
-                                                                                                Print {
-                                                                                                    value: IntegerLiteral(
-                                                                                                        IntegerLiteral {
-                                                                                                            repr: "0",
-                                                                                                            value: 0,
-                                                                                                        },
-                                                                                                    ),
-                                                                                                },
-                                                                                            ),
-                                                                                        ],
-                                                                                    ),
-                                                                                    on_false: None,
-                                                                                },
-                                                                            ),
-                                                                        ],
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/for_loops.txt
+++ b/tests/parser/pass/for_loops.txt
@@ -1,366 +1,341 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"array_length",
-                    arguments: [
-                        (
-                            r"a",
-                            Array(
-                                ArrayDescription {
-                                    t: Int,
-                                    length: None,
-                                },
-                            ),
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"array_length",
+                arguments: [
+                    (
+                        r"a",
+                        Array(
+                            ArrayDescription {
+                                t: Int,
+                                length: None,
+                            },
                         ),
-                    ],
-                    return_type: Some(
+                    ),
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: None,
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"bubble_sort",
+                arguments: [
+                    (
+                        r"a",
+                        Array(
+                            ArrayDescription {
+                                t: Int,
+                                length: None,
+                            },
+                        ),
+                    ),
+                    (
+                        r"length",
                         Int,
                     ),
-                    body: None,
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"bubble_sort",
-                    arguments: [
-                        (
-                            r"a",
-                            Array(
-                                ArrayDescription {
-                                    t: Int,
-                                    length: None,
-                                },
-                            ),
-                        ),
-                        (
-                            r"length",
-                            Int,
-                        ),
-                    ],
-                    return_type: None,
-                    body: None,
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"sort_and_print_reversed_array",
-                    arguments: [
-                        (
-                            r"a",
-                            Array(
-                                ArrayDescription {
-                                    t: Int,
-                                    length: None,
-                                },
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Expr(
-                                            Call {
-                                                callee: r"bubble_sort",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"a",
-                                                        ),
-                                                    ),
-                                                    LvalueToRvalue(
-                                                        Member {
-                                                            lhs: Identifier(
-                                                                r"a",
-                                                            ),
-                                                            member_name: r"length",
-                                                        },
-                                                    ),
-                                                ],
-                                            },
-                                        ),
-                                    ),
-                                    Stmt(
-                                        For {
-                                            counter: r"elem",
-                                            from: LvalueToRvalue(
-                                                Identifier(
-                                                    r"a",
-                                                ),
-                                            ),
-                                            to: None,
-                                            order: Reversed,
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        Print {
-                                                            value: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"elem",
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                ],
+                return_type: None,
+                body: None,
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"sort_and_print_reversed_array",
+                arguments: [
+                    (
+                        r"a",
+                        Array(
+                            ArrayDescription {
+                                t: Int,
+                                length: None,
+                            },
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"array_length",
-                    arguments: [
-                        (
-                            r"a",
-                            Array(
-                                ArrayDescription {
-                                    t: Int,
-                                    length: None,
-                                },
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Int,
-                    ),
-                    body: Some(
+                ],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"result",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        For {
-                                            counter: r"_",
-                                            from: LvalueToRvalue(
-                                                Identifier(
-                                                    r"a",
-                                                ),
-                                            ),
-                                            to: None,
-                                            order: Direct,
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"result",
-                                                            ),
-                                                            rhs: BinOp {
-                                                                op: Plus,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"result",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"result",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"bubble_sort",
-                    arguments: [
-                        (
-                            r"a",
-                            Array(
-                                ArrayDescription {
-                                    t: Int,
-                                    length: None,
-                                },
-                            ),
-                        ),
-                        (
-                            r"length",
-                            Int,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        For {
-                                            counter: r"i",
-                                            from: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "1",
-                                                    value: 1,
-                                                },
-                                            ),
-                                            to: Some(
+                            [
+                                Stmt(
+                                    Expr(
+                                        Call {
+                                            callee: r"bubble_sort",
+                                            args: [
                                                 LvalueToRvalue(
                                                     Identifier(
-                                                        r"length",
+                                                        r"a",
                                                     ),
                                                 ),
+                                                LvalueToRvalue(
+                                                    Member {
+                                                        lhs: Identifier(
+                                                            r"a",
+                                                        ),
+                                                        member_name: r"length",
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ),
+                                Stmt(
+                                    For {
+                                        counter: r"elem",
+                                        from: LvalueToRvalue(
+                                            Identifier(
+                                                r"a",
                                             ),
-                                            order: Direct,
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        For {
-                                                            counter: r"j",
-                                                            from: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "2",
-                                                                    value: 2,
-                                                                },
+                                        ),
+                                        to: None,
+                                        order: Reversed,
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    Print {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"elem",
                                                             ),
-                                                            to: Some(
-                                                                LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"i",
-                                                                    ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"array_length",
+                arguments: [
+                    (
+                        r"a",
+                        Array(
+                            ArrayDescription {
+                                t: Int,
+                                length: None,
+                            },
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"result",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    For {
+                                        counter: r"_",
+                                        from: LvalueToRvalue(
+                                            Identifier(
+                                                r"a",
+                                            ),
+                                        ),
+                                        to: None,
+                                        order: Direct,
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"result",
+                                                        ),
+                                                        rhs: BinOp {
+                                                            op: Plus,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"result",
                                                                 ),
                                                             ),
-                                                            order: Direct,
-                                                            body: Block(
-                                                                [
-                                                                    Stmt(
-                                                                        If {
-                                                                            condition: BinOp {
-                                                                                op: Gt,
-                                                                                lhs: LvalueToRvalue(
-                                                                                    Index {
-                                                                                        lhs: Identifier(
-                                                                                            r"a",
-                                                                                        ),
-                                                                                        index: BinOp {
-                                                                                            op: Minus,
-                                                                                            lhs: LvalueToRvalue(
-                                                                                                Identifier(
-                                                                                                    r"j",
-                                                                                                ),
-                                                                                            ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
-                                                                                                    repr: "1",
-                                                                                                    value: 1,
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    },
-                                                                                ),
-                                                                                rhs: LvalueToRvalue(
-                                                                                    Index {
-                                                                                        lhs: Identifier(
-                                                                                            r"a",
-                                                                                        ),
-                                                                                        index: LvalueToRvalue(
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"result",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"bubble_sort",
+                arguments: [
+                    (
+                        r"a",
+                        Array(
+                            ArrayDescription {
+                                t: Int,
+                                length: None,
+                            },
+                        ),
+                    ),
+                    (
+                        r"length",
+                        Int,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    For {
+                                        counter: r"i",
+                                        from: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "1",
+                                                value: 1,
+                                            },
+                                        ),
+                                        to: Some(
+                                            LvalueToRvalue(
+                                                Identifier(
+                                                    r"length",
+                                                ),
+                                            ),
+                                        ),
+                                        order: Direct,
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    For {
+                                                        counter: r"j",
+                                                        from: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "2",
+                                                                value: 2,
+                                                            },
+                                                        ),
+                                                        to: Some(
+                                                            LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"i",
+                                                                ),
+                                                            ),
+                                                        ),
+                                                        order: Direct,
+                                                        body: Block(
+                                                            [
+                                                                Stmt(
+                                                                    If {
+                                                                        condition: BinOp {
+                                                                            op: Gt,
+                                                                            lhs: LvalueToRvalue(
+                                                                                Index {
+                                                                                    lhs: Identifier(
+                                                                                        r"a",
+                                                                                    ),
+                                                                                    index: BinOp {
+                                                                                        op: Minus,
+                                                                                        lhs: LvalueToRvalue(
                                                                                             Identifier(
                                                                                                 r"j",
                                                                                             ),
                                                                                         ),
-                                                                                    },
-                                                                                ),
-                                                                            },
-                                                                            on_true: Block(
-                                                                                [
-                                                                                    VarDecl(
-                                                                                        VarDecl {
-                                                                                            name: r"t",
-                                                                                            t: None,
-                                                                                            initialiser: Some(
-                                                                                                LvalueToRvalue(
-                                                                                                    Index {
-                                                                                                        lhs: Identifier(
-                                                                                                            r"a",
-                                                                                                        ),
-                                                                                                        index: LvalueToRvalue(
-                                                                                                            Identifier(
-                                                                                                                r"j",
-                                                                                                            ),
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    Stmt(
-                                                                                        Assignment {
-                                                                                            lhs: Index {
-                                                                                                lhs: Identifier(
-                                                                                                    r"a",
-                                                                                                ),
-                                                                                                index: LvalueToRvalue(
-                                                                                                    Identifier(
-                                                                                                        r"j",
-                                                                                                    ),
-                                                                                                ),
+                                                                                        rhs: IntegerLiteral(
+                                                                                            IntegerLiteral {
+                                                                                                repr: "1",
+                                                                                                value: 1,
                                                                                             },
-                                                                                            rhs: LvalueToRvalue(
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                            rhs: LvalueToRvalue(
+                                                                                Index {
+                                                                                    lhs: Identifier(
+                                                                                        r"a",
+                                                                                    ),
+                                                                                    index: LvalueToRvalue(
+                                                                                        Identifier(
+                                                                                            r"j",
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                        on_true: Block(
+                                                                            [
+                                                                                VarDecl(
+                                                                                    VarDecl {
+                                                                                        name: r"t",
+                                                                                        t: None,
+                                                                                        initialiser: Some(
+                                                                                            LvalueToRvalue(
                                                                                                 Index {
                                                                                                     lhs: Identifier(
                                                                                                         r"a",
                                                                                                     ),
-                                                                                                    index: BinOp {
-                                                                                                        op: Minus,
-                                                                                                        lhs: LvalueToRvalue(
-                                                                                                            Identifier(
-                                                                                                                r"j",
-                                                                                                            ),
+                                                                                                    index: LvalueToRvalue(
+                                                                                                        Identifier(
+                                                                                                            r"j",
                                                                                                         ),
-                                                                                                        rhs: IntegerLiteral(
-                                                                                                            IntegerLiteral {
-                                                                                                                repr: "1",
-                                                                                                                value: 1,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    },
+                                                                                                    ),
                                                                                                 },
                                                                                             ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Stmt(
+                                                                                    Assignment {
+                                                                                        lhs: Index {
+                                                                                            lhs: Identifier(
+                                                                                                r"a",
+                                                                                            ),
+                                                                                            index: LvalueToRvalue(
+                                                                                                Identifier(
+                                                                                                    r"j",
+                                                                                                ),
+                                                                                            ),
                                                                                         },
-                                                                                    ),
-                                                                                    Stmt(
-                                                                                        Assignment {
-                                                                                            lhs: Index {
+                                                                                        rhs: LvalueToRvalue(
+                                                                                            Index {
                                                                                                 lhs: Identifier(
                                                                                                     r"a",
                                                                                                 ),
@@ -379,150 +354,190 @@
                                                                                                     ),
                                                                                                 },
                                                                                             },
-                                                                                            rhs: LvalueToRvalue(
-                                                                                                Identifier(
-                                                                                                    r"t",
-                                                                                                ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Stmt(
+                                                                                    Assignment {
+                                                                                        lhs: Index {
+                                                                                            lhs: Identifier(
+                                                                                                r"a",
                                                                                             ),
+                                                                                            index: BinOp {
+                                                                                                op: Minus,
+                                                                                                lhs: LvalueToRvalue(
+                                                                                                    Identifier(
+                                                                                                        r"j",
+                                                                                                    ),
+                                                                                                ),
+                                                                                                rhs: IntegerLiteral(
+                                                                                                    IntegerLiteral {
+                                                                                                        repr: "1",
+                                                                                                        value: 1,
+                                                                                                    },
+                                                                                                ),
+                                                                                            },
                                                                                         },
-                                                                                    ),
-                                                                                ],
-                                                                            ),
-                                                                            on_false: None,
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"countdown",
-                    arguments: [
-                        (
-                            r"n",
-                            Int,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        For {
-                                            counter: r"i",
-                                            from: LvalueToRvalue(
-                                                Identifier(
-                                                    r"n",
-                                                ),
-                                            ),
-                                            to: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
+                                                                                        rhs: LvalueToRvalue(
+                                                                                            Identifier(
+                                                                                                r"t",
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        ),
+                                                                        on_false: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
                                                     },
                                                 ),
-                                            ),
-                                            order: Reversed,
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        Print {
-                                                            value: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"i",
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"count",
-                    arguments: [
-                        (
-                            r"n",
-                            Int,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"countdown",
+                arguments: [
+                    (
+                        r"n",
+                        Int,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        For {
-                                            counter: r"i",
-                                            from: IntegerLiteral(
+                            [
+                                Stmt(
+                                    For {
+                                        counter: r"i",
+                                        from: LvalueToRvalue(
+                                            Identifier(
+                                                r"n",
+                                            ),
+                                        ),
+                                        to: Some(
+                                            IntegerLiteral(
                                                 IntegerLiteral {
                                                     repr: "0",
                                                     value: 0,
                                                 },
                                             ),
-                                            to: Some(
-                                                LvalueToRvalue(
-                                                    Identifier(
-                                                        r"n",
-                                                    ),
-                                                ),
-                                            ),
-                                            order: Direct,
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        Print {
-                                                            value: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"i",
-                                                                ),
+                                        ),
+                                        order: Reversed,
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    Print {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"i",
                                                             ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"count",
+                arguments: [
+                    (
+                        r"n",
+                        Int,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"arr",
-                                            t: Some(
-                                                Array(
+                            [
+                                Stmt(
+                                    For {
+                                        counter: r"i",
+                                        from: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "0",
+                                                value: 0,
+                                            },
+                                        ),
+                                        to: Some(
+                                            LvalueToRvalue(
+                                                Identifier(
+                                                    r"n",
+                                                ),
+                                            ),
+                                        ),
+                                        order: Direct,
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    Print {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"i",
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"arr",
+                                        t: Some(
+                                            Array(
+                                                ArrayDescription {
+                                                    t: Int,
+                                                    length: Some(
+                                                        IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "5",
+                                                                value: 5,
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        initialiser: Some(
+                                            New {
+                                                t: Array(
                                                     ArrayDescription {
                                                         t: Int,
                                                         length: Some(
@@ -535,183 +550,165 @@
                                                         ),
                                                     },
                                                 ),
-                                            ),
-                                            initialiser: Some(
-                                                New {
-                                                    t: Array(
-                                                        ArrayDescription {
-                                                            t: Int,
-                                                            length: Some(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "5",
-                                                                        value: 5,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                    fields: None,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Identifier(
-                                                    r"arr",
-                                                ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
+                                                fields: None,
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "3",
-                                                    value: 3,
-                                                },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"arr",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Identifier(
-                                                    r"arr",
-                                                ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
-                                                    },
-                                                ),
-                                            },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "5",
-                                                    value: 5,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Identifier(
-                                                    r"arr",
-                                                ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "3",
-                                                        value: 3,
-                                                    },
-                                                ),
-                                            },
-                                            rhs: IntegerLiteral(
+                                            index: IntegerLiteral(
                                                 IntegerLiteral {
                                                     repr: "1",
                                                     value: 1,
                                                 },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Identifier(
-                                                    r"arr",
-                                                ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "4",
-                                                        value: 4,
-                                                    },
-                                                ),
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "3",
+                                                value: 3,
                                             },
-                                            rhs: IntegerLiteral(
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"arr",
+                                            ),
+                                            index: IntegerLiteral(
                                                 IntegerLiteral {
                                                     repr: "2",
                                                     value: 2,
                                                 },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Identifier(
-                                                    r"arr",
-                                                ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "5",
-                                                        value: 5,
-                                                    },
-                                                ),
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "5",
+                                                value: 5,
                                             },
-                                            rhs: IntegerLiteral(
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"arr",
+                                            ),
+                                            index: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
+                                                },
+                                            ),
+                                        },
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "1",
+                                                value: 1,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"arr",
+                                            ),
+                                            index: IntegerLiteral(
                                                 IntegerLiteral {
                                                     repr: "4",
                                                     value: 4,
                                                 },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Expr(
-                                            Call {
-                                                callee: r"sort_and_print_reversed_array",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"arr",
-                                                        ),
-                                                    ),
-                                                ],
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "2",
+                                                value: 2,
                                             },
                                         ),
-                                    ),
-                                    Stmt(
-                                        Expr(
-                                            Call {
-                                                callee: r"count",
-                                                args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "3",
-                                                            value: 3,
-                                                        },
-                                                    ),
-                                                ],
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"arr",
+                                            ),
+                                            index: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "5",
+                                                    value: 5,
+                                                },
+                                            ),
+                                        },
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "4",
+                                                value: 4,
                                             },
                                         ),
-                                    ),
-                                    Stmt(
-                                        Expr(
-                                            Call {
-                                                callee: r"countdown",
-                                                args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "5",
-                                                            value: 5,
-                                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Expr(
+                                        Call {
+                                            callee: r"sort_and_print_reversed_array",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"arr",
                                                     ),
-                                                ],
-                                            },
-                                        ),
+                                                ),
+                                            ],
+                                        },
                                     ),
-                                ],
-                            ),
+                                ),
+                                Stmt(
+                                    Expr(
+                                        Call {
+                                            callee: r"count",
+                                            args: [
+                                                IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "3",
+                                                        value: 3,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ),
+                                Stmt(
+                                    Expr(
+                                        Call {
+                                            callee: r"countdown",
+                                            args: [
+                                                IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "5",
+                                                        value: 5,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/function_parameters.txt
+++ b/tests/parser/pass/function_parameters.txt
@@ -1,84 +1,81 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"a_plus_b",
-                    arguments: [
-                        (
-                            r"a",
-                            Int,
-                        ),
-                        (
-                            r"b",
-                            Int,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"a_plus_b",
+                arguments: [
+                    (
+                        r"a",
+                        Int,
+                    ),
+                    (
+                        r"b",
+                        Int,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                            [
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
-                                            },
+                                            ),
+                                        },
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Expr(
+                                        Call {
+                                            callee: r"a_plus_b",
+                                            args: [
+                                                IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "3",
+                                                        value: 3,
+                                                    },
+                                                ),
+                                                IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "5",
+                                                        value: 5,
+                                                    },
+                                                ),
+                                            ],
                                         },
                                     ),
-                                ],
-                            ),
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Expr(
-                                            Call {
-                                                callee: r"a_plus_b",
-                                                args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "3",
-                                                            value: 3,
-                                                        },
-                                                    ),
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "5",
-                                                            value: 5,
-                                                        },
-                                                    ),
-                                                ],
-                                            },
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/function_return.txt
+++ b/tests/parser/pass/function_return.txt
@@ -1,77 +1,74 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"echo",
-                    arguments: [
-                        (
-                            r"data",
-                            Int,
-                        ),
-                    ],
-                    return_type: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"echo",
+                arguments: [
+                    (
+                        r"data",
                         Int,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"data",
-                                                ),
+                            [
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"data",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"data",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"data",
                                             ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: Call {
-                                                callee: r"echo",
-                                                args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "42",
-                                                            value: 42,
-                                                        },
-                                                    ),
-                                                ],
-                                            },
+                            [
+                                Stmt(
+                                    Print {
+                                        value: Call {
+                                            callee: r"echo",
+                                            args: [
+                                                IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "42",
+                                                        value: 42,
+                                                    },
+                                                ),
+                                            ],
                                         },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/identifiers.txt
+++ b/tests/parser/pass/identifiers.txt
@@ -1,245 +1,242 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"кошка",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"кошка",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"ねこ",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"π",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"α",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"值",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "4",
+                                                    value: 4,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"变量",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "5",
+                                                    value: 5,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"고양이",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "6",
+                                                    value: 6,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"pequeño_pingüino",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "7",
+                                                    value: 7,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"'no_strings",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "8",
+                                                    value: 8,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"_",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "9",
+                                                    value: 9,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"α",
+                                        ),
+                                        rhs: BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"кошка",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"ねこ",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"ねこ",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"π",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "3",
-                                                        value: 3,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"α",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"值",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "4",
-                                                        value: 4,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"变量",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "5",
-                                                        value: 5,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"고양이",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "6",
-                                                        value: 6,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"pequeño_pingüino",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "7",
-                                                        value: 7,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"'no_strings",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "8",
-                                                        value: 8,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"_",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "9",
-                                                        value: 9,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
                                                 r"α",
                                             ),
-                                            rhs: BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"кошка",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"ねこ",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"α",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"π",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"π",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"值",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"值",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"变量",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"变量",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"고양이",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"고양이",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"pequeño_pingüino",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"pequeño_pingüino",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"'no_strings",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"'no_strings",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/lazy_operators.txt
+++ b/tests/parser/pass/lazy_operators.txt
@@ -1,264 +1,261 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"False",
-                    arguments: [],
-                    return_type: Some(
-                        Bool,
-                    ),
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"False",
+                arguments: [],
+                return_type: Some(
+                    Bool,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"result",
-                                            t: None,
-                                            initialiser: Some(
-                                                BoolLiteral(
-                                                    False,
-                                                ),
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"result",
+                                        t: None,
+                                        initialiser: Some(
+                                            BoolLiteral(
+                                                False,
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"result",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"result",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"result",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"result",
                                             ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"True",
-                    arguments: [],
-                    return_type: Some(
-                        Bool,
-                    ),
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"True",
+                arguments: [],
+                return_type: Some(
+                    Bool,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"result",
-                                            t: None,
-                                            initialiser: Some(
-                                                BoolLiteral(
-                                                    True,
-                                                ),
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"result",
+                                        t: None,
+                                        initialiser: Some(
+                                            BoolLiteral(
+                                                True,
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"result",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"result",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"result",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"result",
                                             ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "0",
-                                                    value: 0,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: Call {
-                                                    callee: r"True",
-                                                    args: [],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"False",
-                                                    args: [],
-                                                },
+                            [
+                                Stmt(
+                                    Print {
+                                        value: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "0",
+                                                value: 0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: Call {
+                                                callee: r"True",
+                                                args: [],
+                                            },
+                                            rhs: Call {
+                                                callee: r"False",
+                                                args: [],
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "1",
-                                                    value: 1,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: Call {
-                                                    callee: r"False",
-                                                    args: [],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"True",
-                                                    args: [],
-                                                },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "1",
+                                                value: 1,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: Call {
+                                                callee: r"False",
+                                                args: [],
+                                            },
+                                            rhs: Call {
+                                                callee: r"True",
+                                                args: [],
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "2",
-                                                    value: 2,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Or,
-                                                lhs: Call {
-                                                    callee: r"True",
-                                                    args: [],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"False",
-                                                    args: [],
-                                                },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "2",
+                                                value: 2,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Or,
+                                            lhs: Call {
+                                                callee: r"True",
+                                                args: [],
+                                            },
+                                            rhs: Call {
+                                                callee: r"False",
+                                                args: [],
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "3",
-                                                    value: 3,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Or,
-                                                lhs: Call {
-                                                    callee: r"False",
-                                                    args: [],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"True",
-                                                    args: [],
-                                                },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "3",
+                                                value: 3,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Or,
+                                            lhs: Call {
+                                                callee: r"False",
+                                                args: [],
+                                            },
+                                            rhs: Call {
+                                                callee: r"True",
+                                                args: [],
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "4",
-                                                    value: 4,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Xor,
-                                                lhs: Call {
-                                                    callee: r"True",
-                                                    args: [],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"False",
-                                                    args: [],
-                                                },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "4",
+                                                value: 4,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Xor,
+                                            lhs: Call {
+                                                callee: r"True",
+                                                args: [],
+                                            },
+                                            rhs: Call {
+                                                callee: r"False",
+                                                args: [],
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "5",
-                                                    value: 5,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Xor,
-                                                lhs: Call {
-                                                    callee: r"False",
-                                                    args: [],
-                                                },
-                                                rhs: Call {
-                                                    callee: r"True",
-                                                    args: [],
-                                                },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "5",
+                                                value: 5,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Xor,
+                                            lhs: Call {
+                                                callee: r"False",
+                                                args: [],
+                                            },
+                                            rhs: Call {
+                                                callee: r"True",
+                                                args: [],
                                             },
                                         },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/length.txt
+++ b/tests/parser/pass/length.txt
@@ -1,161 +1,158 @@
-(
-    Program(
-        [
-            Type(
-                TypeDecl {
-                    name: r"square",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"length",
-                                    t: Real,
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"print_length",
-                    arguments: [
-                        (
-                            r"a",
-                            Array(
-                                ArrayDescription {
-                                    t: Int,
-                                    length: None,
-                                },
-                            ),
-                        ),
-                        (
-                            r"s",
-                            Alias(
-                                r"square",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"a",
-                                                    ),
-                                                    member_name: r"length",
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"s",
-                                                    ),
-                                                    member_name: r"length",
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+Program(
+    [
+        Type(
+            TypeDecl {
+                name: r"square",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"length",
+                                t: Real,
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"print_length",
+                arguments: [
+                    (
+                        r"a",
+                        Array(
+                            ArrayDescription {
+                                t: Int,
+                                length: None,
+                            },
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                    (
+                        r"s",
+                        Alias(
+                            r"square",
+                        ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Array(
-                                                        ArrayDescription {
-                                                            t: Int,
-                                                            length: Some(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "5",
-                                                                        value: 5,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                    fields: None,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"s",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Alias(
-                                                        r"square",
-                                                    ),
-                                                    fields: Some(
-                                                        [
-                                                            (
-                                                                r"length",
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "10",
-                                                                        value: 10,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        ],
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Expr(
-                                            Call {
-                                                callee: r"print_length",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"a",
-                                                        ),
-                                                    ),
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"s",
-                                                        ),
-                                                    ),
-                                                ],
+                            [
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"a",
+                                                ),
+                                                member_name: r"length",
                                             },
                                         ),
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"s",
+                                                ),
+                                                member_name: r"length",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Array(
+                                                    ArrayDescription {
+                                                        t: Int,
+                                                        length: Some(
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "5",
+                                                                    value: 5,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                fields: None,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"s",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Alias(
+                                                    r"square",
+                                                ),
+                                                fields: Some(
+                                                    [
+                                                        (
+                                                            r"length",
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "10",
+                                                                    value: 10,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ],
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Expr(
+                                        Call {
+                                            callee: r"print_length",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"a",
+                                                    ),
+                                                ),
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"s",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/logical_operators.txt
+++ b/tests/parser/pass/logical_operators.txt
@@ -1,184 +1,181 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                BoolLiteral(
-                                                    True,
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            BoolLiteral(
+                                                True,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: None,
+                                        initialiser: Some(
+                                            BoolLiteral(
+                                                False,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"x",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "5",
+                                                    value: 5,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"y",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: None,
-                                            initialiser: Some(
-                                                BoolLiteral(
-                                                    False,
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: BoolLiteral(
+                                                True,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Or,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"x",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "5",
-                                                        value: 5,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Or,
+                                            lhs: BoolLiteral(
+                                                False,
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"y",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
-                                                    },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: UnOp {
+                                            op: Not,
+                                            operand: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: UnOp {
+                                            op: Not,
+                                            operand: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: UnOp {
+                                            op: Not,
+                                            operand: LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
                                                 ),
-                                                rhs: BoolLiteral(
-                                                    True,
-                                                ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Or,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: UnOp {
+                                            op: Not,
+                                            operand: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Or,
-                                                lhs: BoolLiteral(
-                                                    False,
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: UnOp {
-                                                op: Not,
-                                                operand: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: UnOp {
-                                                op: Not,
-                                                operand: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: UnOp {
-                                                op: Not,
-                                                operand: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"x",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: UnOp {
-                                                op: Not,
-                                                operand: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"y",
-                                                    ),
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/nested_control.txt
+++ b/tests/parser/pass/nested_control.txt
@@ -1,352 +1,349 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"i",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
-                                                    },
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"i",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    While {
+                                        condition: BinOp {
+                                            op: Lt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"i",
                                                 ),
                                             ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        While {
-                                            condition: BinOp {
-                                                op: Lt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"i",
-                                                    ),
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
+                                        body: Block(
+                                            [
+                                                VarDecl(
+                                                    VarDecl {
+                                                        name: r"j",
+                                                        t: None,
+                                                        initialiser: Some(
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "0",
+                                                                    value: 0,
+                                                                },
+                                                            ),
+                                                        ),
                                                     },
                                                 ),
-                                            },
-                                            body: Block(
-                                                [
-                                                    VarDecl(
-                                                        VarDecl {
-                                                            name: r"j",
-                                                            t: None,
-                                                            initialiser: Some(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "0",
-                                                                        value: 0,
-                                                                    },
+                                                Stmt(
+                                                    While {
+                                                        condition: BinOp {
+                                                            op: Lt,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"j",
                                                                 ),
                                                             ),
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "2",
+                                                                    value: 2,
+                                                                },
+                                                            ),
                                                         },
-                                                    ),
-                                                    Stmt(
-                                                        While {
-                                                            condition: BinOp {
-                                                                op: Lt,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"j",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "2",
-                                                                        value: 2,
+                                                        body: Block(
+                                                            [
+                                                                VarDecl(
+                                                                    VarDecl {
+                                                                        name: r"k",
+                                                                        t: None,
+                                                                        initialiser: Some(
+                                                                            IntegerLiteral(
+                                                                                IntegerLiteral {
+                                                                                    repr: "0",
+                                                                                    value: 0,
+                                                                                },
+                                                                            ),
+                                                                        ),
                                                                     },
                                                                 ),
-                                                            },
-                                                            body: Block(
-                                                                [
-                                                                    VarDecl(
-                                                                        VarDecl {
-                                                                            name: r"k",
-                                                                            t: None,
-                                                                            initialiser: Some(
-                                                                                IntegerLiteral(
-                                                                                    IntegerLiteral {
-                                                                                        repr: "0",
-                                                                                        value: 0,
-                                                                                    },
+                                                                Stmt(
+                                                                    While {
+                                                                        condition: BinOp {
+                                                                            op: Lt,
+                                                                            lhs: LvalueToRvalue(
+                                                                                Identifier(
+                                                                                    r"k",
                                                                                 ),
                                                                             ),
+                                                                            rhs: IntegerLiteral(
+                                                                                IntegerLiteral {
+                                                                                    repr: "2",
+                                                                                    value: 2,
+                                                                                },
+                                                                            ),
                                                                         },
-                                                                    ),
-                                                                    Stmt(
-                                                                        While {
-                                                                            condition: BinOp {
-                                                                                op: Lt,
-                                                                                lhs: LvalueToRvalue(
-                                                                                    Identifier(
-                                                                                        r"k",
-                                                                                    ),
-                                                                                ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
-                                                                                        repr: "2",
-                                                                                        value: 2,
+                                                                        body: Block(
+                                                                            [
+                                                                                VarDecl(
+                                                                                    VarDecl {
+                                                                                        name: r"w",
+                                                                                        t: None,
+                                                                                        initialiser: Some(
+                                                                                            IntegerLiteral(
+                                                                                                IntegerLiteral {
+                                                                                                    repr: "0",
+                                                                                                    value: 0,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
                                                                                     },
                                                                                 ),
-                                                                            },
-                                                                            body: Block(
-                                                                                [
-                                                                                    VarDecl(
-                                                                                        VarDecl {
-                                                                                            name: r"w",
-                                                                                            t: None,
-                                                                                            initialiser: Some(
-                                                                                                IntegerLiteral(
-                                                                                                    IntegerLiteral {
-                                                                                                        repr: "0",
-                                                                                                        value: 0,
-                                                                                                    },
+                                                                                Stmt(
+                                                                                    While {
+                                                                                        condition: BinOp {
+                                                                                            op: Lt,
+                                                                                            lhs: LvalueToRvalue(
+                                                                                                Identifier(
+                                                                                                    r"w",
                                                                                                 ),
                                                                                             ),
+                                                                                            rhs: IntegerLiteral(
+                                                                                                IntegerLiteral {
+                                                                                                    repr: "2",
+                                                                                                    value: 2,
+                                                                                                },
+                                                                                            ),
                                                                                         },
-                                                                                    ),
-                                                                                    Stmt(
-                                                                                        While {
-                                                                                            condition: BinOp {
-                                                                                                op: Lt,
-                                                                                                lhs: LvalueToRvalue(
-                                                                                                    Identifier(
-                                                                                                        r"w",
-                                                                                                    ),
-                                                                                                ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
-                                                                                                        repr: "2",
-                                                                                                        value: 2,
+                                                                                        body: Block(
+                                                                                            [
+                                                                                                VarDecl(
+                                                                                                    VarDecl {
+                                                                                                        name: r"v",
+                                                                                                        t: None,
+                                                                                                        initialiser: Some(
+                                                                                                            IntegerLiteral(
+                                                                                                                IntegerLiteral {
+                                                                                                                    repr: "0",
+                                                                                                                    value: 0,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ),
                                                                                                     },
                                                                                                 ),
-                                                                                            },
-                                                                                            body: Block(
-                                                                                                [
-                                                                                                    VarDecl(
-                                                                                                        VarDecl {
-                                                                                                            name: r"v",
-                                                                                                            t: None,
-                                                                                                            initialiser: Some(
-                                                                                                                IntegerLiteral(
-                                                                                                                    IntegerLiteral {
-                                                                                                                        repr: "0",
-                                                                                                                        value: 0,
-                                                                                                                    },
+                                                                                                Stmt(
+                                                                                                    While {
+                                                                                                        condition: BinOp {
+                                                                                                            op: Lt,
+                                                                                                            lhs: LvalueToRvalue(
+                                                                                                                Identifier(
+                                                                                                                    r"v",
                                                                                                                 ),
                                                                                                             ),
+                                                                                                            rhs: IntegerLiteral(
+                                                                                                                IntegerLiteral {
+                                                                                                                    repr: "2",
+                                                                                                                    value: 2,
+                                                                                                                },
+                                                                                                            ),
                                                                                                         },
-                                                                                                    ),
-                                                                                                    Stmt(
-                                                                                                        While {
-                                                                                                            condition: BinOp {
-                                                                                                                op: Lt,
-                                                                                                                lhs: LvalueToRvalue(
-                                                                                                                    Identifier(
-                                                                                                                        r"v",
-                                                                                                                    ),
-                                                                                                                ),
-                                                                                                                rhs: IntegerLiteral(
-                                                                                                                    IntegerLiteral {
-                                                                                                                        repr: "2",
-                                                                                                                        value: 2,
+                                                                                                        body: Block(
+                                                                                                            [
+                                                                                                                Stmt(
+                                                                                                                    Print {
+                                                                                                                        value: LvalueToRvalue(
+                                                                                                                            Identifier(
+                                                                                                                                r"i",
+                                                                                                                            ),
+                                                                                                                        ),
                                                                                                                     },
                                                                                                                 ),
-                                                                                                            },
-                                                                                                            body: Block(
-                                                                                                                [
-                                                                                                                    Stmt(
-                                                                                                                        Print {
-                                                                                                                            value: LvalueToRvalue(
-                                                                                                                                Identifier(
-                                                                                                                                    r"i",
-                                                                                                                                ),
+                                                                                                                Stmt(
+                                                                                                                    Print {
+                                                                                                                        value: LvalueToRvalue(
+                                                                                                                            Identifier(
+                                                                                                                                r"j",
                                                                                                                             ),
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                    Stmt(
-                                                                                                                        Print {
-                                                                                                                            value: LvalueToRvalue(
-                                                                                                                                Identifier(
-                                                                                                                                    r"j",
-                                                                                                                                ),
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                Stmt(
+                                                                                                                    Print {
+                                                                                                                        value: LvalueToRvalue(
+                                                                                                                            Identifier(
+                                                                                                                                r"k",
                                                                                                                             ),
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                    Stmt(
-                                                                                                                        Print {
-                                                                                                                            value: LvalueToRvalue(
-                                                                                                                                Identifier(
-                                                                                                                                    r"k",
-                                                                                                                                ),
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                Stmt(
+                                                                                                                    Print {
+                                                                                                                        value: LvalueToRvalue(
+                                                                                                                            Identifier(
+                                                                                                                                r"w",
                                                                                                                             ),
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                    Stmt(
-                                                                                                                        Print {
-                                                                                                                            value: LvalueToRvalue(
-                                                                                                                                Identifier(
-                                                                                                                                    r"w",
-                                                                                                                                ),
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                Stmt(
+                                                                                                                    Print {
+                                                                                                                        value: LvalueToRvalue(
+                                                                                                                            Identifier(
+                                                                                                                                r"v",
                                                                                                                             ),
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                    Stmt(
-                                                                                                                        Print {
-                                                                                                                            value: LvalueToRvalue(
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                Stmt(
+                                                                                                                    Assignment {
+                                                                                                                        lhs: Identifier(
+                                                                                                                            r"v",
+                                                                                                                        ),
+                                                                                                                        rhs: BinOp {
+                                                                                                                            op: Plus,
+                                                                                                                            lhs: LvalueToRvalue(
                                                                                                                                 Identifier(
                                                                                                                                     r"v",
                                                                                                                                 ),
                                                                                                                             ),
-                                                                                                                        },
-                                                                                                                    ),
-                                                                                                                    Stmt(
-                                                                                                                        Assignment {
-                                                                                                                            lhs: Identifier(
-                                                                                                                                r"v",
+                                                                                                                            rhs: IntegerLiteral(
+                                                                                                                                IntegerLiteral {
+                                                                                                                                    repr: "1",
+                                                                                                                                    value: 1,
+                                                                                                                                },
                                                                                                                             ),
-                                                                                                                            rhs: BinOp {
-                                                                                                                                op: Plus,
-                                                                                                                                lhs: LvalueToRvalue(
-                                                                                                                                    Identifier(
-                                                                                                                                        r"v",
-                                                                                                                                    ),
-                                                                                                                                ),
-                                                                                                                                rhs: IntegerLiteral(
-                                                                                                                                    IntegerLiteral {
-                                                                                                                                        repr: "1",
-                                                                                                                                        value: 1,
-                                                                                                                                    },
-                                                                                                                                ),
-                                                                                                                            },
                                                                                                                         },
-                                                                                                                    ),
-                                                                                                                ],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                    Stmt(
-                                                                                                        Assignment {
-                                                                                                            lhs: Identifier(
-                                                                                                                r"w",
-                                                                                                            ),
-                                                                                                            rhs: BinOp {
-                                                                                                                op: Plus,
-                                                                                                                lhs: LvalueToRvalue(
-                                                                                                                    Identifier(
-                                                                                                                        r"w",
-                                                                                                                    ),
-                                                                                                                ),
-                                                                                                                rhs: IntegerLiteral(
-                                                                                                                    IntegerLiteral {
-                                                                                                                        repr: "1",
-                                                                                                                        value: 1,
                                                                                                                     },
                                                                                                                 ),
-                                                                                                            },
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    Stmt(
-                                                                                        Assignment {
-                                                                                            lhs: Identifier(
-                                                                                                r"k",
-                                                                                            ),
-                                                                                            rhs: BinOp {
-                                                                                                op: Plus,
-                                                                                                lhs: LvalueToRvalue(
-                                                                                                    Identifier(
-                                                                                                        r"k",
-                                                                                                    ),
-                                                                                                ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
-                                                                                                        repr: "1",
-                                                                                                        value: 1,
+                                                                                                            ],
+                                                                                                        ),
                                                                                                     },
                                                                                                 ),
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    Stmt(
-                                                                        Assignment {
-                                                                            lhs: Identifier(
-                                                                                r"j",
-                                                                            ),
-                                                                            rhs: BinOp {
-                                                                                op: Plus,
-                                                                                lhs: LvalueToRvalue(
-                                                                                    Identifier(
-                                                                                        r"j",
-                                                                                    ),
-                                                                                ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
-                                                                                        repr: "1",
-                                                                                        value: 1,
+                                                                                                Stmt(
+                                                                                                    Assignment {
+                                                                                                        lhs: Identifier(
+                                                                                                            r"w",
+                                                                                                        ),
+                                                                                                        rhs: BinOp {
+                                                                                                            op: Plus,
+                                                                                                            lhs: LvalueToRvalue(
+                                                                                                                Identifier(
+                                                                                                                    r"w",
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                            rhs: IntegerLiteral(
+                                                                                                                IntegerLiteral {
+                                                                                                                    repr: "1",
+                                                                                                                    value: 1,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                            ],
+                                                                                        ),
                                                                                     },
                                                                                 ),
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            ),
-                                                        },
-                                                    ),
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"i",
-                                                            ),
-                                                            rhs: BinOp {
-                                                                op: Plus,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"i",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
+                                                                                Stmt(
+                                                                                    Assignment {
+                                                                                        lhs: Identifier(
+                                                                                            r"k",
+                                                                                        ),
+                                                                                        rhs: BinOp {
+                                                                                            op: Plus,
+                                                                                            lhs: LvalueToRvalue(
+                                                                                                Identifier(
+                                                                                                    r"k",
+                                                                                                ),
+                                                                                            ),
+                                                                                            rhs: IntegerLiteral(
+                                                                                                IntegerLiteral {
+                                                                                                    repr: "1",
+                                                                                                    value: 1,
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        ),
                                                                     },
                                                                 ),
-                                                            },
+                                                                Stmt(
+                                                                    Assignment {
+                                                                        lhs: Identifier(
+                                                                            r"j",
+                                                                        ),
+                                                                        rhs: BinOp {
+                                                                            op: Plus,
+                                                                            lhs: LvalueToRvalue(
+                                                                                Identifier(
+                                                                                    r"j",
+                                                                                ),
+                                                                            ),
+                                                                            rhs: IntegerLiteral(
+                                                                                IntegerLiteral {
+                                                                                    repr: "1",
+                                                                                    value: 1,
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"i",
+                                                        ),
+                                                        rhs: BinOp {
+                                                            op: Plus,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"i",
+                                                                ),
+                                                            ),
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
                                                         },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/oob_big.txt
+++ b/tests/parser/pass/oob_big.txt
@@ -1,63 +1,60 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Array(
-                                                        ArrayDescription {
-                                                            t: Bool,
-                                                            length: Some(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "3",
-                                                                        value: 3,
-                                                                    },
-                                                                ),
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Array(
+                                                    ArrayDescription {
+                                                        t: Bool,
+                                                        length: Some(
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "3",
+                                                                    value: 3,
+                                                                },
                                                             ),
-                                                        },
-                                                    ),
-                                                    fields: None,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Index {
-                                                    lhs: Identifier(
-                                                        r"a",
-                                                    ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "10",
-                                                            value: 10,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                fields: None,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Index {
+                                                lhs: Identifier(
+                                                    r"a",
+                                                ),
+                                                index: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "10",
+                                                        value: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/oob_neg.txt
+++ b/tests/parser/pass/oob_neg.txt
@@ -1,66 +1,63 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Array(
-                                                        ArrayDescription {
-                                                            t: Bool,
-                                                            length: Some(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "3",
-                                                                        value: 3,
-                                                                    },
-                                                                ),
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Array(
+                                                    ArrayDescription {
+                                                        t: Bool,
+                                                        length: Some(
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "3",
+                                                                    value: 3,
+                                                                },
                                                             ),
-                                                        },
-                                                    ),
-                                                    fields: None,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Index {
-                                                    lhs: Identifier(
-                                                        r"a",
-                                                    ),
-                                                    index: UnOp {
-                                                        op: Minus,
-                                                        operand: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "2",
-                                                                value: 2,
-                                                            },
                                                         ),
                                                     },
+                                                ),
+                                                fields: None,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Index {
+                                                lhs: Identifier(
+                                                    r"a",
+                                                ),
+                                                index: UnOp {
+                                                    op: Minus,
+                                                    operand: IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "2",
+                                                            value: 2,
+                                                        },
+                                                    ),
                                                 },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/oob_zero.txt
+++ b/tests/parser/pass/oob_zero.txt
@@ -1,63 +1,60 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Array(
-                                                        ArrayDescription {
-                                                            t: Bool,
-                                                            length: Some(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "3",
-                                                                        value: 3,
-                                                                    },
-                                                                ),
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Array(
+                                                    ArrayDescription {
+                                                        t: Bool,
+                                                        length: Some(
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "3",
+                                                                    value: 3,
+                                                                },
                                                             ),
-                                                        },
-                                                    ),
-                                                    fields: None,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Index {
-                                                    lhs: Identifier(
-                                                        r"a",
-                                                    ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "0",
-                                                            value: 0,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                fields: None,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Index {
+                                                lhs: Identifier(
+                                                    r"a",
+                                                ),
+                                                index: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "0",
+                                                        value: 0,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/operator_precedence.txt
+++ b/tests/parser/pass/operator_precedence.txt
@@ -1,72 +1,213 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"f",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            IntegerLiteral(
-                                IntegerLiteral {
-                                    repr: "3",
-                                    value: 3,
-                                },
-                            ),
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"f",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        IntegerLiteral(
+                            IntegerLiteral {
+                                repr: "3",
+                                value: 3,
+                            },
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"g",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            IntegerLiteral(
-                                IntegerLiteral {
-                                    repr: "4",
-                                    value: 4,
-                                },
-                            ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"g",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        IntegerLiteral(
+                            IntegerLiteral {
+                                repr: "4",
+                                value: 4,
+                            },
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"h",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            IntegerLiteral(
-                                IntegerLiteral {
-                                    repr: "5",
-                                    value: 5,
-                                },
-                            ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"h",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        IntegerLiteral(
+                            IntegerLiteral {
+                                repr: "5",
+                                value: 5,
+                            },
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
+                            [
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: BinOp {
+                                                op: Lt,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "5",
+                                                        value: 5,
+                                                    },
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "3",
+                                                        value: 3,
+                                                    },
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Gt,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "4",
+                                                        value: 4,
+                                                    },
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "2",
+                                                        value: 2,
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Or,
+                                            lhs: BinOp {
+                                                op: And,
+                                                lhs: BoolLiteral(
+                                                    True,
+                                                ),
+                                                rhs: BoolLiteral(
+                                                    False,
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Eq,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
+                                                    },
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: Call {
+                                                callee: r"g",
+                                                args: [],
+                                            },
+                                            rhs: BinOp {
+                                                op: Mul,
+                                                lhs: Call {
+                                                    callee: r"h",
+                                                    args: [],
+                                                },
+                                                rhs: Call {
+                                                    callee: r"f",
+                                                    args: [],
+                                                },
+                                            },
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mod,
+                                            lhs: BinOp {
+                                                op: Mod,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "17",
+                                                        value: 17,
+                                                    },
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "5",
+                                                        value: 5,
+                                                    },
+                                                ),
+                                            },
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Mul,
+                                            lhs: BinOp {
+                                                op: Plus,
+                                                lhs: Call {
+                                                    callee: r"g",
+                                                    args: [],
+                                                },
+                                                rhs: Call {
+                                                    callee: r"h",
+                                                    args: [],
+                                                },
+                                            },
+                                            rhs: Call {
+                                                callee: r"f",
+                                                args: [],
+                                            },
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Or,
+                                            lhs: BinOp {
                                                 op: And,
                                                 lhs: BinOp {
-                                                    op: Lt,
+                                                    op: Gt,
                                                     lhs: IntegerLiteral(
                                                         IntegerLiteral {
                                                             repr: "5",
@@ -81,95 +222,45 @@
                                                     ),
                                                 },
                                                 rhs: BinOp {
-                                                    op: Gt,
+                                                    op: Lt,
                                                     lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "4",
-                                                            value: 4,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
                                                         IntegerLiteral {
                                                             repr: "2",
                                                             value: 2,
                                                         },
                                                     ),
-                                                },
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Or,
-                                                lhs: BinOp {
-                                                    op: And,
-                                                    lhs: BoolLiteral(
-                                                        True,
-                                                    ),
-                                                    rhs: BoolLiteral(
-                                                        False,
-                                                    ),
-                                                },
-                                                rhs: BinOp {
-                                                    op: Eq,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
                                                     rhs: IntegerLiteral(
                                                         IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
+                                                            repr: "4",
+                                                            value: 4,
                                                         },
                                                     ),
                                                 },
                                             },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: Call {
-                                                    callee: r"g",
-                                                    args: [],
-                                                },
-                                                rhs: BinOp {
-                                                    op: Mul,
-                                                    lhs: Call {
-                                                        callee: r"h",
-                                                        args: [],
+                                            rhs: UnOp {
+                                                op: Not,
+                                                operand: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
                                                     },
-                                                    rhs: Call {
-                                                        callee: r"f",
-                                                        args: [],
-                                                    },
-                                                },
+                                                ),
                                             },
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mod,
-                                                lhs: BinOp {
-                                                    op: Mod,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "17",
-                                                            value: 17,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "5",
-                                                            value: 5,
-                                                        },
-                                                    ),
-                                                },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Div,
+                                            lhs: BinOp {
+                                                op: Div,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "100",
+                                                        value: 100,
+                                                    },
+                                                ),
                                                 rhs: IntegerLiteral(
                                                     IntegerLiteral {
                                                         repr: "2",
@@ -177,114 +268,20 @@
                                                     },
                                                 ),
                                             },
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "5",
+                                                    value: 5,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Mul,
-                                                lhs: BinOp {
-                                                    op: Plus,
-                                                    lhs: Call {
-                                                        callee: r"g",
-                                                        args: [],
-                                                    },
-                                                    rhs: Call {
-                                                        callee: r"h",
-                                                        args: [],
-                                                    },
-                                                },
-                                                rhs: Call {
-                                                    callee: r"f",
-                                                    args: [],
-                                                },
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Or,
-                                                lhs: BinOp {
-                                                    op: And,
-                                                    lhs: BinOp {
-                                                        op: Gt,
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "5",
-                                                                value: 5,
-                                                            },
-                                                        ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "3",
-                                                                value: 3,
-                                                            },
-                                                        ),
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Lt,
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "2",
-                                                                value: 2,
-                                                            },
-                                                        ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "4",
-                                                                value: 4,
-                                                            },
-                                                        ),
-                                                    },
-                                                },
-                                                rhs: UnOp {
-                                                    op: Not,
-                                                    operand: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                },
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Div,
-                                                lhs: BinOp {
-                                                    op: Div,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "100",
-                                                            value: 100,
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "5",
-                                                        value: 5,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/panic.txt
+++ b/tests/parser/pass/panic.txt
@@ -1,67 +1,64 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "0",
-                                                    value: 0,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BoolLiteral(
-                                                True,
-                                            ),
-                                            on_true: Block(
+                            [
+                                Stmt(
+                                    Print {
+                                        value: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "0",
+                                                value: 0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BoolLiteral(
+                                            True,
+                                        ),
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Panic {
+                                                        pos: Position {
+                                                            line: 4,
+                                                            column: 2,
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: Some(
+                                            Block(
                                                 [
                                                     Stmt(
-                                                        Panic {
-                                                            pos: Position {
-                                                                line: 4,
-                                                                column: 2,
-                                                            },
+                                                        Print {
+                                                            value: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
                                                         },
                                                     ),
                                                 ],
                                             ),
-                                            on_false: Some(
-                                                Block(
-                                                    [
-                                                        Stmt(
-                                                            Print {
-                                                                value: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/parse_minus.txt
+++ b/tests/parser/pass/parse_minus.txt
@@ -1,130 +1,127 @@
-(
-    Program(
-        [
-            Var(
-                VarDecl {
-                    name: r"a",
-                    t: None,
-                    initialiser: Some(
-                        IntegerLiteral(
+Program(
+    [
+        Var(
+            VarDecl {
+                name: r"a",
+                t: None,
+                initialiser: Some(
+                    IntegerLiteral(
+                        IntegerLiteral {
+                            repr: "-1",
+                            value: -1,
+                        },
+                    ),
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"b",
+                t: None,
+                initialiser: Some(
+                    BinOp {
+                        op: Minus,
+                        lhs: IntegerLiteral(
                             IntegerLiteral {
                                 repr: "-1",
                                 value: -1,
                             },
                         ),
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"b",
-                    t: None,
-                    initialiser: Some(
-                        BinOp {
-                            op: Minus,
-                            lhs: IntegerLiteral(
-                                IntegerLiteral {
-                                    repr: "-1",
-                                    value: -1,
-                                },
-                            ),
-                            rhs: IntegerLiteral(
-                                IntegerLiteral {
-                                    repr: "-2",
-                                    value: -2,
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"c",
-                    t: None,
-                    initialiser: Some(
-                        BinOp {
-                            op: Minus,
-                            lhs: IntegerLiteral(
-                                IntegerLiteral {
-                                    repr: "-1",
-                                    value: -1,
-                                },
-                            ),
-                            rhs: IntegerLiteral(
-                                IntegerLiteral {
-                                    repr: "-2",
-                                    value: -2,
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"d",
-                    t: None,
-                    initialiser: Some(
-                        BinOp {
+                        rhs: IntegerLiteral(
+                            IntegerLiteral {
+                                repr: "-2",
+                                value: -2,
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"c",
+                t: None,
+                initialiser: Some(
+                    BinOp {
+                        op: Minus,
+                        lhs: IntegerLiteral(
+                            IntegerLiteral {
+                                repr: "-1",
+                                value: -1,
+                            },
+                        ),
+                        rhs: IntegerLiteral(
+                            IntegerLiteral {
+                                repr: "-2",
+                                value: -2,
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"d",
+                t: None,
+                initialiser: Some(
+                    BinOp {
+                        op: Plus,
+                        lhs: IntegerLiteral(
+                            IntegerLiteral {
+                                repr: "-5",
+                                value: -5,
+                            },
+                        ),
+                        rhs: BinOp {
                             op: Plus,
                             lhs: IntegerLiteral(
-                                IntegerLiteral {
-                                    repr: "-5",
-                                    value: -5,
-                                },
-                            ),
-                            rhs: BinOp {
-                                op: Plus,
-                                lhs: IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "-7",
-                                        value: -7,
-                                    },
-                                ),
-                                rhs: IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "-8",
-                                        value: -8,
-                                    },
-                                ),
-                            },
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"e",
-                    t: None,
-                    initialiser: Some(
-                        UnOp {
-                            op: Minus,
-                            operand: IntegerLiteral(
                                 IntegerLiteral {
                                     repr: "-7",
                                     value: -7,
                                 },
                             ),
-                        },
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [],
+                            rhs: IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "-8",
+                                    value: -8,
+                                },
                             ),
+                        },
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"e",
+                t: None,
+                initialiser: Some(
+                    UnOp {
+                        op: Minus,
+                        operand: IntegerLiteral(
+                            IntegerLiteral {
+                                repr: "-7",
+                                value: -7,
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/raytracer.txt
+++ b/tests/parser/pass/raytracer.txt
@@ -1,308 +1,293 @@
-(
-    Program(
-        [
-            Var(
-                VarDecl {
-                    name: r"EPS",
-                    t: Some(
+Program(
+    [
+        Var(
+            VarDecl {
+                name: r"EPS",
+                t: Some(
+                    Real,
+                ),
+                initialiser: Some(
+                    RealLiteral(
+                        RealLiteral {
+                            repr: "0.0001",
+                            value: 0.0001,
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"real_min",
+                arguments: [
+                    (
+                        r"a",
                         Real,
                     ),
-                    initialiser: Some(
-                        RealLiteral(
-                            RealLiteral {
-                                repr: "0.0001",
-                                value: 0.0001,
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"real_min",
-                    arguments: [
-                        (
-                            r"a",
-                            Real,
-                        ),
-                        (
-                            r"b",
-                            Real,
-                        ),
-                    ],
-                    return_type: Some(
+                    (
+                        r"b",
                         Real,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Le,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                            [
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Le,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
-                                            },
-                                            on_true: Block(
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"a",
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: Some(
+                                            Block(
                                                 [
                                                     Stmt(
                                                         Return {
                                                             value: LvalueToRvalue(
                                                                 Identifier(
-                                                                    r"a",
+                                                                    r"b",
                                                                 ),
                                                             ),
                                                         },
                                                     ),
                                                 ],
                                             ),
-                                            on_false: Some(
-                                                Block(
-                                                    [
-                                                        Stmt(
-                                                            Return {
-                                                                value: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"b",
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"real_max",
+                arguments: [
+                    (
+                        r"a",
+                        Real,
+                    ),
+                    (
+                        r"b",
+                        Real,
+                    ),
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Ge,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"b",
                                                 ),
                                             ),
                                         },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"real_max",
-                    arguments: [
-                        (
-                            r"a",
-                            Real,
-                        ),
-                        (
-                            r"b",
-                            Real,
-                        ),
-                    ],
-                    return_type: Some(
-                        Real,
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Ge,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"a",
+                                                            ),
+                                                        ),
+                                                    },
                                                 ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                            },
-                                            on_true: Block(
+                                            ],
+                                        ),
+                                        on_false: Some(
+                                            Block(
                                                 [
                                                     Stmt(
                                                         Return {
                                                             value: LvalueToRvalue(
                                                                 Identifier(
-                                                                    r"a",
+                                                                    r"b",
                                                                 ),
                                                             ),
                                                         },
                                                     ),
                                                 ],
                                             ),
-                                            on_false: Some(
-                                                Block(
-                                                    [
-                                                        Stmt(
-                                                            Return {
-                                                                value: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"b",
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"is_nan",
+                arguments: [
+                    (
+                        r"x",
+                        Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        BinOp {
+                            op: Ne,
+                            lhs: LvalueToRvalue(
+                                Identifier(
+                                    r"x",
+                                ),
                             ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"is_nan",
-                    arguments: [
-                        (
-                            r"x",
-                            Real,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            BinOp {
-                                op: Ne,
-                                lhs: LvalueToRvalue(
-                                    Identifier(
-                                        r"x",
-                                    ),
+                            rhs: LvalueToRvalue(
+                                Identifier(
+                                    r"x",
                                 ),
-                                rhs: LvalueToRvalue(
-                                    Identifier(
-                                        r"x",
-                                    ),
-                                ),
-                            },
-                        ),
+                            ),
+                        },
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"approx_eq",
-                    arguments: [
-                        (
-                            r"lhs",
-                            Real,
-                        ),
-                        (
-                            r"rhs",
-                            Real,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            BinOp {
-                                op: Lt,
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"approx_eq",
+                arguments: [
+                    (
+                        r"lhs",
+                        Real,
+                    ),
+                    (
+                        r"rhs",
+                        Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        BinOp {
+                            op: Lt,
+                            lhs: BinOp {
+                                op: Mul,
                                 lhs: BinOp {
-                                    op: Mul,
-                                    lhs: BinOp {
-                                        op: Minus,
-                                        lhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"lhs",
-                                            ),
-                                        ),
-                                        rhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"rhs",
-                                            ),
-                                        ),
-                                    },
-                                    rhs: BinOp {
-                                        op: Minus,
-                                        lhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"lhs",
-                                            ),
-                                        ),
-                                        rhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"rhs",
-                                            ),
-                                        ),
-                                    },
-                                },
-                                rhs: BinOp {
-                                    op: Mul,
+                                    op: Minus,
                                     lhs: LvalueToRvalue(
                                         Identifier(
-                                            r"EPS",
+                                            r"lhs",
                                         ),
                                     ),
                                     rhs: LvalueToRvalue(
                                         Identifier(
-                                            r"EPS",
+                                            r"rhs",
+                                        ),
+                                    ),
+                                },
+                                rhs: BinOp {
+                                    op: Minus,
+                                    lhs: LvalueToRvalue(
+                                        Identifier(
+                                            r"lhs",
+                                        ),
+                                    ),
+                                    rhs: LvalueToRvalue(
+                                        Identifier(
+                                            r"rhs",
                                         ),
                                     ),
                                 },
                             },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"real_interpolate",
-                    arguments: [
-                        (
-                            r"from",
-                            Real,
-                        ),
-                        (
-                            r"to",
-                            Real,
-                        ),
-                        (
-                            r"ratio",
-                            Real,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            BinOp {
-                                op: Plus,
-                                lhs: BinOp {
-                                    op: Mul,
-                                    lhs: LvalueToRvalue(
-                                        Identifier(
-                                            r"from",
-                                        ),
+                            rhs: BinOp {
+                                op: Mul,
+                                lhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"EPS",
                                     ),
-                                    rhs: BinOp {
-                                        op: Minus,
-                                        lhs: IntegerLiteral(
-                                            IntegerLiteral {
-                                                repr: "1",
-                                                value: 1,
-                                            },
-                                        ),
-                                        rhs: LvalueToRvalue(
-                                            Identifier(
-                                                r"ratio",
-                                            ),
-                                        ),
-                                    },
-                                },
+                                ),
+                                rhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"EPS",
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"real_interpolate",
+                arguments: [
+                    (
+                        r"from",
+                        Real,
+                    ),
+                    (
+                        r"to",
+                        Real,
+                    ),
+                    (
+                        r"ratio",
+                        Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        BinOp {
+                            op: Plus,
+                            lhs: BinOp {
+                                op: Mul,
+                                lhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"from",
+                                    ),
+                                ),
                                 rhs: BinOp {
-                                    op: Mul,
-                                    lhs: LvalueToRvalue(
-                                        Identifier(
-                                            r"to",
-                                        ),
+                                    op: Minus,
+                                    lhs: IntegerLiteral(
+                                        IntegerLiteral {
+                                            repr: "1",
+                                            value: 1,
+                                        },
                                     ),
                                     rhs: LvalueToRvalue(
                                         Identifier(
@@ -311,269 +296,328 @@
                                     ),
                                 },
                             },
-                        ),
+                            rhs: BinOp {
+                                op: Mul,
+                                lhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"to",
+                                    ),
+                                ),
+                                rhs: LvalueToRvalue(
+                                    Identifier(
+                                        r"ratio",
+                                    ),
+                                ),
+                            },
+                        },
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"round",
-                    arguments: [
-                        (
-                            r"x",
-                            Real,
-                        ),
-                    ],
-                    return_type: Some(
-                        Int,
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"round",
+                arguments: [
+                    (
+                        r"x",
+                        Real,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"res",
-                                            t: Some(
-                                                Int,
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"res",
+                                        t: Some(
+                                            Int,
+                                        ),
+                                        initialiser: Some(
+                                            LvalueToRvalue(
+                                                Identifier(
+                                                    r"x",
+                                                ),
                                             ),
-                                            initialiser: Some(
-                                                LvalueToRvalue(
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Ge,
+                                            lhs: BinOp {
+                                                op: Minus,
+                                                lhs: LvalueToRvalue(
                                                     Identifier(
                                                         r"x",
                                                     ),
                                                 ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"res",
+                                                    ),
+                                                ),
+                                            },
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.5",
+                                                    value: 0.5,
+                                                },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Ge,
-                                                lhs: BinOp {
-                                                    op: Minus,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"x",
-                                                        ),
-                                                    ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
                                                             r"res",
                                                         ),
-                                                    ),
-                                                },
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.5",
-                                                        value: 0.5,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"res",
+                                                        rhs: BinOp {
+                                                            op: Plus,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"res",
+                                                                ),
                                                             ),
-                                                            rhs: BinOp {
-                                                                op: Plus,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"res",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"res",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"sqrt",
-                    arguments: [
-                        (
-                            r"s",
-                            Real,
-                        ),
-                    ],
-                    return_type: Some(
-                        Real,
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Lt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"s",
-                                                    ),
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.0",
-                                                        value: 0.0,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: RealLiteral(
-                                                                RealLiteral {
-                                                                    repr: "NaN",
-                                                                    value: NaN,
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
                                                                 },
                                                             ),
                                                         },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"x",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "1.0",
-                                                        value: 1.0,
                                                     },
                                                 ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"res",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Gt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"s",
-                                                    ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"sqrt",
+                arguments: [
+                    (
+                        r"s",
+                        Real,
+                    ),
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Lt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"s",
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "1.0",
-                                                        value: 1.0,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"x",
-                                                            ),
-                                                            rhs: BinOp {
-                                                                op: Div,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"s",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "2",
-                                                                        value: 2,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
                                             ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        For {
-                                            counter: r"i",
-                                            from: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "0",
-                                                    value: 0,
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.0",
+                                                    value: 0.0,
                                                 },
                                             ),
-                                            to: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "100",
-                                                        value: 100,
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: RealLiteral(
+                                                            RealLiteral {
+                                                                repr: "NaN",
+                                                                value: NaN,
+                                                            },
+                                                        ),
                                                     },
                                                 ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"x",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "1.0",
+                                                    value: 1.0,
+                                                },
                                             ),
-                                            order: Direct,
-                                            body: Block(
-                                                [
-                                                    VarDecl(
-                                                        VarDecl {
-                                                            name: r"prev_x",
-                                                            t: None,
-                                                            initialiser: Some(
-                                                                LvalueToRvalue(
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Gt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"s",
+                                                ),
+                                            ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "1.0",
+                                                    value: 1.0,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"x",
+                                                        ),
+                                                        rhs: BinOp {
+                                                            op: Div,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"s",
+                                                                ),
+                                                            ),
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "2",
+                                                                    value: 2,
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    For {
+                                        counter: r"i",
+                                        from: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "0",
+                                                value: 0,
+                                            },
+                                        ),
+                                        to: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "100",
+                                                    value: 100,
+                                                },
+                                            ),
+                                        ),
+                                        order: Direct,
+                                        body: Block(
+                                            [
+                                                VarDecl(
+                                                    VarDecl {
+                                                        name: r"prev_x",
+                                                        t: None,
+                                                        initialiser: Some(
+                                                            LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"x",
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"x",
+                                                        ),
+                                                        rhs: BinOp {
+                                                            op: Div,
+                                                            lhs: BinOp {
+                                                                op: Plus,
+                                                                lhs: LvalueToRvalue(
                                                                     Identifier(
                                                                         r"x",
                                                                     ),
                                                                 ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"x",
-                                                            ),
-                                                            rhs: BinOp {
-                                                                op: Div,
-                                                                lhs: BinOp {
-                                                                    op: Plus,
+                                                                rhs: BinOp {
+                                                                    op: Div,
                                                                     lhs: LvalueToRvalue(
+                                                                        Identifier(
+                                                                            r"s",
+                                                                        ),
+                                                                    ),
+                                                                    rhs: LvalueToRvalue(
                                                                         Identifier(
                                                                             r"x",
                                                                         ),
                                                                     ),
-                                                                    rhs: BinOp {
-                                                                        op: Div,
+                                                                },
+                                                            },
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "2",
+                                                                    value: 2,
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    If {
+                                                        condition: BinOp {
+                                                            op: Or,
+                                                            lhs: Call {
+                                                                callee: r"approx_eq",
+                                                                args: [
+                                                                    LvalueToRvalue(
+                                                                        Identifier(
+                                                                            r"prev_x",
+                                                                        ),
+                                                                    ),
+                                                                    LvalueToRvalue(
+                                                                        Identifier(
+                                                                            r"x",
+                                                                        ),
+                                                                    ),
+                                                                ],
+                                                            },
+                                                            rhs: Call {
+                                                                callee: r"approx_eq",
+                                                                args: [
+                                                                    BinOp {
+                                                                        op: Mul,
                                                                         lhs: LvalueToRvalue(
                                                                             Identifier(
-                                                                                r"s",
+                                                                                r"x",
                                                                             ),
                                                                         ),
                                                                         rhs: LvalueToRvalue(
@@ -582,522 +626,457 @@
                                                                             ),
                                                                         ),
                                                                     },
-                                                                },
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "2",
-                                                                        value: 2,
-                                                                    },
-                                                                ),
+                                                                    LvalueToRvalue(
+                                                                        Identifier(
+                                                                            r"s",
+                                                                        ),
+                                                                    ),
+                                                                ],
                                                             },
                                                         },
-                                                    ),
-                                                    Stmt(
-                                                        If {
-                                                            condition: BinOp {
-                                                                op: Or,
-                                                                lhs: Call {
-                                                                    callee: r"approx_eq",
-                                                                    args: [
-                                                                        LvalueToRvalue(
-                                                                            Identifier(
-                                                                                r"prev_x",
-                                                                            ),
-                                                                        ),
-                                                                        LvalueToRvalue(
+                                                        on_true: Block(
+                                                            [
+                                                                Stmt(
+                                                                    Return {
+                                                                        value: LvalueToRvalue(
                                                                             Identifier(
                                                                                 r"x",
                                                                             ),
                                                                         ),
-                                                                    ],
-                                                                },
-                                                                rhs: Call {
-                                                                    callee: r"approx_eq",
-                                                                    args: [
-                                                                        BinOp {
-                                                                            op: Mul,
-                                                                            lhs: LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"x",
-                                                                                ),
-                                                                            ),
-                                                                            rhs: LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"x",
-                                                                                ),
-                                                                            ),
-                                                                        },
-                                                                        LvalueToRvalue(
-                                                                            Identifier(
-                                                                                r"s",
-                                                                            ),
-                                                                        ),
-                                                                    ],
-                                                                },
-                                                            },
-                                                            on_true: Block(
-                                                                [
-                                                                    Stmt(
-                                                                        Return {
-                                                                            value: LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"x",
-                                                                                ),
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            ),
-                                                            on_false: None,
-                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
+                                                        on_false: None,
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"x",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"vector",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"x",
+                                t: Real,
+                            },
+                            FieldDescription {
+                                name: r"y",
+                                t: Real,
+                            },
+                            FieldDescription {
+                                name: r"z",
+                                t: Real,
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"vector_of",
+                arguments: [
+                    (
+                        r"x",
+                        Real,
+                    ),
+                    (
+                        r"y",
+                        Real,
+                    ),
+                    (
+                        r"z",
+                        Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"vector",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"x",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"x",
+                                            ),
+                                        ),
+                                    ),
+                                    (
+                                        r"y",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"y",
+                                            ),
+                                        ),
+                                    ),
+                                    (
+                                        r"z",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"z",
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"vector_add",
+                arguments: [
+                    (
+                        r"lhs",
+                        Alias(
+                            r"vector",
+                        ),
+                    ),
+                    (
+                        r"rhs",
+                        Alias(
+                            r"vector",
+                        ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"vector",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"x",
+                                        BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"lhs",
                                                     ),
-                                                ],
+                                                    member_name: r"x",
+                                                },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
+                                                    ),
+                                                    member_name: r"x",
+                                                },
                                             ),
                                         },
                                     ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"x",
-                                                ),
+                                    (
+                                        r"y",
+                                        BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"lhs",
+                                                    ),
+                                                    member_name: r"y",
+                                                },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
+                                                    ),
+                                                    member_name: r"y",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    (
+                                        r"z",
+                                        BinOp {
+                                            op: Plus,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"lhs",
+                                                    ),
+                                                    member_name: r"z",
+                                                },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
+                                                    ),
+                                                    member_name: r"z",
+                                                },
                                             ),
                                         },
                                     ),
                                 ],
                             ),
-                        ),
-                    ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"vector",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"x",
-                                    t: Real,
-                                },
-                                FieldDescription {
-                                    name: r"y",
-                                    t: Real,
-                                },
-                                FieldDescription {
-                                    name: r"z",
-                                    t: Real,
-                                },
-                            ],
                         },
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"vector_of",
-                    arguments: [
-                        (
-                            r"x",
-                            Real,
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"vector_sub",
+                arguments: [
+                    (
+                        r"lhs",
+                        Alias(
+                            r"vector",
                         ),
-                        (
-                            r"y",
-                            Real,
+                    ),
+                    (
+                        r"rhs",
+                        Alias(
+                            r"vector",
                         ),
-                        (
-                            r"z",
-                            Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"vector",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"x",
+                                        BinOp {
+                                            op: Minus,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"lhs",
+                                                    ),
+                                                    member_name: r"x",
+                                                },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
+                                                    ),
+                                                    member_name: r"x",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    (
+                                        r"y",
+                                        BinOp {
+                                            op: Minus,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"lhs",
+                                                    ),
+                                                    member_name: r"y",
+                                                },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
+                                                    ),
+                                                    member_name: r"y",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    (
+                                        r"z",
+                                        BinOp {
+                                            op: Minus,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"lhs",
+                                                    ),
+                                                    member_name: r"z",
+                                                },
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
+                                                    ),
+                                                    member_name: r"z",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"vector_mul",
+                arguments: [
+                    (
+                        r"k",
+                        Real,
+                    ),
+                    (
+                        r"rhs",
+                        Alias(
+                            r"vector",
                         ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"vector",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"x",
-                                            LvalueToRvalue(
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"vector",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"x",
+                                        BinOp {
+                                            op: Mul,
+                                            lhs: LvalueToRvalue(
                                                 Identifier(
-                                                    r"x",
+                                                    r"k",
                                                 ),
                                             ),
-                                        ),
-                                        (
-                                            r"y",
-                                            LvalueToRvalue(
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
+                                                    ),
+                                                    member_name: r"x",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    (
+                                        r"y",
+                                        BinOp {
+                                            op: Mul,
+                                            lhs: LvalueToRvalue(
                                                 Identifier(
-                                                    r"y",
+                                                    r"k",
                                                 ),
                                             ),
-                                        ),
-                                        (
-                                            r"z",
-                                            LvalueToRvalue(
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
+                                                    ),
+                                                    member_name: r"y",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    (
+                                        r"z",
+                                        BinOp {
+                                            op: Mul,
+                                            lhs: LvalueToRvalue(
                                                 Identifier(
-                                                    r"z",
+                                                    r"k",
                                                 ),
                                             ),
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"vector_add",
-                    arguments: [
-                        (
-                            r"lhs",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                        (
-                            r"rhs",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"vector",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"x",
-                                            BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"lhs",
-                                                        ),
-                                                        member_name: r"x",
-                                                    },
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"x",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        (
-                                            r"y",
-                                            BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"lhs",
-                                                        ),
-                                                        member_name: r"y",
-                                                    },
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"y",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        (
-                                            r"z",
-                                            BinOp {
-                                                op: Plus,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"lhs",
-                                                        ),
-                                                        member_name: r"z",
-                                                    },
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"z",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"vector_sub",
-                    arguments: [
-                        (
-                            r"lhs",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                        (
-                            r"rhs",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"vector",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"x",
-                                            BinOp {
-                                                op: Minus,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"lhs",
-                                                        ),
-                                                        member_name: r"x",
-                                                    },
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"x",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        (
-                                            r"y",
-                                            BinOp {
-                                                op: Minus,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"lhs",
-                                                        ),
-                                                        member_name: r"y",
-                                                    },
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"y",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        (
-                                            r"z",
-                                            BinOp {
-                                                op: Minus,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"lhs",
-                                                        ),
-                                                        member_name: r"z",
-                                                    },
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"z",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"vector_mul",
-                    arguments: [
-                        (
-                            r"k",
-                            Real,
-                        ),
-                        (
-                            r"rhs",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"vector",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"x",
-                                            BinOp {
-                                                op: Mul,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"k",
+                                            rhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"rhs",
                                                     ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"x",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        (
-                                            r"y",
-                                            BinOp {
-                                                op: Mul,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"k",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"y",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        (
-                                            r"z",
-                                            BinOp {
-                                                op: Mul,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"k",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"rhs",
-                                                        ),
-                                                        member_name: r"z",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                ),
-                            },
+                                                    member_name: r"z",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"vector_dot",
+                arguments: [
+                    (
+                        r"lhs",
+                        Alias(
+                            r"vector",
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"vector_dot",
-                    arguments: [
-                        (
-                            r"lhs",
-                            Alias(
-                                r"vector",
-                            ),
+                    (
+                        r"rhs",
+                        Alias(
+                            r"vector",
                         ),
-                        (
-                            r"rhs",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            BinOp {
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        BinOp {
+                            op: Plus,
+                            lhs: BinOp {
                                 op: Plus,
                                 lhs: BinOp {
-                                    op: Plus,
-                                    lhs: BinOp {
-                                        op: Mul,
-                                        lhs: LvalueToRvalue(
-                                            Member {
-                                                lhs: Identifier(
-                                                    r"lhs",
-                                                ),
-                                                member_name: r"x",
-                                            },
-                                        ),
-                                        rhs: LvalueToRvalue(
-                                            Member {
-                                                lhs: Identifier(
-                                                    r"rhs",
-                                                ),
-                                                member_name: r"x",
-                                            },
-                                        ),
-                                    },
-                                    rhs: BinOp {
-                                        op: Mul,
-                                        lhs: LvalueToRvalue(
-                                            Member {
-                                                lhs: Identifier(
-                                                    r"lhs",
-                                                ),
-                                                member_name: r"y",
-                                            },
-                                        ),
-                                        rhs: LvalueToRvalue(
-                                            Member {
-                                                lhs: Identifier(
-                                                    r"rhs",
-                                                ),
-                                                member_name: r"y",
-                                            },
-                                        ),
-                                    },
+                                    op: Mul,
+                                    lhs: LvalueToRvalue(
+                                        Member {
+                                            lhs: Identifier(
+                                                r"lhs",
+                                            ),
+                                            member_name: r"x",
+                                        },
+                                    ),
+                                    rhs: LvalueToRvalue(
+                                        Member {
+                                            lhs: Identifier(
+                                                r"rhs",
+                                            ),
+                                            member_name: r"x",
+                                        },
+                                    ),
                                 },
                                 rhs: BinOp {
                                     op: Mul,
@@ -1106,7 +1085,7 @@
                                             lhs: Identifier(
                                                 r"lhs",
                                             ),
-                                            member_name: r"z",
+                                            member_name: r"y",
                                         },
                                     ),
                                     rhs: LvalueToRvalue(
@@ -1114,1259 +1093,859 @@
                                             lhs: Identifier(
                                                 r"rhs",
                                             ),
-                                            member_name: r"z",
+                                            member_name: r"y",
                                         },
                                     ),
                                 },
                             },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"vector_norm",
-                    arguments: [
-                        (
-                            r"v",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            Call {
-                                callee: r"sqrt",
-                                args: [
-                                    Call {
-                                        callee: r"vector_dot",
-                                        args: [
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"v",
-                                                ),
-                                            ),
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"v",
-                                                ),
-                                            ),
-                                        ],
-                                    },
-                                ],
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"vector_normalised",
-                    arguments: [
-                        (
-                            r"v",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            Call {
-                                callee: r"vector_mul",
-                                args: [
-                                    BinOp {
-                                        op: Div,
-                                        lhs: IntegerLiteral(
-                                            IntegerLiteral {
-                                                repr: "1",
-                                                value: 1,
-                                            },
+                            rhs: BinOp {
+                                op: Mul,
+                                lhs: LvalueToRvalue(
+                                    Member {
+                                        lhs: Identifier(
+                                            r"lhs",
                                         ),
-                                        rhs: Call {
-                                            callee: r"vector_norm",
-                                            args: [
-                                                LvalueToRvalue(
-                                                    Identifier(
-                                                        r"v",
-                                                    ),
-                                                ),
-                                            ],
-                                        },
+                                        member_name: r"z",
                                     },
-                                    LvalueToRvalue(
-                                        Identifier(
-                                            r"v",
+                                ),
+                                rhs: LvalueToRvalue(
+                                    Member {
+                                        lhs: Identifier(
+                                            r"rhs",
                                         ),
-                                    ),
-                                ],
+                                        member_name: r"z",
+                                    },
+                                ),
                             },
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"vector_norm",
+                arguments: [
+                    (
+                        r"v",
+                        Alias(
+                            r"vector",
                         ),
                     ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"ray",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"base",
-                                    t: Alias(
-                                        r"vector",
-                                    ),
-                                },
-                                FieldDescription {
-                                    name: r"dest",
-                                    t: Alias(
-                                        r"vector",
-                                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        Call {
+                            callee: r"sqrt",
+                            args: [
+                                Call {
+                                    callee: r"vector_dot",
+                                    args: [
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"v",
+                                            ),
+                                        ),
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"v",
+                                            ),
+                                        ),
+                                    ],
                                 },
                             ],
                         },
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"ray_from_to",
-                    arguments: [
-                        (
-                            r"start",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                        (
-                            r"point",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"ray",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"base",
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"start",
-                                                ),
-                                            ),
-                                        ),
-                                        (
-                                            r"dest",
-                                            Call {
-                                                callee: r"vector_normalised",
-                                                args: [
-                                                    Call {
-                                                        callee: r"vector_sub",
-                                                        args: [
-                                                            LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"point",
-                                                                ),
-                                                            ),
-                                                            LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"start",
-                                                                ),
-                                                            ),
-                                                        ],
-                                                    },
-                                                ],
-                                            },
-                                        ),
-                                    ],
-                                ),
-                            },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"vector_normalised",
+                arguments: [
+                    (
+                        r"v",
+                        Alias(
+                            r"vector",
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"ray_cut",
-                    arguments: [
-                        (
-                            r"r",
-                            Alias(
-                                r"ray",
-                            ),
-                        ),
-                        (
-                            r"k",
-                            Real,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            Call {
-                                callee: r"vector_add",
-                                args: [
-                                    LvalueToRvalue(
-                                        Member {
-                                            lhs: Identifier(
-                                                r"r",
-                                            ),
-                                            member_name: r"base",
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        Call {
+                            callee: r"vector_mul",
+                            args: [
+                                BinOp {
+                                    op: Div,
+                                    lhs: IntegerLiteral(
+                                        IntegerLiteral {
+                                            repr: "1",
+                                            value: 1,
                                         },
                                     ),
-                                    Call {
-                                        callee: r"vector_mul",
+                                    rhs: Call {
+                                        callee: r"vector_norm",
                                         args: [
                                             LvalueToRvalue(
                                                 Identifier(
-                                                    r"k",
+                                                    r"v",
                                                 ),
-                                            ),
-                                            LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"r",
-                                                    ),
-                                                    member_name: r"dest",
-                                                },
                                             ),
                                         ],
                                     },
-                                ],
+                                },
+                                LvalueToRvalue(
+                                    Identifier(
+                                        r"v",
+                                    ),
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"ray",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"base",
+                                t: Alias(
+                                    r"vector",
+                                ),
                             },
-                        ),
-                    ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"byte",
-                    t: Int,
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"int_to_byte",
-                    arguments: [
-                        (
-                            r"val",
-                            Int,
-                        ),
-                    ],
-                    return_type: Some(
+                            FieldDescription {
+                                name: r"dest",
+                                t: Alias(
+                                    r"vector",
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"ray_from_to",
+                arguments: [
+                    (
+                        r"start",
                         Alias(
-                            r"byte",
+                            r"vector",
                         ),
                     ),
-                    body: Some(
-                        Block(
-                            Block(
+                    (
+                        r"point",
+                        Alias(
+                            r"vector",
+                        ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"ray",
+                            ),
+                            fields: Some(
                                 [
-                                    Stmt(
-                                        Assert {
-                                            pos: Position {
-                                                line: 125,
-                                                column: 2,
-                                            },
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: BinOp {
-                                                    op: Ge,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"val",
+                                    (
+                                        r"base",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"start",
+                                            ),
+                                        ),
+                                    ),
+                                    (
+                                        r"dest",
+                                        Call {
+                                            callee: r"vector_normalised",
+                                            args: [
+                                                Call {
+                                                    callee: r"vector_sub",
+                                                    args: [
+                                                        LvalueToRvalue(
+                                                            Identifier(
+                                                                r"point",
+                                                            ),
                                                         ),
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "0",
-                                                            value: 0,
-                                                        },
-                                                    ),
-                                                },
-                                                rhs: BinOp {
-                                                    op: Lt,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"val",
+                                                        LvalueToRvalue(
+                                                            Identifier(
+                                                                r"start",
+                                                            ),
                                                         ),
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "256",
-                                                            value: 256,
-                                                        },
-                                                    ),
+                                                    ],
                                                 },
-                                            },
+                                            ],
                                         },
                                     ),
-                                    Stmt(
-                                        Return {
-                                            value: Cast {
-                                                operand: LvalueToRvalue(
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"ray_cut",
+                arguments: [
+                    (
+                        r"r",
+                        Alias(
+                            r"ray",
+                        ),
+                    ),
+                    (
+                        r"k",
+                        Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        Call {
+                            callee: r"vector_add",
+                            args: [
+                                LvalueToRvalue(
+                                    Member {
+                                        lhs: Identifier(
+                                            r"r",
+                                        ),
+                                        member_name: r"base",
+                                    },
+                                ),
+                                Call {
+                                    callee: r"vector_mul",
+                                    args: [
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"k",
+                                            ),
+                                        ),
+                                        LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"r",
+                                                ),
+                                                member_name: r"dest",
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ],
+                        },
+                    ),
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"byte",
+                t: Int,
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"int_to_byte",
+                arguments: [
+                    (
+                        r"val",
+                        Int,
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"byte",
+                    ),
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Assert {
+                                        pos: Position {
+                                            line: 125,
+                                            column: 2,
+                                        },
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: BinOp {
+                                                op: Ge,
+                                                lhs: LvalueToRvalue(
                                                     Identifier(
                                                         r"val",
                                                     ),
                                                 ),
-                                                target: Alias(
-                                                    r"byte",
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "0",
+                                                        value: 0,
+                                                    },
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Lt,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"val",
+                                                    ),
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "256",
+                                                        value: 256,
+                                                    },
                                                 ),
                                             },
                                         },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"colour",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"red",
-                                    t: Alias(
-                                        r"byte",
-                                    ),
-                                },
-                                FieldDescription {
-                                    name: r"green",
-                                    t: Alias(
-                                        r"byte",
-                                    ),
-                                },
-                                FieldDescription {
-                                    name: r"blue",
-                                    t: Alias(
-                                        r"byte",
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"colour_of",
-                    arguments: [
-                        (
-                            r"r",
-                            Int,
-                        ),
-                        (
-                            r"g",
-                            Int,
-                        ),
-                        (
-                            r"b",
-                            Int,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"colour",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"red",
-                                            Call {
-                                                callee: r"int_to_byte",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"r",
-                                                        ),
-                                                    ),
-                                                ],
-                                            },
-                                        ),
-                                        (
-                                            r"green",
-                                            Call {
-                                                callee: r"int_to_byte",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"g",
-                                                        ),
-                                                    ),
-                                                ],
-                                            },
-                                        ),
-                                        (
-                                            r"blue",
-                                            Call {
-                                                callee: r"int_to_byte",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"b",
-                                                        ),
-                                                    ),
-                                                ],
-                                            },
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"colour_mix_with_ratio",
-                    arguments: [
-                        (
-                            r"base",
-                            Alias(
-                                r"colour",
-                            ),
-                        ),
-                        (
-                            r"paint",
-                            Alias(
-                                r"colour",
-                            ),
-                        ),
-                        (
-                            r"ratio",
-                            Real,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            Call {
-                                callee: r"colour_of",
-                                args: [
-                                    Call {
-                                        callee: r"round",
-                                        args: [
-                                            Call {
-                                                callee: r"real_interpolate",
-                                                args: [
-                                                    Cast {
-                                                        operand: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"base",
-                                                                ),
-                                                                member_name: r"red",
-                                                            },
-                                                        ),
-                                                        target: Int,
-                                                    },
-                                                    Cast {
-                                                        operand: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"paint",
-                                                                ),
-                                                                member_name: r"red",
-                                                            },
-                                                        ),
-                                                        target: Int,
-                                                    },
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"ratio",
-                                                        ),
-                                                    ),
-                                                ],
-                                            },
-                                        ],
-                                    },
-                                    Call {
-                                        callee: r"round",
-                                        args: [
-                                            Call {
-                                                callee: r"real_interpolate",
-                                                args: [
-                                                    Cast {
-                                                        operand: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"base",
-                                                                ),
-                                                                member_name: r"green",
-                                                            },
-                                                        ),
-                                                        target: Int,
-                                                    },
-                                                    Cast {
-                                                        operand: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"paint",
-                                                                ),
-                                                                member_name: r"green",
-                                                            },
-                                                        ),
-                                                        target: Int,
-                                                    },
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"ratio",
-                                                        ),
-                                                    ),
-                                                ],
-                                            },
-                                        ],
-                                    },
-                                    Call {
-                                        callee: r"round",
-                                        args: [
-                                            Call {
-                                                callee: r"real_interpolate",
-                                                args: [
-                                                    Cast {
-                                                        operand: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"base",
-                                                                ),
-                                                                member_name: r"blue",
-                                                            },
-                                                        ),
-                                                        target: Int,
-                                                    },
-                                                    Cast {
-                                                        operand: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"paint",
-                                                                ),
-                                                                member_name: r"blue",
-                                                            },
-                                                        ),
-                                                        target: Int,
-                                                    },
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"ratio",
-                                                        ),
-                                                    ),
-                                                ],
-                                            },
-                                        ],
-                                    },
-                                ],
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"RED",
-                    t: None,
-                    initialiser: Some(
-                        Call {
-                            callee: r"colour_of",
-                            args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "255",
-                                        value: 255,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"GREEN",
-                    t: None,
-                    initialiser: Some(
-                        Call {
-                            callee: r"colour_of",
-                            args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "255",
-                                        value: 255,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"BLUE",
-                    t: None,
-                    initialiser: Some(
-                        Call {
-                            callee: r"colour_of",
-                            args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "255",
-                                        value: 255,
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"BLACK",
-                    t: None,
-                    initialiser: Some(
-                        Call {
-                            callee: r"colour_of",
-                            args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "0",
-                                        value: 0,
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"WHITE",
-                    t: None,
-                    initialiser: Some(
-                        Call {
-                            callee: r"colour_of",
-                            args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "255",
-                                        value: 255,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "255",
-                                        value: 255,
-                                    },
-                                ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
-                                        repr: "255",
-                                        value: 255,
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Const(
-                ConstDecl {
-                    name: r"CANVAS_MAX_HEIGHT",
-                    t: None,
-                    initialiser: IntegerLiteral(
-                        IntegerLiteral {
-                            repr: "360",
-                            value: 360,
-                        },
-                    ),
-                },
-            ),
-            Const(
-                ConstDecl {
-                    name: r"CANVAS_MAX_WIDTH",
-                    t: None,
-                    initialiser: IntegerLiteral(
-                        IntegerLiteral {
-                            repr: "640",
-                            value: 640,
-                        },
-                    ),
-                },
-            ),
-            Const(
-                ConstDecl {
-                    name: r"CANVAS_MAX_PIXELS",
-                    t: None,
-                    initialiser: BinOp {
-                        op: Mul,
-                        lhs: LvalueToRvalue(
-                            Identifier(
-                                r"CANVAS_MAX_HEIGHT",
-                            ),
-                        ),
-                        rhs: LvalueToRvalue(
-                            Identifier(
-                                r"CANVAS_MAX_WIDTH",
-                            ),
-                        ),
-                    },
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"canvas",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"pixels",
-                                    t: Array(
-                                        ArrayDescription {
-                                            t: Alias(
-                                                r"colour",
+                                Stmt(
+                                    Return {
+                                        value: Cast {
+                                            operand: LvalueToRvalue(
+                                                Identifier(
+                                                    r"val",
+                                                ),
                                             ),
-                                            length: Some(
+                                            target: Alias(
+                                                r"byte",
+                                            ),
+                                        },
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"colour",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"red",
+                                t: Alias(
+                                    r"byte",
+                                ),
+                            },
+                            FieldDescription {
+                                name: r"green",
+                                t: Alias(
+                                    r"byte",
+                                ),
+                            },
+                            FieldDescription {
+                                name: r"blue",
+                                t: Alias(
+                                    r"byte",
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"colour_of",
+                arguments: [
+                    (
+                        r"r",
+                        Int,
+                    ),
+                    (
+                        r"g",
+                        Int,
+                    ),
+                    (
+                        r"b",
+                        Int,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"colour",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"red",
+                                        Call {
+                                            callee: r"int_to_byte",
+                                            args: [
                                                 LvalueToRvalue(
                                                     Identifier(
-                                                        r"CANVAS_MAX_PIXELS",
+                                                        r"r",
                                                     ),
                                                 ),
-                                            ),
+                                            ],
                                         },
                                     ),
-                                },
-                                FieldDescription {
-                                    name: r"height",
-                                    t: Int,
-                                },
-                                FieldDescription {
-                                    name: r"width",
-                                    t: Int,
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"get_canvas_at",
-                    arguments: [
-                        (
-                            r"c",
-                            Alias(
-                                r"canvas",
-                            ),
-                        ),
-                        (
-                            r"x",
-                            Int,
-                        ),
-                        (
-                            r"y",
-                            Int,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            LvalueToRvalue(
-                                Index {
-                                    lhs: Member {
-                                        lhs: Identifier(
-                                            r"c",
-                                        ),
-                                        member_name: r"pixels",
-                                    },
-                                    index: BinOp {
-                                        op: Plus,
-                                        lhs: BinOp {
-                                            op: Plus,
-                                            lhs: BinOp {
-                                                op: Mul,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"c",
-                                                        ),
-                                                        member_name: r"width",
-                                                    },
-                                                ),
-                                                rhs: LvalueToRvalue(
+                                    (
+                                        r"green",
+                                        Call {
+                                            callee: r"int_to_byte",
+                                            args: [
+                                                LvalueToRvalue(
                                                     Identifier(
-                                                        r"y",
+                                                        r"g",
                                                     ),
                                                 ),
-                                            },
-                                            rhs: LvalueToRvalue(
-                                                Identifier(
-                                                    r"x",
-                                                ),
-                                            ),
+                                            ],
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
-                                                repr: "1",
-                                                value: 1,
-                                            },
-                                        ),
-                                    },
-                                },
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"set_canvas_at",
-                    arguments: [
-                        (
-                            r"c",
-                            Alias(
-                                r"canvas",
-                            ),
-                        ),
-                        (
-                            r"x",
-                            Int,
-                        ),
-                        (
-                            r"y",
-                            Int,
-                        ),
-                        (
-                            r"nc",
-                            Alias(
-                                r"colour",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Member {
-                                                    lhs: Identifier(
-                                                        r"c",
+                                    ),
+                                    (
+                                        r"blue",
+                                        Call {
+                                            callee: r"int_to_byte",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"b",
                                                     ),
-                                                    member_name: r"pixels",
-                                                },
-                                                index: BinOp {
-                                                    op: Plus,
-                                                    lhs: BinOp {
-                                                        op: Plus,
-                                                        lhs: BinOp {
-                                                            op: Mul,
-                                                            lhs: LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"c",
-                                                                    ),
-                                                                    member_name: r"width",
-                                                                },
-                                                            ),
-                                                            rhs: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"y",
-                                                                ),
-                                                            ),
-                                                        },
-                                                        rhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"x",
-                                                            ),
-                                                        ),
-                                                    },
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                },
-                                            },
-                                            rhs: LvalueToRvalue(
-                                                Identifier(
-                                                    r"nc",
                                                 ),
-                                            ),
+                                            ],
                                         },
                                     ),
                                 ],
                             ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"colour_mix_with_ratio",
+                arguments: [
+                    (
+                        r"base",
+                        Alias(
+                            r"colour",
+                        ),
+                    ),
+                    (
+                        r"paint",
+                        Alias(
+                            r"colour",
+                        ),
+                    ),
+                    (
+                        r"ratio",
+                        Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        Call {
+                            callee: r"colour_of",
+                            args: [
+                                Call {
+                                    callee: r"round",
+                                    args: [
+                                        Call {
+                                            callee: r"real_interpolate",
+                                            args: [
+                                                Cast {
+                                                    operand: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"base",
+                                                            ),
+                                                            member_name: r"red",
+                                                        },
+                                                    ),
+                                                    target: Int,
+                                                },
+                                                Cast {
+                                                    operand: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"paint",
+                                                            ),
+                                                            member_name: r"red",
+                                                        },
+                                                    ),
+                                                    target: Int,
+                                                },
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"ratio",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ],
+                                },
+                                Call {
+                                    callee: r"round",
+                                    args: [
+                                        Call {
+                                            callee: r"real_interpolate",
+                                            args: [
+                                                Cast {
+                                                    operand: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"base",
+                                                            ),
+                                                            member_name: r"green",
+                                                        },
+                                                    ),
+                                                    target: Int,
+                                                },
+                                                Cast {
+                                                    operand: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"paint",
+                                                            ),
+                                                            member_name: r"green",
+                                                        },
+                                                    ),
+                                                    target: Int,
+                                                },
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"ratio",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ],
+                                },
+                                Call {
+                                    callee: r"round",
+                                    args: [
+                                        Call {
+                                            callee: r"real_interpolate",
+                                            args: [
+                                                Cast {
+                                                    operand: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"base",
+                                                            ),
+                                                            member_name: r"blue",
+                                                        },
+                                                    ),
+                                                    target: Int,
+                                                },
+                                                Cast {
+                                                    operand: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"paint",
+                                                            ),
+                                                            member_name: r"blue",
+                                                        },
+                                                    ),
+                                                    target: Int,
+                                                },
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"ratio",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ),
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"RED",
+                t: None,
+                initialiser: Some(
+                    Call {
+                        callee: r"colour_of",
+                        args: [
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "255",
+                                    value: 255,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"GREEN",
+                t: None,
+                initialiser: Some(
+                    Call {
+                        callee: r"colour_of",
+                        args: [
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "255",
+                                    value: 255,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"BLUE",
+                t: None,
+                initialiser: Some(
+                    Call {
+                        callee: r"colour_of",
+                        args: [
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "255",
+                                    value: 255,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"BLACK",
+                t: None,
+                initialiser: Some(
+                    Call {
+                        callee: r"colour_of",
+                        args: [
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "0",
+                                    value: 0,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"WHITE",
+                t: None,
+                initialiser: Some(
+                    Call {
+                        callee: r"colour_of",
+                        args: [
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "255",
+                                    value: 255,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "255",
+                                    value: 255,
+                                },
+                            ),
+                            IntegerLiteral(
+                                IntegerLiteral {
+                                    repr: "255",
+                                    value: 255,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ),
+        Const(
+            ConstDecl {
+                name: r"CANVAS_MAX_HEIGHT",
+                t: None,
+                initialiser: IntegerLiteral(
+                    IntegerLiteral {
+                        repr: "360",
+                        value: 360,
+                    },
+                ),
+            },
+        ),
+        Const(
+            ConstDecl {
+                name: r"CANVAS_MAX_WIDTH",
+                t: None,
+                initialiser: IntegerLiteral(
+                    IntegerLiteral {
+                        repr: "640",
+                        value: 640,
+                    },
+                ),
+            },
+        ),
+        Const(
+            ConstDecl {
+                name: r"CANVAS_MAX_PIXELS",
+                t: None,
+                initialiser: BinOp {
+                    op: Mul,
+                    lhs: LvalueToRvalue(
+                        Identifier(
+                            r"CANVAS_MAX_HEIGHT",
+                        ),
+                    ),
+                    rhs: LvalueToRvalue(
+                        Identifier(
+                            r"CANVAS_MAX_WIDTH",
                         ),
                     ),
                 },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"new_canvas",
-                    arguments: [
-                        (
-                            r"h",
-                            Int,
-                        ),
-                        (
-                            r"w",
-                            Int,
-                        ),
-                        (
-                            r"background",
-                            Alias(
-                                r"colour",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"canvas",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"pixels",
+                                t: Array(
+                                    ArrayDescription {
+                                        t: Alias(
+                                            r"colour",
+                                        ),
+                                        length: Some(
+                                            LvalueToRvalue(
+                                                Identifier(
+                                                    r"CANVAS_MAX_PIXELS",
+                                                ),
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            FieldDescription {
+                                name: r"height",
+                                t: Int,
+                            },
+                            FieldDescription {
+                                name: r"width",
+                                t: Int,
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"get_canvas_at",
+                arguments: [
+                    (
+                        r"c",
                         Alias(
                             r"canvas",
                         ),
                     ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Assert {
-                                            pos: Position {
-                                                line: 173,
-                                                column: 2,
-                                            },
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: BinOp {
-                                                    op: Ge,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"h",
-                                                        ),
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "0",
-                                                            value: 0,
-                                                        },
-                                                    ),
-                                                },
-                                                rhs: BinOp {
-                                                    op: Le,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"h",
-                                                        ),
-                                                    ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"CANVAS_MAX_HEIGHT",
-                                                        ),
-                                                    ),
-                                                },
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assert {
-                                            pos: Position {
-                                                line: 174,
-                                                column: 2,
-                                            },
-                                            value: BinOp {
-                                                op: And,
-                                                lhs: BinOp {
-                                                    op: Ge,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"w",
-                                                        ),
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "0",
-                                                            value: 0,
-                                                        },
-                                                    ),
-                                                },
-                                                rhs: BinOp {
-                                                    op: Le,
-                                                    lhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"w",
-                                                        ),
-                                                    ),
-                                                    rhs: LvalueToRvalue(
-                                                        Identifier(
-                                                            r"CANVAS_MAX_WIDTH",
-                                                        ),
-                                                    ),
-                                                },
-                                            },
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"res",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Alias(
-                                                        r"canvas",
-                                                    ),
-                                                    fields: Some(
-                                                        [
-                                                            (
-                                                                r"pixels",
-                                                                New {
-                                                                    t: Array(
-                                                                        ArrayDescription {
-                                                                            t: Alias(
-                                                                                r"colour",
-                                                                            ),
-                                                                            length: Some(
-                                                                                LvalueToRvalue(
-                                                                                    Identifier(
-                                                                                        r"CANVAS_MAX_PIXELS",
-                                                                                    ),
-                                                                                ),
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    fields: None,
-                                                                },
-                                                            ),
-                                                            (
-                                                                r"height",
-                                                                LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"h",
-                                                                    ),
-                                                                ),
-                                                            ),
-                                                            (
-                                                                r"width",
-                                                                LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"w",
-                                                                    ),
-                                                                ),
-                                                            ),
-                                                        ],
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        For {
-                                            counter: r"x",
-                                            from: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "0",
-                                                    value: 0,
-                                                },
-                                            ),
-                                            to: Some(
-                                                BinOp {
-                                                    op: Minus,
-                                                    lhs: LvalueToRvalue(
-                                                        Member {
-                                                            lhs: Identifier(
-                                                                r"res",
-                                                            ),
-                                                            member_name: r"height",
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            order: Direct,
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        For {
-                                                            counter: r"y",
-                                                            from: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "0",
-                                                                    value: 0,
-                                                                },
-                                                            ),
-                                                            to: Some(
-                                                                BinOp {
-                                                                    op: Minus,
-                                                                    lhs: LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"res",
-                                                                            ),
-                                                                            member_name: r"width",
-                                                                        },
-                                                                    ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
-                                                                            repr: "1",
-                                                                            value: 1,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            order: Direct,
-                                                            body: Block(
-                                                                [
-                                                                    Stmt(
-                                                                        Expr(
-                                                                            Call {
-                                                                                callee: r"set_canvas_at",
-                                                                                args: [
-                                                                                    LvalueToRvalue(
-                                                                                        Identifier(
-                                                                                            r"res",
-                                                                                        ),
-                                                                                    ),
-                                                                                    LvalueToRvalue(
-                                                                                        Identifier(
-                                                                                            r"x",
-                                                                                        ),
-                                                                                    ),
-                                                                                    LvalueToRvalue(
-                                                                                        Identifier(
-                                                                                            r"y",
-                                                                                        ),
-                                                                                    ),
-                                                                                    LvalueToRvalue(
-                                                                                        Identifier(
-                                                                                            r"background",
-                                                                                        ),
-                                                                                    ),
-                                                                                ],
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                ],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"res",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
+                    (
+                        r"x",
+                        Int,
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"render_canvas",
-                    arguments: [
-                        (
-                            r"c",
-                            Alias(
-                                r"canvas",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"c",
-                                                    ),
-                                                    member_name: r"height",
-                                                },
-                                            ),
-                                        },
+                    (
+                        r"y",
+                        Int,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        LvalueToRvalue(
+                            Index {
+                                lhs: Member {
+                                    lhs: Identifier(
+                                        r"c",
                                     ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
+                                    member_name: r"pixels",
+                                },
+                                index: BinOp {
+                                    op: Plus,
+                                    lhs: BinOp {
+                                        op: Plus,
+                                        lhs: BinOp {
+                                            op: Mul,
+                                            lhs: LvalueToRvalue(
                                                 Member {
                                                     lhs: Identifier(
                                                         r"c",
@@ -2374,17 +1953,290 @@
                                                     member_name: r"width",
                                                 },
                                             ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"y",
+                                                ),
+                                            ),
+                                        },
+                                        rhs: LvalueToRvalue(
+                                            Identifier(
+                                                r"x",
+                                            ),
+                                        ),
+                                    },
+                                    rhs: IntegerLiteral(
+                                        IntegerLiteral {
+                                            repr: "1",
+                                            value: 1,
                                         },
                                     ),
-                                    Stmt(
-                                        For {
-                                            counter: r"x",
-                                            from: BinOp {
+                                },
+                            },
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"set_canvas_at",
+                arguments: [
+                    (
+                        r"c",
+                        Alias(
+                            r"canvas",
+                        ),
+                    ),
+                    (
+                        r"x",
+                        Int,
+                    ),
+                    (
+                        r"y",
+                        Int,
+                    ),
+                    (
+                        r"nc",
+                        Alias(
+                            r"colour",
+                        ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Member {
+                                                lhs: Identifier(
+                                                    r"c",
+                                                ),
+                                                member_name: r"pixels",
+                                            },
+                                            index: BinOp {
+                                                op: Plus,
+                                                lhs: BinOp {
+                                                    op: Plus,
+                                                    lhs: BinOp {
+                                                        op: Mul,
+                                                        lhs: LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Identifier(
+                                                                    r"c",
+                                                                ),
+                                                                member_name: r"width",
+                                                            },
+                                                        ),
+                                                        rhs: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"y",
+                                                            ),
+                                                        ),
+                                                    },
+                                                    rhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"x",
+                                                        ),
+                                                    ),
+                                                },
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "1",
+                                                        value: 1,
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                        rhs: LvalueToRvalue(
+                                            Identifier(
+                                                r"nc",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"new_canvas",
+                arguments: [
+                    (
+                        r"h",
+                        Int,
+                    ),
+                    (
+                        r"w",
+                        Int,
+                    ),
+                    (
+                        r"background",
+                        Alias(
+                            r"colour",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"canvas",
+                    ),
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Assert {
+                                        pos: Position {
+                                            line: 173,
+                                            column: 2,
+                                        },
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: BinOp {
+                                                op: Ge,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"h",
+                                                    ),
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "0",
+                                                        value: 0,
+                                                    },
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Le,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"h",
+                                                    ),
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"CANVAS_MAX_HEIGHT",
+                                                    ),
+                                                ),
+                                            },
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Assert {
+                                        pos: Position {
+                                            line: 174,
+                                            column: 2,
+                                        },
+                                        value: BinOp {
+                                            op: And,
+                                            lhs: BinOp {
+                                                op: Ge,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"w",
+                                                    ),
+                                                ),
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "0",
+                                                        value: 0,
+                                                    },
+                                                ),
+                                            },
+                                            rhs: BinOp {
+                                                op: Le,
+                                                lhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"w",
+                                                    ),
+                                                ),
+                                                rhs: LvalueToRvalue(
+                                                    Identifier(
+                                                        r"CANVAS_MAX_WIDTH",
+                                                    ),
+                                                ),
+                                            },
+                                        },
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"res",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Alias(
+                                                    r"canvas",
+                                                ),
+                                                fields: Some(
+                                                    [
+                                                        (
+                                                            r"pixels",
+                                                            New {
+                                                                t: Array(
+                                                                    ArrayDescription {
+                                                                        t: Alias(
+                                                                            r"colour",
+                                                                        ),
+                                                                        length: Some(
+                                                                            LvalueToRvalue(
+                                                                                Identifier(
+                                                                                    r"CANVAS_MAX_PIXELS",
+                                                                                ),
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                fields: None,
+                                                            },
+                                                        ),
+                                                        (
+                                                            r"height",
+                                                            LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"h",
+                                                                ),
+                                                            ),
+                                                        ),
+                                                        (
+                                                            r"width",
+                                                            LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"w",
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ],
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    For {
+                                        counter: r"x",
+                                        from: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "0",
+                                                value: 0,
+                                            },
+                                        ),
+                                        to: Some(
+                                            BinOp {
                                                 op: Minus,
                                                 lhs: LvalueToRvalue(
                                                     Member {
                                                         lhs: Identifier(
-                                                            r"c",
+                                                            r"res",
                                                         ),
                                                         member_name: r"height",
                                                     },
@@ -2396,66 +2248,869 @@
                                                     },
                                                 ),
                                             },
-                                            to: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
+                                        ),
+                                        order: Direct,
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    For {
+                                                        counter: r"y",
+                                                        from: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "0",
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                        to: Some(
+                                                            BinOp {
+                                                                op: Minus,
+                                                                lhs: LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"res",
+                                                                        ),
+                                                                        member_name: r"width",
+                                                                    },
+                                                                ),
+                                                                rhs: IntegerLiteral(
+                                                                    IntegerLiteral {
+                                                                        repr: "1",
+                                                                        value: 1,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                        order: Direct,
+                                                        body: Block(
+                                                            [
+                                                                Stmt(
+                                                                    Expr(
+                                                                        Call {
+                                                                            callee: r"set_canvas_at",
+                                                                            args: [
+                                                                                LvalueToRvalue(
+                                                                                    Identifier(
+                                                                                        r"res",
+                                                                                    ),
+                                                                                ),
+                                                                                LvalueToRvalue(
+                                                                                    Identifier(
+                                                                                        r"x",
+                                                                                    ),
+                                                                                ),
+                                                                                LvalueToRvalue(
+                                                                                    Identifier(
+                                                                                        r"y",
+                                                                                    ),
+                                                                                ),
+                                                                                LvalueToRvalue(
+                                                                                    Identifier(
+                                                                                        r"background",
+                                                                                    ),
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                        ),
                                                     },
                                                 ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"res",
                                             ),
-                                            order: Reversed,
-                                            body: Block(
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"render_canvas",
+                arguments: [
+                    (
+                        r"c",
+                        Alias(
+                            r"canvas",
+                        ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"c",
+                                                ),
+                                                member_name: r"height",
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"c",
+                                                ),
+                                                member_name: r"width",
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    For {
+                                        counter: r"x",
+                                        from: BinOp {
+                                            op: Minus,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"c",
+                                                    ),
+                                                    member_name: r"height",
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        },
+                                        to: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
+                                                },
+                                            ),
+                                        ),
+                                        order: Reversed,
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    For {
+                                                        counter: r"y",
+                                                        from: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "0",
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                        to: Some(
+                                                            BinOp {
+                                                                op: Minus,
+                                                                lhs: LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"c",
+                                                                        ),
+                                                                        member_name: r"width",
+                                                                    },
+                                                                ),
+                                                                rhs: IntegerLiteral(
+                                                                    IntegerLiteral {
+                                                                        repr: "1",
+                                                                        value: 1,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                        order: Direct,
+                                                        body: Block(
+                                                            [
+                                                                Stmt(
+                                                                    Print {
+                                                                        value: Call {
+                                                                            callee: r"get_canvas_at",
+                                                                            args: [
+                                                                                LvalueToRvalue(
+                                                                                    Identifier(
+                                                                                        r"c",
+                                                                                    ),
+                                                                                ),
+                                                                                LvalueToRvalue(
+                                                                                    Identifier(
+                                                                                        r"x",
+                                                                                    ),
+                                                                                ),
+                                                                                LvalueToRvalue(
+                                                                                    Identifier(
+                                                                                        r"y",
+                                                                                    ),
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"sphere",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"centre",
+                                t: Alias(
+                                    r"vector",
+                                ),
+                            },
+                            FieldDescription {
+                                name: r"radius",
+                                t: Real,
+                            },
+                            FieldDescription {
+                                name: r"colour",
+                                t: Alias(
+                                    r"colour",
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"plane",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"point",
+                                t: Alias(
+                                    r"vector",
+                                ),
+                            },
+                            FieldDescription {
+                                name: r"normal",
+                                t: Alias(
+                                    r"vector",
+                                ),
+                            },
+                            FieldDescription {
+                                name: r"colour",
+                                t: Alias(
+                                    r"colour",
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"object",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"kind",
+                                t: Int,
+                            },
+                            FieldDescription {
+                                name: r"s",
+                                t: Alias(
+                                    r"sphere",
+                                ),
+                            },
+                            FieldDescription {
+                                name: r"p",
+                                t: Alias(
+                                    r"plane",
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"sphere_to_object",
+                arguments: [
+                    (
+                        r"f",
+                        Alias(
+                            r"sphere",
+                        ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"object",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"kind",
+                                        IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "1",
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                    (
+                                        r"s",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"f",
+                                            ),
+                                        ),
+                                    ),
+                                    (
+                                        r"p",
+                                        Null,
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"plane_to_object",
+                arguments: [
+                    (
+                        r"f",
+                        Alias(
+                            r"plane",
+                        ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"object",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"kind",
+                                        IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "2",
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                    (
+                                        r"s",
+                                        Null,
+                                    ),
+                                    (
+                                        r"p",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"f",
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"intersect_sphere",
+                arguments: [
+                    (
+                        r"s",
+                        Alias(
+                            r"sphere",
+                        ),
+                    ),
+                    (
+                        r"r",
+                        Alias(
+                            r"ray",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"vector_dot",
+                                                args: [
+                                                    LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"r",
+                                                            ),
+                                                            member_name: r"dest",
+                                                        },
+                                                    ),
+                                                    LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"r",
+                                                            ),
+                                                            member_name: r"dest",
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Mul,
+                                                lhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "2",
+                                                        value: 2,
+                                                    },
+                                                ),
+                                                rhs: Call {
+                                                    callee: r"vector_dot",
+                                                    args: [
+                                                        LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Identifier(
+                                                                    r"r",
+                                                                ),
+                                                                member_name: r"dest",
+                                                            },
+                                                        ),
+                                                        Call {
+                                                            callee: r"vector_sub",
+                                                            args: [
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"r",
+                                                                        ),
+                                                                        member_name: r"base",
+                                                                    },
+                                                                ),
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"s",
+                                                                        ),
+                                                                        member_name: r"centre",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"c",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Minus,
+                                                lhs: Call {
+                                                    callee: r"vector_dot",
+                                                    args: [
+                                                        Call {
+                                                            callee: r"vector_sub",
+                                                            args: [
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"r",
+                                                                        ),
+                                                                        member_name: r"base",
+                                                                    },
+                                                                ),
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"s",
+                                                                        ),
+                                                                        member_name: r"centre",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                        Call {
+                                                            callee: r"vector_sub",
+                                                            args: [
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"r",
+                                                                        ),
+                                                                        member_name: r"base",
+                                                                    },
+                                                                ),
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"s",
+                                                                        ),
+                                                                        member_name: r"centre",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ],
+                                                },
+                                                rhs: BinOp {
+                                                    op: Mul,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"s",
+                                                            ),
+                                                            member_name: r"radius",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"s",
+                                                            ),
+                                                            member_name: r"radius",
+                                                        },
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"discriminant",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Minus,
+                                                lhs: BinOp {
+                                                    op: Mul,
+                                                    lhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"b",
+                                                        ),
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"b",
+                                                        ),
+                                                    ),
+                                                },
+                                                rhs: BinOp {
+                                                    op: Mul,
+                                                    lhs: BinOp {
+                                                        op: Mul,
+                                                        lhs: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "4",
+                                                                value: 4,
+                                                            },
+                                                        ),
+                                                        rhs: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"a",
+                                                            ),
+                                                        ),
+                                                    },
+                                                    rhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"c",
+                                                        ),
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Lt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"discriminant",
+                                                ),
+                                            ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.0",
+                                                    value: 0.0,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: RealLiteral(
+                                                            RealLiteral {
+                                                                repr: "NaN",
+                                                                value: NaN,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"t1",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Div,
+                                                lhs: BinOp {
+                                                    op: Plus,
+                                                    lhs: UnOp {
+                                                        op: Minus,
+                                                        operand: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"b",
+                                                            ),
+                                                        ),
+                                                    },
+                                                    rhs: Call {
+                                                        callee: r"sqrt",
+                                                        args: [
+                                                            LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"discriminant",
+                                                                ),
+                                                            ),
+                                                        ],
+                                                    },
+                                                },
+                                                rhs: BinOp {
+                                                    op: Mul,
+                                                    lhs: IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "2",
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"a",
+                                                        ),
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"t2",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Div,
+                                                lhs: BinOp {
+                                                    op: Minus,
+                                                    lhs: UnOp {
+                                                        op: Minus,
+                                                        operand: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"b",
+                                                            ),
+                                                        ),
+                                                    },
+                                                    rhs: Call {
+                                                        callee: r"sqrt",
+                                                        args: [
+                                                            LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"discriminant",
+                                                                ),
+                                                            ),
+                                                        ],
+                                                    },
+                                                },
+                                                rhs: BinOp {
+                                                    op: Mul,
+                                                    lhs: IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "2",
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"a",
+                                                        ),
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Gt,
+                                            lhs: Call {
+                                                callee: r"real_min",
+                                                args: [
+                                                    LvalueToRvalue(
+                                                        Identifier(
+                                                            r"t1",
+                                                        ),
+                                                    ),
+                                                    LvalueToRvalue(
+                                                        Identifier(
+                                                            r"t2",
+                                                        ),
+                                                    ),
+                                                ],
+                                            },
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: Call {
+                                                            callee: r"real_min",
+                                                            args: [
+                                                                LvalueToRvalue(
+                                                                    Identifier(
+                                                                        r"t1",
+                                                                    ),
+                                                                ),
+                                                                LvalueToRvalue(
+                                                                    Identifier(
+                                                                        r"t2",
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: Some(
+                                            Block(
                                                 [
                                                     Stmt(
-                                                        For {
-                                                            counter: r"y",
-                                                            from: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "0",
-                                                                    value: 0,
-                                                                },
-                                                            ),
-                                                            to: Some(
-                                                                BinOp {
-                                                                    op: Minus,
-                                                                    lhs: LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"c",
+                                                        If {
+                                                            condition: BinOp {
+                                                                op: Gt,
+                                                                lhs: Call {
+                                                                    callee: r"real_max",
+                                                                    args: [
+                                                                        LvalueToRvalue(
+                                                                            Identifier(
+                                                                                r"t1",
                                                                             ),
-                                                                            member_name: r"width",
-                                                                        },
-                                                                    ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
-                                                                            repr: "1",
-                                                                            value: 1,
-                                                                        },
-                                                                    ),
+                                                                        ),
+                                                                        LvalueToRvalue(
+                                                                            Identifier(
+                                                                                r"t2",
+                                                                            ),
+                                                                        ),
+                                                                    ],
                                                                 },
-                                                            ),
-                                                            order: Direct,
-                                                            body: Block(
+                                                                rhs: IntegerLiteral(
+                                                                    IntegerLiteral {
+                                                                        repr: "0",
+                                                                        value: 0,
+                                                                    },
+                                                                ),
+                                                            },
+                                                            on_true: Block(
                                                                 [
                                                                     Stmt(
-                                                                        Print {
+                                                                        Return {
                                                                             value: Call {
-                                                                                callee: r"get_canvas_at",
+                                                                                callee: r"real_max",
                                                                                 args: [
                                                                                     LvalueToRvalue(
                                                                                         Identifier(
-                                                                                            r"c",
+                                                                                            r"t1",
                                                                                         ),
                                                                                     ),
                                                                                     LvalueToRvalue(
                                                                                         Identifier(
-                                                                                            r"x",
-                                                                                        ),
-                                                                                    ),
-                                                                                    LvalueToRvalue(
-                                                                                        Identifier(
-                                                                                            r"y",
+                                                                                            r"t2",
                                                                                         ),
                                                                                     ),
                                                                                 ],
@@ -2464,229 +3119,154 @@
                                                                     ),
                                                                 ],
                                                             ),
+                                                            on_false: Some(
+                                                                Block(
+                                                                    [
+                                                                        Stmt(
+                                                                            Return {
+                                                                                value: RealLiteral(
+                                                                                    RealLiteral {
+                                                                                        repr: "NaN",
+                                                                                        value: NaN,
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                ),
+                                                            ),
                                                         },
                                                     ),
                                                 ],
                                             ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"sphere",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"centre",
-                                    t: Alias(
-                                        r"vector",
-                                    ),
-                                },
-                                FieldDescription {
-                                    name: r"radius",
-                                    t: Real,
-                                },
-                                FieldDescription {
-                                    name: r"colour",
-                                    t: Alias(
-                                        r"colour",
-                                    ),
-                                },
+                                        ),
+                                    },
+                                ),
                             ],
-                        },
-                    ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"plane",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"point",
-                                    t: Alias(
-                                        r"vector",
-                                    ),
-                                },
-                                FieldDescription {
-                                    name: r"normal",
-                                    t: Alias(
-                                        r"vector",
-                                    ),
-                                },
-                                FieldDescription {
-                                    name: r"colour",
-                                    t: Alias(
-                                        r"colour",
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"object",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"kind",
-                                    t: Int,
-                                },
-                                FieldDescription {
-                                    name: r"s",
-                                    t: Alias(
-                                        r"sphere",
-                                    ),
-                                },
-                                FieldDescription {
-                                    name: r"p",
-                                    t: Alias(
-                                        r"plane",
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"sphere_to_object",
-                    arguments: [
-                        (
-                            r"f",
-                            Alias(
-                                r"sphere",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"object",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"kind",
-                                            IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "1",
-                                                    value: 1,
-                                                },
-                                            ),
-                                        ),
-                                        (
-                                            r"s",
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"f",
-                                                ),
-                                            ),
-                                        ),
-                                        (
-                                            r"p",
-                                            Null,
-                                        ),
-                                    ],
-                                ),
-                            },
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"plane_to_object",
-                    arguments: [
-                        (
-                            r"f",
-                            Alias(
-                                r"plane",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"object",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"kind",
-                                            IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "2",
-                                                    value: 2,
-                                                },
-                                            ),
-                                        ),
-                                        (
-                                            r"s",
-                                            Null,
-                                        ),
-                                        (
-                                            r"p",
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"f",
-                                                ),
-                                            ),
-                                        ),
-                                    ],
-                                ),
-                            },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"intersect_plane",
+                arguments: [
+                    (
+                        r"p",
+                        Alias(
+                            r"plane",
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"intersect_sphere",
-                    arguments: [
-                        (
-                            r"s",
-                            Alias(
-                                r"sphere",
-                            ),
+                    (
+                        r"r",
+                        Alias(
+                            r"ray",
                         ),
-                        (
-                            r"r",
-                            Alias(
-                                r"ray",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Real,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
+                            [
+                                Stmt(
+                                    If {
+                                        condition: Call {
+                                            callee: r"approx_eq",
+                                            args: [
                                                 Call {
+                                                    callee: r"vector_dot",
+                                                    args: [
+                                                        LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Identifier(
+                                                                    r"p",
+                                                                ),
+                                                                member_name: r"normal",
+                                                            },
+                                                        ),
+                                                        LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Identifier(
+                                                                    r"r",
+                                                                ),
+                                                                member_name: r"dest",
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                                IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "0",
+                                                        value: 0,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: RealLiteral(
+                                                            RealLiteral {
+                                                                repr: "NaN",
+                                                                value: NaN,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"t",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Div,
+                                                lhs: Call {
+                                                    callee: r"vector_dot",
+                                                    args: [
+                                                        Call {
+                                                            callee: r"vector_sub",
+                                                            args: [
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"p",
+                                                                        ),
+                                                                        member_name: r"point",
+                                                                    },
+                                                                ),
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"r",
+                                                                        ),
+                                                                        member_name: r"base",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                        LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Identifier(
+                                                                    r"p",
+                                                                ),
+                                                                member_name: r"normal",
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                                rhs: Call {
                                                     callee: r"vector_dot",
                                                     args: [
                                                         LvalueToRvalue(
@@ -2700,213 +3280,47 @@
                                                         LvalueToRvalue(
                                                             Member {
                                                                 lhs: Identifier(
-                                                                    r"r",
+                                                                    r"p",
                                                                 ),
-                                                                member_name: r"dest",
+                                                                member_name: r"normal",
                                                             },
                                                         ),
                                                     ],
                                                 },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
-                                                BinOp {
-                                                    op: Mul,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "2",
-                                                            value: 2,
-                                                        },
-                                                    ),
-                                                    rhs: Call {
-                                                        callee: r"vector_dot",
-                                                        args: [
-                                                            LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"r",
-                                                                    ),
-                                                                    member_name: r"dest",
-                                                                },
-                                                            ),
-                                                            Call {
-                                                                callee: r"vector_sub",
-                                                                args: [
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"r",
-                                                                            ),
-                                                                            member_name: r"base",
-                                                                        },
-                                                                    ),
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"s",
-                                                                            ),
-                                                                            member_name: r"centre",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ],
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"c",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
-                                                BinOp {
-                                                    op: Minus,
-                                                    lhs: Call {
-                                                        callee: r"vector_dot",
-                                                        args: [
-                                                            Call {
-                                                                callee: r"vector_sub",
-                                                                args: [
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"r",
-                                                                            ),
-                                                                            member_name: r"base",
-                                                                        },
-                                                                    ),
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"s",
-                                                                            ),
-                                                                            member_name: r"centre",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                            Call {
-                                                                callee: r"vector_sub",
-                                                                args: [
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"r",
-                                                                            ),
-                                                                            member_name: r"base",
-                                                                        },
-                                                                    ),
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"s",
-                                                                            ),
-                                                                            member_name: r"centre",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ],
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Mul,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"s",
-                                                                ),
-                                                                member_name: r"radius",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"s",
-                                                                ),
-                                                                member_name: r"radius",
-                                                            },
-                                                        ),
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"discriminant",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
-                                                BinOp {
-                                                    op: Minus,
-                                                    lhs: BinOp {
-                                                        op: Mul,
-                                                        lhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"b",
-                                                            ),
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"b",
-                                                            ),
-                                                        ),
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Mul,
-                                                        lhs: BinOp {
-                                                            op: Mul,
-                                                            lhs: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "4",
-                                                                    value: 4,
-                                                                },
-                                                            ),
-                                                            rhs: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"a",
-                                                                ),
-                                                            ),
-                                                        },
-                                                        rhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"c",
-                                                            ),
-                                                        ),
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Lt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"discriminant",
-                                                    ),
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.0",
-                                                        value: 0.0,
-                                                    },
-                                                ),
                                             },
-                                            on_true: Block(
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Gt,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"t",
+                                                ),
+                                            ),
+                                            rhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"EPS",
+                                                ),
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"t",
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: Some(
+                                            Block(
                                                 [
                                                     Stmt(
                                                         Return {
@@ -2920,284 +3334,998 @@
                                                     ),
                                                 ],
                                             ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"t1",
-                                            t: Some(
-                                                Real,
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"intersect_object",
+                arguments: [
+                    (
+                        r"o",
+                        Alias(
+                            r"object",
+                        ),
+                    ),
+                    (
+                        r"r",
+                        Alias(
+                            r"ray",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"o",
+                                                    ),
+                                                    member_name: r"kind",
+                                                },
                                             ),
-                                            initialiser: Some(
-                                                BinOp {
-                                                    op: Div,
-                                                    lhs: BinOp {
-                                                        op: Plus,
-                                                        lhs: UnOp {
-                                                            op: Minus,
-                                                            operand: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"b",
-                                                                ),
-                                                            ),
-                                                        },
-                                                        rhs: Call {
-                                                            callee: r"sqrt",
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: Call {
+                                                            callee: r"intersect_sphere",
                                                             args: [
                                                                 LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"o",
+                                                                        ),
+                                                                        member_name: r"s",
+                                                                    },
+                                                                ),
+                                                                LvalueToRvalue(
                                                                     Identifier(
-                                                                        r"discriminant",
+                                                                        r"r",
                                                                     ),
                                                                 ),
                                                             ],
                                                         },
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Mul,
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "2",
-                                                                value: 2,
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"a",
-                                                            ),
-                                                        ),
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"t2",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
-                                                BinOp {
-                                                    op: Div,
-                                                    lhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: UnOp {
-                                                            op: Minus,
-                                                            operand: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"b",
-                                                                ),
-                                                            ),
-                                                        },
-                                                        rhs: Call {
-                                                            callee: r"sqrt",
-                                                            args: [
-                                                                LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"discriminant",
-                                                                    ),
-                                                                ),
-                                                            ],
-                                                        },
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Mul,
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "2",
-                                                                value: 2,
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"a",
-                                                            ),
-                                                        ),
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Gt,
-                                                lhs: Call {
-                                                    callee: r"real_min",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"t1",
-                                                            ),
-                                                        ),
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"t2",
-                                                            ),
-                                                        ),
-                                                    ],
-                                                },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
                                                     },
                                                 ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"o",
+                                                    ),
+                                                    member_name: r"kind",
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: Call {
+                                                            callee: r"intersect_plane",
+                                                            args: [
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"o",
+                                                                        ),
+                                                                        member_name: r"p",
+                                                                    },
+                                                                ),
+                                                                LvalueToRvalue(
+                                                                    Identifier(
+                                                                        r"r",
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: RealLiteral(
+                                            RealLiteral {
+                                                repr: "NaN",
+                                                value: NaN,
                                             },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: Call {
-                                                                callee: r"real_min",
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"normal_at_sphere",
+                arguments: [
+                    (
+                        r"s",
+                        Alias(
+                            r"sphere",
+                        ),
+                    ),
+                    (
+                        r"point",
+                        Alias(
+                            r"vector",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"vector",
+                    ),
+                ),
+                body: Some(
+                    Expression(
+                        Call {
+                            callee: r"vector_normalised",
+                            args: [
+                                Call {
+                                    callee: r"vector_sub",
+                                    args: [
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"point",
+                                            ),
+                                        ),
+                                        LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"s",
+                                                ),
+                                                member_name: r"centre",
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ],
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"normal_at_plane",
+                arguments: [
+                    (
+                        r"p",
+                        Alias(
+                            r"plane",
+                        ),
+                    ),
+                    (
+                        r"point",
+                        Alias(
+                            r"vector",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"vector",
+                    ),
+                ),
+                body: Some(
+                    Expression(
+                        LvalueToRvalue(
+                            Member {
+                                lhs: Identifier(
+                                    r"p",
+                                ),
+                                member_name: r"normal",
+                            },
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"normal_at_object",
+                arguments: [
+                    (
+                        r"o",
+                        Alias(
+                            r"object",
+                        ),
+                    ),
+                    (
+                        r"r",
+                        Alias(
+                            r"vector",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"vector",
+                    ),
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"o",
+                                                    ),
+                                                    member_name: r"kind",
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: Call {
+                                                            callee: r"normal_at_sphere",
+                                                            args: [
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"o",
+                                                                        ),
+                                                                        member_name: r"s",
+                                                                    },
+                                                                ),
+                                                                LvalueToRvalue(
+                                                                    Identifier(
+                                                                        r"r",
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"o",
+                                                    ),
+                                                    member_name: r"kind",
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: Call {
+                                                            callee: r"normal_at_plane",
+                                                            args: [
+                                                                LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"o",
+                                                                        ),
+                                                                        member_name: r"p",
+                                                                    },
+                                                                ),
+                                                                LvalueToRvalue(
+                                                                    Identifier(
+                                                                        r"r",
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                        },
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: Null,
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"colour_at_object",
+                arguments: [
+                    (
+                        r"o",
+                        Alias(
+                            r"object",
+                        ),
+                    ),
+                    (
+                        r"r",
+                        Alias(
+                            r"vector",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"colour",
+                    ),
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"o",
+                                                    ),
+                                                    member_name: r"kind",
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Member {
+                                                                    lhs: Identifier(
+                                                                        r"o",
+                                                                    ),
+                                                                    member_name: r"s",
+                                                                },
+                                                                member_name: r"colour",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Member {
+                                                    lhs: Identifier(
+                                                        r"o",
+                                                    ),
+                                                    member_name: r"kind",
+                                                },
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Member {
+                                                                    lhs: Identifier(
+                                                                        r"o",
+                                                                    ),
+                                                                    member_name: r"p",
+                                                                },
+                                                                member_name: r"colour",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: Null,
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"intersection_desc",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"t",
+                                t: Real,
+                            },
+                            FieldDescription {
+                                name: r"object",
+                                t: Alias(
+                                    r"object",
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"empty_intersection_desc",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"intersection_desc",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"t",
+                                        RealLiteral(
+                                            RealLiteral {
+                                                repr: "NaN",
+                                                value: NaN,
+                                            },
+                                        ),
+                                    ),
+                                    (
+                                        r"object",
+                                        Null,
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"trace_ray",
+                arguments: [
+                    (
+                        r"r",
+                        Alias(
+                            r"ray",
+                        ),
+                    ),
+                    (
+                        r"scene",
+                        Array(
+                            ArrayDescription {
+                                t: Alias(
+                                    r"object",
+                                ),
+                                length: None,
+                            },
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"intersection_desc",
+                    ),
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"best_intersection",
+                                        t: None,
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"empty_intersection_desc",
+                                                args: [],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    For {
+                                        counter: r"obj",
+                                        from: LvalueToRvalue(
+                                            Identifier(
+                                                r"scene",
+                                            ),
+                                        ),
+                                        to: None,
+                                        order: Direct,
+                                        body: Block(
+                                            [
+                                                VarDecl(
+                                                    VarDecl {
+                                                        name: r"intersection",
+                                                        t: None,
+                                                        initialiser: Some(
+                                                            Call {
+                                                                callee: r"intersect_object",
                                                                 args: [
                                                                     LvalueToRvalue(
                                                                         Identifier(
-                                                                            r"t1",
+                                                                            r"obj",
                                                                         ),
                                                                     ),
                                                                     LvalueToRvalue(
                                                                         Identifier(
-                                                                            r"t2",
+                                                                            r"r",
                                                                         ),
                                                                     ),
                                                                 ],
                                                             },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: Some(
-                                                Block(
-                                                    [
-                                                        Stmt(
-                                                            If {
-                                                                condition: BinOp {
-                                                                    op: Gt,
-                                                                    lhs: Call {
-                                                                        callee: r"real_max",
-                                                                        args: [
-                                                                            LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"t1",
-                                                                                ),
+                                                        ),
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    If {
+                                                        condition: BinOp {
+                                                            op: And,
+                                                            lhs: UnOp {
+                                                                op: Not,
+                                                                operand: Call {
+                                                                    callee: r"is_nan",
+                                                                    args: [
+                                                                        LvalueToRvalue(
+                                                                            Identifier(
+                                                                                r"intersection",
                                                                             ),
-                                                                            LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"t2",
-                                                                                ),
-                                                                            ),
-                                                                        ],
-                                                                    },
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
-                                                                            repr: "0",
-                                                                            value: 0,
-                                                                        },
-                                                                    ),
+                                                                        ),
+                                                                    ],
                                                                 },
-                                                                on_true: Block(
-                                                                    [
-                                                                        Stmt(
-                                                                            Return {
-                                                                                value: Call {
-                                                                                    callee: r"real_max",
-                                                                                    args: [
-                                                                                        LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"t1",
-                                                                                            ),
-                                                                                        ),
-                                                                                        LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"t2",
-                                                                                            ),
-                                                                                        ),
-                                                                                    ],
-                                                                                },
+                                                            },
+                                                            rhs: BinOp {
+                                                                op: Or,
+                                                                lhs: Call {
+                                                                    callee: r"is_nan",
+                                                                    args: [
+                                                                        LvalueToRvalue(
+                                                                            Member {
+                                                                                lhs: Identifier(
+                                                                                    r"best_intersection",
+                                                                                ),
+                                                                                member_name: r"t",
                                                                             },
                                                                         ),
                                                                     ],
-                                                                ),
-                                                                on_false: Some(
-                                                                    Block(
-                                                                        [
-                                                                            Stmt(
-                                                                                Return {
-                                                                                    value: RealLiteral(
-                                                                                        RealLiteral {
-                                                                                            repr: "NaN",
-                                                                                            value: NaN,
-                                                                                        },
-                                                                                    ),
-                                                                                },
+                                                                },
+                                                                rhs: BinOp {
+                                                                    op: Gt,
+                                                                    lhs: LvalueToRvalue(
+                                                                        Member {
+                                                                            lhs: Identifier(
+                                                                                r"best_intersection",
                                                                             ),
-                                                                        ],
+                                                                            member_name: r"t",
+                                                                        },
                                                                     ),
+                                                                    rhs: BinOp {
+                                                                        op: Plus,
+                                                                        lhs: LvalueToRvalue(
+                                                                            Identifier(
+                                                                                r"intersection",
+                                                                            ),
+                                                                        ),
+                                                                        rhs: LvalueToRvalue(
+                                                                            Identifier(
+                                                                                r"EPS",
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                },
+                                                            },
+                                                        },
+                                                        on_true: Block(
+                                                            [
+                                                                Stmt(
+                                                                    Assignment {
+                                                                        lhs: Identifier(
+                                                                            r"best_intersection",
+                                                                        ),
+                                                                        rhs: New {
+                                                                            t: Alias(
+                                                                                r"intersection_desc",
+                                                                            ),
+                                                                            fields: Some(
+                                                                                [
+                                                                                    (
+                                                                                        r"t",
+                                                                                        LvalueToRvalue(
+                                                                                            Identifier(
+                                                                                                r"intersection",
+                                                                                            ),
+                                                                                        ),
+                                                                                    ),
+                                                                                    (
+                                                                                        r"object",
+                                                                                        LvalueToRvalue(
+                                                                                            Identifier(
+                                                                                                r"obj",
+                                                                                            ),
+                                                                                        ),
+                                                                                    ),
+                                                                                ],
+                                                                            ),
+                                                                        },
+                                                                    },
                                                                 ),
+                                                            ],
+                                                        ),
+                                                        on_false: None,
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"best_intersection",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"trace_rays",
+                arguments: [
+                    (
+                        r"h",
+                        Int,
+                    ),
+                    (
+                        r"w",
+                        Int,
+                    ),
+                    (
+                        r"scene",
+                        Array(
+                            ArrayDescription {
+                                t: Alias(
+                                    r"object",
+                                ),
+                                length: None,
+                            },
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"canvas",
+                    ),
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"c",
+                                        t: None,
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"new_canvas",
+                                                args: [
+                                                    LvalueToRvalue(
+                                                        Identifier(
+                                                            r"h",
+                                                        ),
+                                                    ),
+                                                    LvalueToRvalue(
+                                                        Identifier(
+                                                            r"w",
+                                                        ),
+                                                    ),
+                                                    LvalueToRvalue(
+                                                        Identifier(
+                                                            r"BLACK",
+                                                        ),
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"virtual_screen_height",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"virtual_screen_width",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Div,
+                                                lhs: BinOp {
+                                                    op: Mul,
+                                                    lhs: LvalueToRvalue(
+                                                        Identifier(
+                                                            r"virtual_screen_height",
+                                                        ),
+                                                    ),
+                                                    rhs: IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "16",
+                                                            value: 16,
+                                                        },
+                                                    ),
+                                                },
+                                                rhs: IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "9",
+                                                        value: 9,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"base",
+                                        t: Some(
+                                            Alias(
+                                                r"vector",
+                                            ),
+                                        ),
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"vector_of",
+                                                args: [
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "0",
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "0",
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "-2",
+                                                            value: -2,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"x_orth",
+                                        t: Some(
+                                            Alias(
+                                                r"vector",
+                                            ),
+                                        ),
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"vector_of",
+                                                args: [
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "1",
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "0",
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "0",
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"y_orth",
+                                        t: Some(
+                                            Alias(
+                                                r"vector",
+                                            ),
+                                        ),
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"vector_of",
+                                                args: [
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "0",
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "1",
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "0",
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"left_bottom",
+                                        t: Some(
+                                            Alias(
+                                                r"vector",
+                                            ),
+                                        ),
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"vector_of",
+                                                args: [
+                                                    BinOp {
+                                                        op: Div,
+                                                        lhs: UnOp {
+                                                            op: Minus,
+                                                            operand: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"virtual_screen_width",
+                                                                ),
+                                                            ),
+                                                        },
+                                                        rhs: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "2",
+                                                                value: 2,
                                                             },
                                                         ),
-                                                    ],
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"intersect_plane",
-                    arguments: [
-                        (
-                            r"p",
-                            Alias(
-                                r"plane",
-                            ),
-                        ),
-                        (
-                            r"r",
-                            Alias(
-                                r"ray",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Real,
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: Call {
-                                                callee: r"approx_eq",
-                                                args: [
-                                                    Call {
-                                                        callee: r"vector_dot",
-                                                        args: [
-                                                            LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"p",
-                                                                    ),
-                                                                    member_name: r"normal",
-                                                                },
+                                                    },
+                                                    BinOp {
+                                                        op: Div,
+                                                        lhs: UnOp {
+                                                            op: Minus,
+                                                            operand: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"virtual_screen_height",
+                                                                ),
                                                             ),
-                                                            LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"r",
-                                                                    ),
-                                                                    member_name: r"dest",
-                                                                },
-                                                            ),
-                                                        ],
+                                                        },
+                                                        rhs: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "2",
+                                                                value: 2,
+                                                            },
+                                                        ),
                                                     },
                                                     IntegerLiteral(
                                                         IntegerLiteral {
@@ -3207,402 +4335,27 @@
                                                     ),
                                                 ],
                                             },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: RealLiteral(
-                                                                RealLiteral {
-                                                                    repr: "NaN",
-                                                                    value: NaN,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"t",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
-                                                BinOp {
-                                                    op: Div,
-                                                    lhs: Call {
-                                                        callee: r"vector_dot",
-                                                        args: [
-                                                            Call {
-                                                                callee: r"vector_sub",
-                                                                args: [
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"p",
-                                                                            ),
-                                                                            member_name: r"point",
-                                                                        },
-                                                                    ),
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"r",
-                                                                            ),
-                                                                            member_name: r"base",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                            LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"p",
-                                                                    ),
-                                                                    member_name: r"normal",
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                    rhs: Call {
-                                                        callee: r"vector_dot",
-                                                        args: [
-                                                            LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"r",
-                                                                    ),
-                                                                    member_name: r"dest",
-                                                                },
-                                                            ),
-                                                            LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"p",
-                                                                    ),
-                                                                    member_name: r"normal",
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Gt,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"t",
-                                                    ),
-                                                ),
-                                                rhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"EPS",
-                                                    ),
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"t",
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: Some(
-                                                Block(
-                                                    [
-                                                        Stmt(
-                                                            Return {
-                                                                value: RealLiteral(
-                                                                    RealLiteral {
-                                                                        repr: "NaN",
-                                                                        value: NaN,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"intersect_object",
-                    arguments: [
-                        (
-                            r"o",
-                            Alias(
-                                r"object",
-                            ),
-                        ),
-                        (
-                            r"r",
-                            Alias(
-                                r"ray",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Real,
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"o",
-                                                        ),
-                                                        member_name: r"kind",
-                                                    },
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: Call {
-                                                                callee: r"intersect_sphere",
-                                                                args: [
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"o",
-                                                                            ),
-                                                                            member_name: r"s",
-                                                                        },
-                                                                    ),
-                                                                    LvalueToRvalue(
-                                                                        Identifier(
-                                                                            r"r",
-                                                                        ),
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"o",
-                                                        ),
-                                                        member_name: r"kind",
-                                                    },
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: Call {
-                                                                callee: r"intersect_plane",
-                                                                args: [
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"o",
-                                                                            ),
-                                                                            member_name: r"p",
-                                                                        },
-                                                                    ),
-                                                                    LvalueToRvalue(
-                                                                        Identifier(
-                                                                            r"r",
-                                                                        ),
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "NaN",
-                                                    value: NaN,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"normal_at_sphere",
-                    arguments: [
-                        (
-                            r"s",
-                            Alias(
-                                r"sphere",
-                            ),
-                        ),
-                        (
-                            r"point",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Alias(
-                            r"vector",
-                        ),
-                    ),
-                    body: Some(
-                        Expression(
-                            Call {
-                                callee: r"vector_normalised",
-                                args: [
-                                    Call {
-                                        callee: r"vector_sub",
-                                        args: [
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"point",
-                                                ),
-                                            ),
-                                            LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"s",
-                                                    ),
-                                                    member_name: r"centre",
-                                                },
-                                            ),
-                                        ],
+                                        ),
                                     },
-                                ],
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"normal_at_plane",
-                    arguments: [
-                        (
-                            r"p",
-                            Alias(
-                                r"plane",
-                            ),
-                        ),
-                        (
-                            r"point",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Alias(
-                            r"vector",
-                        ),
-                    ),
-                    body: Some(
-                        Expression(
-                            LvalueToRvalue(
-                                Member {
-                                    lhs: Identifier(
-                                        r"p",
-                                    ),
-                                    member_name: r"normal",
-                                },
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"normal_at_object",
-                    arguments: [
-                        (
-                            r"o",
-                            Alias(
-                                r"object",
-                            ),
-                        ),
-                        (
-                            r"r",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Alias(
-                            r"vector",
-                        ),
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Eq,
+                                ),
+                                Stmt(
+                                    For {
+                                        counter: r"x",
+                                        from: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "0",
+                                                value: 0,
+                                            },
+                                        ),
+                                        to: Some(
+                                            BinOp {
+                                                op: Minus,
                                                 lhs: LvalueToRvalue(
                                                     Member {
                                                         lhs: Identifier(
-                                                            r"o",
+                                                            r"c",
                                                         ),
-                                                        member_name: r"kind",
+                                                        member_name: r"width",
                                                     },
                                                 ),
                                                 rhs: IntegerLiteral(
@@ -3612,1561 +4365,805 @@
                                                     },
                                                 ),
                                             },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: Call {
-                                                                callee: r"normal_at_sphere",
-                                                                args: [
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"o",
-                                                                            ),
-                                                                            member_name: r"s",
-                                                                        },
-                                                                    ),
-                                                                    LvalueToRvalue(
-                                                                        Identifier(
-                                                                            r"r",
-                                                                        ),
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"o",
-                                                        ),
-                                                        member_name: r"kind",
-                                                    },
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: Call {
-                                                                callee: r"normal_at_plane",
-                                                                args: [
-                                                                    LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"o",
-                                                                            ),
-                                                                            member_name: r"p",
-                                                                        },
-                                                                    ),
-                                                                    LvalueToRvalue(
-                                                                        Identifier(
-                                                                            r"r",
-                                                                        ),
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: Null,
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"colour_at_object",
-                    arguments: [
-                        (
-                            r"o",
-                            Alias(
-                                r"object",
-                            ),
-                        ),
-                        (
-                            r"r",
-                            Alias(
-                                r"vector",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Alias(
-                            r"colour",
-                        ),
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"o",
-                                                        ),
-                                                        member_name: r"kind",
-                                                    },
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Member {
-                                                                        lhs: Identifier(
-                                                                            r"o",
-                                                                        ),
-                                                                        member_name: r"s",
-                                                                    },
-                                                                    member_name: r"colour",
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Member {
-                                                        lhs: Identifier(
-                                                            r"o",
-                                                        ),
-                                                        member_name: r"kind",
-                                                    },
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
-                                                    },
-                                                ),
-                                            },
-                                            on_true: Block(
-                                                [
-                                                    Stmt(
-                                                        Return {
-                                                            value: LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Member {
-                                                                        lhs: Identifier(
-                                                                            r"o",
-                                                                        ),
-                                                                        member_name: r"p",
-                                                                    },
-                                                                    member_name: r"colour",
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: Null,
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"intersection_desc",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"t",
-                                    t: Real,
-                                },
-                                FieldDescription {
-                                    name: r"object",
-                                    t: Alias(
-                                        r"object",
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"empty_intersection_desc",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"intersection_desc",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"t",
-                                            RealLiteral(
-                                                RealLiteral {
-                                                    repr: "NaN",
-                                                    value: NaN,
-                                                },
-                                            ),
                                         ),
-                                        (
-                                            r"object",
-                                            Null,
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"trace_ray",
-                    arguments: [
-                        (
-                            r"r",
-                            Alias(
-                                r"ray",
-                            ),
-                        ),
-                        (
-                            r"scene",
-                            Array(
-                                ArrayDescription {
-                                    t: Alias(
-                                        r"object",
-                                    ),
-                                    length: None,
-                                },
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Alias(
-                            r"intersection_desc",
-                        ),
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"best_intersection",
-                                            t: None,
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"empty_intersection_desc",
-                                                    args: [],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        For {
-                                            counter: r"obj",
-                                            from: LvalueToRvalue(
-                                                Identifier(
-                                                    r"scene",
-                                                ),
-                                            ),
-                                            to: None,
-                                            order: Direct,
-                                            body: Block(
-                                                [
-                                                    VarDecl(
-                                                        VarDecl {
-                                                            name: r"intersection",
-                                                            t: None,
-                                                            initialiser: Some(
-                                                                Call {
-                                                                    callee: r"intersect_object",
-                                                                    args: [
-                                                                        LvalueToRvalue(
-                                                                            Identifier(
-                                                                                r"obj",
-                                                                            ),
+                                        order: Direct,
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    For {
+                                                        counter: r"y",
+                                                        from: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "0",
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                        to: Some(
+                                                            BinOp {
+                                                                op: Minus,
+                                                                lhs: LvalueToRvalue(
+                                                                    Member {
+                                                                        lhs: Identifier(
+                                                                            r"c",
                                                                         ),
-                                                                        LvalueToRvalue(
-                                                                            Identifier(
-                                                                                r"r",
-                                                                            ),
-                                                                        ),
-                                                                    ],
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                    Stmt(
-                                                        If {
-                                                            condition: BinOp {
-                                                                op: And,
-                                                                lhs: UnOp {
-                                                                    op: Not,
-                                                                    operand: Call {
-                                                                        callee: r"is_nan",
-                                                                        args: [
-                                                                            LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"intersection",
-                                                                                ),
-                                                                            ),
-                                                                        ],
+                                                                        member_name: r"height",
                                                                     },
-                                                                },
-                                                                rhs: BinOp {
-                                                                    op: Or,
-                                                                    lhs: Call {
-                                                                        callee: r"is_nan",
-                                                                        args: [
-                                                                            LvalueToRvalue(
-                                                                                Member {
-                                                                                    lhs: Identifier(
-                                                                                        r"best_intersection",
+                                                                ),
+                                                                rhs: IntegerLiteral(
+                                                                    IntegerLiteral {
+                                                                        repr: "1",
+                                                                        value: 1,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                        order: Direct,
+                                                        body: Block(
+                                                            [
+                                                                VarDecl(
+                                                                    VarDecl {
+                                                                        name: r"virtual_screen_point",
+                                                                        t: Some(
+                                                                            Alias(
+                                                                                r"vector",
+                                                                            ),
+                                                                        ),
+                                                                        initialiser: Some(
+                                                                            Call {
+                                                                                callee: r"vector_add",
+                                                                                args: [
+                                                                                    LvalueToRvalue(
+                                                                                        Identifier(
+                                                                                            r"left_bottom",
+                                                                                        ),
                                                                                     ),
-                                                                                    member_name: r"t",
-                                                                                },
-                                                                            ),
-                                                                        ],
-                                                                    },
-                                                                    rhs: BinOp {
-                                                                        op: Gt,
-                                                                        lhs: LvalueToRvalue(
-                                                                            Member {
-                                                                                lhs: Identifier(
-                                                                                    r"best_intersection",
-                                                                                ),
-                                                                                member_name: r"t",
-                                                                            },
-                                                                        ),
-                                                                        rhs: BinOp {
-                                                                            op: Plus,
-                                                                            lhs: LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"intersection",
-                                                                                ),
-                                                                            ),
-                                                                            rhs: LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"EPS",
-                                                                                ),
-                                                                            ),
-                                                                        },
-                                                                    },
-                                                                },
-                                                            },
-                                                            on_true: Block(
-                                                                [
-                                                                    Stmt(
-                                                                        Assignment {
-                                                                            lhs: Identifier(
-                                                                                r"best_intersection",
-                                                                            ),
-                                                                            rhs: New {
-                                                                                t: Alias(
-                                                                                    r"intersection_desc",
-                                                                                ),
-                                                                                fields: Some(
-                                                                                    [
-                                                                                        (
-                                                                                            r"t",
-                                                                                            LvalueToRvalue(
-                                                                                                Identifier(
-                                                                                                    r"intersection",
-                                                                                                ),
-                                                                                            ),
-                                                                                        ),
-                                                                                        (
-                                                                                            r"object",
-                                                                                            LvalueToRvalue(
-                                                                                                Identifier(
-                                                                                                    r"obj",
-                                                                                                ),
-                                                                                            ),
-                                                                                        ),
-                                                                                    ],
-                                                                                ),
-                                                                            },
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            ),
-                                                            on_false: None,
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"best_intersection",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"trace_rays",
-                    arguments: [
-                        (
-                            r"h",
-                            Int,
-                        ),
-                        (
-                            r"w",
-                            Int,
-                        ),
-                        (
-                            r"scene",
-                            Array(
-                                ArrayDescription {
-                                    t: Alias(
-                                        r"object",
-                                    ),
-                                    length: None,
-                                },
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Alias(
-                            r"canvas",
-                        ),
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"c",
-                                            t: None,
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"new_canvas",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"h",
-                                                            ),
-                                                        ),
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"w",
-                                                            ),
-                                                        ),
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"BLACK",
-                                                            ),
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"virtual_screen_height",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"virtual_screen_width",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: Some(
-                                                BinOp {
-                                                    op: Div,
-                                                    lhs: BinOp {
-                                                        op: Mul,
-                                                        lhs: LvalueToRvalue(
-                                                            Identifier(
-                                                                r"virtual_screen_height",
-                                                            ),
-                                                        ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "16",
-                                                                value: 16,
-                                                            },
-                                                        ),
-                                                    },
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "9",
-                                                            value: 9,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"base",
-                                            t: Some(
-                                                Alias(
-                                                    r"vector",
-                                                ),
-                                            ),
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"vector_of",
-                                                    args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "0",
-                                                                value: 0,
-                                                            },
-                                                        ),
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "0",
-                                                                value: 0,
-                                                            },
-                                                        ),
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "-2",
-                                                                value: -2,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"x_orth",
-                                            t: Some(
-                                                Alias(
-                                                    r"vector",
-                                                ),
-                                            ),
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"vector_of",
-                                                    args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "1",
-                                                                value: 1,
-                                                            },
-                                                        ),
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "0",
-                                                                value: 0,
-                                                            },
-                                                        ),
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "0",
-                                                                value: 0,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"y_orth",
-                                            t: Some(
-                                                Alias(
-                                                    r"vector",
-                                                ),
-                                            ),
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"vector_of",
-                                                    args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "0",
-                                                                value: 0,
-                                                            },
-                                                        ),
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "1",
-                                                                value: 1,
-                                                            },
-                                                        ),
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "0",
-                                                                value: 0,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"left_bottom",
-                                            t: Some(
-                                                Alias(
-                                                    r"vector",
-                                                ),
-                                            ),
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"vector_of",
-                                                    args: [
-                                                        BinOp {
-                                                            op: Div,
-                                                            lhs: UnOp {
-                                                                op: Minus,
-                                                                operand: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"virtual_screen_width",
-                                                                    ),
-                                                                ),
-                                                            },
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "2",
-                                                                    value: 2,
-                                                                },
-                                                            ),
-                                                        },
-                                                        BinOp {
-                                                            op: Div,
-                                                            lhs: UnOp {
-                                                                op: Minus,
-                                                                operand: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"virtual_screen_height",
-                                                                    ),
-                                                                ),
-                                                            },
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "2",
-                                                                    value: 2,
-                                                                },
-                                                            ),
-                                                        },
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "0",
-                                                                value: 0,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        For {
-                                            counter: r"x",
-                                            from: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "0",
-                                                    value: 0,
-                                                },
-                                            ),
-                                            to: Some(
-                                                BinOp {
-                                                    op: Minus,
-                                                    lhs: LvalueToRvalue(
-                                                        Member {
-                                                            lhs: Identifier(
-                                                                r"c",
-                                                            ),
-                                                            member_name: r"width",
-                                                        },
-                                                    ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "1",
-                                                            value: 1,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            order: Direct,
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        For {
-                                                            counter: r"y",
-                                                            from: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "0",
-                                                                    value: 0,
-                                                                },
-                                                            ),
-                                                            to: Some(
-                                                                BinOp {
-                                                                    op: Minus,
-                                                                    lhs: LvalueToRvalue(
-                                                                        Member {
-                                                                            lhs: Identifier(
-                                                                                r"c",
-                                                                            ),
-                                                                            member_name: r"height",
-                                                                        },
-                                                                    ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
-                                                                            repr: "1",
-                                                                            value: 1,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            order: Direct,
-                                                            body: Block(
-                                                                [
-                                                                    VarDecl(
-                                                                        VarDecl {
-                                                                            name: r"virtual_screen_point",
-                                                                            t: Some(
-                                                                                Alias(
-                                                                                    r"vector",
-                                                                                ),
-                                                                            ),
-                                                                            initialiser: Some(
-                                                                                Call {
-                                                                                    callee: r"vector_add",
-                                                                                    args: [
-                                                                                        LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"left_bottom",
-                                                                                            ),
-                                                                                        ),
-                                                                                        Call {
-                                                                                            callee: r"vector_add",
-                                                                                            args: [
-                                                                                                Call {
-                                                                                                    callee: r"vector_mul",
-                                                                                                    args: [
-                                                                                                        BinOp {
-                                                                                                            op: Div,
-                                                                                                            lhs: BinOp {
-                                                                                                                op: Mul,
-                                                                                                                lhs: LvalueToRvalue(
-                                                                                                                    Identifier(
-                                                                                                                        r"virtual_screen_width",
-                                                                                                                    ),
+                                                                                    Call {
+                                                                                        callee: r"vector_add",
+                                                                                        args: [
+                                                                                            Call {
+                                                                                                callee: r"vector_mul",
+                                                                                                args: [
+                                                                                                    BinOp {
+                                                                                                        op: Div,
+                                                                                                        lhs: BinOp {
+                                                                                                            op: Mul,
+                                                                                                            lhs: LvalueToRvalue(
+                                                                                                                Identifier(
+                                                                                                                    r"virtual_screen_width",
                                                                                                                 ),
-                                                                                                                rhs: LvalueToRvalue(
-                                                                                                                    Identifier(
-                                                                                                                        r"x",
-                                                                                                                    ),
-                                                                                                                ),
-                                                                                                            },
-                                                                                                            rhs: BinOp {
-                                                                                                                op: Mul,
-                                                                                                                lhs: RealLiteral(
-                                                                                                                    RealLiteral {
-                                                                                                                        repr: "1.0",
-                                                                                                                        value: 1.0,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                                rhs: LvalueToRvalue(
-                                                                                                                    Member {
-                                                                                                                        lhs: Identifier(
-                                                                                                                            r"c",
-                                                                                                                        ),
-                                                                                                                        member_name: r"width",
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            },
-                                                                                                        },
-                                                                                                        LvalueToRvalue(
-                                                                                                            Identifier(
-                                                                                                                r"x_orth",
                                                                                                             ),
-                                                                                                        ),
-                                                                                                    ],
-                                                                                                },
-                                                                                                Call {
-                                                                                                    callee: r"vector_mul",
-                                                                                                    args: [
-                                                                                                        BinOp {
-                                                                                                            op: Div,
-                                                                                                            lhs: BinOp {
-                                                                                                                op: Mul,
-                                                                                                                lhs: LvalueToRvalue(
-                                                                                                                    Identifier(
-                                                                                                                        r"virtual_screen_height",
-                                                                                                                    ),
+                                                                                                            rhs: LvalueToRvalue(
+                                                                                                                Identifier(
+                                                                                                                    r"x",
                                                                                                                 ),
-                                                                                                                rhs: LvalueToRvalue(
-                                                                                                                    Identifier(
-                                                                                                                        r"y",
-                                                                                                                    ),
-                                                                                                                ),
-                                                                                                            },
-                                                                                                            rhs: BinOp {
-                                                                                                                op: Mul,
-                                                                                                                lhs: RealLiteral(
-                                                                                                                    RealLiteral {
-                                                                                                                        repr: "1.0",
-                                                                                                                        value: 1.0,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                                rhs: LvalueToRvalue(
-                                                                                                                    Member {
-                                                                                                                        lhs: Identifier(
-                                                                                                                            r"c",
-                                                                                                                        ),
-                                                                                                                        member_name: r"height",
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            },
-                                                                                                        },
-                                                                                                        LvalueToRvalue(
-                                                                                                            Identifier(
-                                                                                                                r"y_orth",
                                                                                                             ),
-                                                                                                        ),
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        },
-                                                                                    ],
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    VarDecl(
-                                                                        VarDecl {
-                                                                            name: r"r",
-                                                                            t: None,
-                                                                            initialiser: Some(
-                                                                                Call {
-                                                                                    callee: r"ray_from_to",
-                                                                                    args: [
-                                                                                        LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"base",
-                                                                                            ),
-                                                                                        ),
-                                                                                        LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"virtual_screen_point",
-                                                                                            ),
-                                                                                        ),
-                                                                                    ],
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    VarDecl(
-                                                                        VarDecl {
-                                                                            name: r"intersection",
-                                                                            t: None,
-                                                                            initialiser: Some(
-                                                                                Call {
-                                                                                    callee: r"trace_ray",
-                                                                                    args: [
-                                                                                        LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"r",
-                                                                                            ),
-                                                                                        ),
-                                                                                        LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"scene",
-                                                                                            ),
-                                                                                        ),
-                                                                                    ],
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    Stmt(
-                                                                        If {
-                                                                            condition: UnOp {
-                                                                                op: Not,
-                                                                                operand: Call {
-                                                                                    callee: r"is_nan",
-                                                                                    args: [
-                                                                                        LvalueToRvalue(
-                                                                                            Member {
-                                                                                                lhs: Identifier(
-                                                                                                    r"intersection",
-                                                                                                ),
-                                                                                                member_name: r"t",
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                },
-                                                                            },
-                                                                            on_true: Block(
-                                                                                [
-                                                                                    VarDecl(
-                                                                                        VarDecl {
-                                                                                            name: r"colour_ratio",
-                                                                                            t: Some(
-                                                                                                Real,
-                                                                                            ),
-                                                                                            initialiser: Some(
-                                                                                                Call {
-                                                                                                    callee: r"vector_dot",
-                                                                                                    args: [
-                                                                                                        Call {
-                                                                                                            callee: r"normal_at_object",
-                                                                                                            args: [
-                                                                                                                LvalueToRvalue(
-                                                                                                                    Member {
-                                                                                                                        lhs: Identifier(
-                                                                                                                            r"intersection",
-                                                                                                                        ),
-                                                                                                                        member_name: r"object",
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                                Call {
-                                                                                                                    callee: r"ray_cut",
-                                                                                                                    args: [
-                                                                                                                        LvalueToRvalue(
-                                                                                                                            Identifier(
-                                                                                                                                r"r",
-                                                                                                                            ),
-                                                                                                                        ),
-                                                                                                                        LvalueToRvalue(
-                                                                                                                            Member {
-                                                                                                                                lhs: Identifier(
-                                                                                                                                    r"intersection",
-                                                                                                                                ),
-                                                                                                                                member_name: r"t",
-                                                                                                                            },
-                                                                                                                        ),
-                                                                                                                    ],
+                                                                                                        },
+                                                                                                        rhs: BinOp {
+                                                                                                            op: Mul,
+                                                                                                            lhs: RealLiteral(
+                                                                                                                RealLiteral {
+                                                                                                                    repr: "1.0",
+                                                                                                                    value: 1.0,
                                                                                                                 },
-                                                                                                            ],
+                                                                                                            ),
+                                                                                                            rhs: LvalueToRvalue(
+                                                                                                                Member {
+                                                                                                                    lhs: Identifier(
+                                                                                                                        r"c",
+                                                                                                                    ),
+                                                                                                                    member_name: r"width",
+                                                                                                                },
+                                                                                                            ),
                                                                                                         },
-                                                                                                        Call {
-                                                                                                            callee: r"vector_mul",
-                                                                                                            args: [
-                                                                                                                IntegerLiteral(
-                                                                                                                    IntegerLiteral {
-                                                                                                                        repr: "-1",
-                                                                                                                        value: -1,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                                LvalueToRvalue(
-                                                                                                                    Member {
-                                                                                                                        lhs: Identifier(
-                                                                                                                            r"r",
-                                                                                                                        ),
-                                                                                                                        member_name: r"dest",
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                        },
-                                                                                                    ],
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    Stmt(
-                                                                                        If {
-                                                                                            condition: BinOp {
-                                                                                                op: Lt,
-                                                                                                lhs: LvalueToRvalue(
-                                                                                                    Identifier(
-                                                                                                        r"colour_ratio",
-                                                                                                    ),
-                                                                                                ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
-                                                                                                        repr: "0",
-                                                                                                        value: 0,
                                                                                                     },
-                                                                                                ),
-                                                                                            },
-                                                                                            on_true: Block(
-                                                                                                [
-                                                                                                    Stmt(
-                                                                                                        Assignment {
-                                                                                                            lhs: Identifier(
-                                                                                                                r"colour_ratio",
-                                                                                                            ),
-                                                                                                            rhs: IntegerLiteral(
-                                                                                                                IntegerLiteral {
-                                                                                                                    repr: "1",
-                                                                                                                    value: 1,
-                                                                                                                },
-                                                                                                            ),
-                                                                                                        },
+                                                                                                    LvalueToRvalue(
+                                                                                                        Identifier(
+                                                                                                            r"x_orth",
+                                                                                                        ),
                                                                                                     ),
                                                                                                 ],
-                                                                                            ),
-                                                                                            on_false: None,
-                                                                                        },
-                                                                                    ),
-                                                                                    VarDecl(
-                                                                                        VarDecl {
-                                                                                            name: r"paint",
-                                                                                            t: None,
-                                                                                            initialiser: Some(
-                                                                                                Call {
-                                                                                                    callee: r"colour_at_object",
-                                                                                                    args: [
-                                                                                                        LvalueToRvalue(
-                                                                                                            Member {
-                                                                                                                lhs: Identifier(
-                                                                                                                    r"intersection",
-                                                                                                                ),
-                                                                                                                member_name: r"object",
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        Call {
-                                                                                                            callee: r"ray_cut",
-                                                                                                            args: [
-                                                                                                                LvalueToRvalue(
-                                                                                                                    Identifier(
-                                                                                                                        r"r",
-                                                                                                                    ),
-                                                                                                                ),
-                                                                                                                LvalueToRvalue(
-                                                                                                                    Member {
-                                                                                                                        lhs: Identifier(
-                                                                                                                            r"intersection",
-                                                                                                                        ),
-                                                                                                                        member_name: r"t",
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                        },
-                                                                                                    ],
-                                                                                                },
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    Stmt(
-                                                                                        Expr(
+                                                                                            },
                                                                                             Call {
-                                                                                                callee: r"set_canvas_at",
+                                                                                                callee: r"vector_mul",
                                                                                                 args: [
+                                                                                                    BinOp {
+                                                                                                        op: Div,
+                                                                                                        lhs: BinOp {
+                                                                                                            op: Mul,
+                                                                                                            lhs: LvalueToRvalue(
+                                                                                                                Identifier(
+                                                                                                                    r"virtual_screen_height",
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                            rhs: LvalueToRvalue(
+                                                                                                                Identifier(
+                                                                                                                    r"y",
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        rhs: BinOp {
+                                                                                                            op: Mul,
+                                                                                                            lhs: RealLiteral(
+                                                                                                                RealLiteral {
+                                                                                                                    repr: "1.0",
+                                                                                                                    value: 1.0,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            rhs: LvalueToRvalue(
+                                                                                                                Member {
+                                                                                                                    lhs: Identifier(
+                                                                                                                        r"c",
+                                                                                                                    ),
+                                                                                                                    member_name: r"height",
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
                                                                                                     LvalueToRvalue(
                                                                                                         Identifier(
-                                                                                                            r"c",
+                                                                                                            r"y_orth",
                                                                                                         ),
                                                                                                     ),
-                                                                                                    LvalueToRvalue(
-                                                                                                        Identifier(
-                                                                                                            r"x",
-                                                                                                        ),
-                                                                                                    ),
-                                                                                                    LvalueToRvalue(
-                                                                                                        Identifier(
-                                                                                                            r"y",
-                                                                                                        ),
-                                                                                                    ),
+                                                                                                ],
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                VarDecl(
+                                                                    VarDecl {
+                                                                        name: r"r",
+                                                                        t: None,
+                                                                        initialiser: Some(
+                                                                            Call {
+                                                                                callee: r"ray_from_to",
+                                                                                args: [
+                                                                                    LvalueToRvalue(
+                                                                                        Identifier(
+                                                                                            r"base",
+                                                                                        ),
+                                                                                    ),
+                                                                                    LvalueToRvalue(
+                                                                                        Identifier(
+                                                                                            r"virtual_screen_point",
+                                                                                        ),
+                                                                                    ),
+                                                                                ],
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                VarDecl(
+                                                                    VarDecl {
+                                                                        name: r"intersection",
+                                                                        t: None,
+                                                                        initialiser: Some(
+                                                                            Call {
+                                                                                callee: r"trace_ray",
+                                                                                args: [
+                                                                                    LvalueToRvalue(
+                                                                                        Identifier(
+                                                                                            r"r",
+                                                                                        ),
+                                                                                    ),
+                                                                                    LvalueToRvalue(
+                                                                                        Identifier(
+                                                                                            r"scene",
+                                                                                        ),
+                                                                                    ),
+                                                                                ],
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                Stmt(
+                                                                    If {
+                                                                        condition: UnOp {
+                                                                            op: Not,
+                                                                            operand: Call {
+                                                                                callee: r"is_nan",
+                                                                                args: [
+                                                                                    LvalueToRvalue(
+                                                                                        Member {
+                                                                                            lhs: Identifier(
+                                                                                                r"intersection",
+                                                                                            ),
+                                                                                            member_name: r"t",
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                            },
+                                                                        },
+                                                                        on_true: Block(
+                                                                            [
+                                                                                VarDecl(
+                                                                                    VarDecl {
+                                                                                        name: r"colour_ratio",
+                                                                                        t: Some(
+                                                                                            Real,
+                                                                                        ),
+                                                                                        initialiser: Some(
+                                                                                            Call {
+                                                                                                callee: r"vector_dot",
+                                                                                                args: [
                                                                                                     Call {
-                                                                                                        callee: r"colour_mix_with_ratio",
+                                                                                                        callee: r"normal_at_object",
                                                                                                         args: [
                                                                                                             LvalueToRvalue(
-                                                                                                                Identifier(
-                                                                                                                    r"BLACK",
-                                                                                                                ),
+                                                                                                                Member {
+                                                                                                                    lhs: Identifier(
+                                                                                                                        r"intersection",
+                                                                                                                    ),
+                                                                                                                    member_name: r"object",
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            Call {
+                                                                                                                callee: r"ray_cut",
+                                                                                                                args: [
+                                                                                                                    LvalueToRvalue(
+                                                                                                                        Identifier(
+                                                                                                                            r"r",
+                                                                                                                        ),
+                                                                                                                    ),
+                                                                                                                    LvalueToRvalue(
+                                                                                                                        Member {
+                                                                                                                            lhs: Identifier(
+                                                                                                                                r"intersection",
+                                                                                                                            ),
+                                                                                                                            member_name: r"t",
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                ],
+                                                                                                            },
+                                                                                                        ],
+                                                                                                    },
+                                                                                                    Call {
+                                                                                                        callee: r"vector_mul",
+                                                                                                        args: [
+                                                                                                            IntegerLiteral(
+                                                                                                                IntegerLiteral {
+                                                                                                                    repr: "-1",
+                                                                                                                    value: -1,
+                                                                                                                },
                                                                                                             ),
                                                                                                             LvalueToRvalue(
-                                                                                                                Identifier(
-                                                                                                                    r"paint",
-                                                                                                                ),
-                                                                                                            ),
-                                                                                                            LvalueToRvalue(
-                                                                                                                Identifier(
-                                                                                                                    r"colour_ratio",
-                                                                                                                ),
+                                                                                                                Member {
+                                                                                                                    lhs: Identifier(
+                                                                                                                        r"r",
+                                                                                                                    ),
+                                                                                                                    member_name: r"dest",
+                                                                                                                },
                                                                                                             ),
                                                                                                         ],
                                                                                                     },
                                                                                                 ],
                                                                                             },
                                                                                         ),
+                                                                                    },
+                                                                                ),
+                                                                                Stmt(
+                                                                                    If {
+                                                                                        condition: BinOp {
+                                                                                            op: Lt,
+                                                                                            lhs: LvalueToRvalue(
+                                                                                                Identifier(
+                                                                                                    r"colour_ratio",
+                                                                                                ),
+                                                                                            ),
+                                                                                            rhs: IntegerLiteral(
+                                                                                                IntegerLiteral {
+                                                                                                    repr: "0",
+                                                                                                    value: 0,
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                        on_true: Block(
+                                                                                            [
+                                                                                                Stmt(
+                                                                                                    Assignment {
+                                                                                                        lhs: Identifier(
+                                                                                                            r"colour_ratio",
+                                                                                                        ),
+                                                                                                        rhs: IntegerLiteral(
+                                                                                                            IntegerLiteral {
+                                                                                                                repr: "1",
+                                                                                                                value: 1,
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                            ],
+                                                                                        ),
+                                                                                        on_false: None,
+                                                                                    },
+                                                                                ),
+                                                                                VarDecl(
+                                                                                    VarDecl {
+                                                                                        name: r"paint",
+                                                                                        t: None,
+                                                                                        initialiser: Some(
+                                                                                            Call {
+                                                                                                callee: r"colour_at_object",
+                                                                                                args: [
+                                                                                                    LvalueToRvalue(
+                                                                                                        Member {
+                                                                                                            lhs: Identifier(
+                                                                                                                r"intersection",
+                                                                                                            ),
+                                                                                                            member_name: r"object",
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    Call {
+                                                                                                        callee: r"ray_cut",
+                                                                                                        args: [
+                                                                                                            LvalueToRvalue(
+                                                                                                                Identifier(
+                                                                                                                    r"r",
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                            LvalueToRvalue(
+                                                                                                                Member {
+                                                                                                                    lhs: Identifier(
+                                                                                                                        r"intersection",
+                                                                                                                    ),
+                                                                                                                    member_name: r"t",
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ],
+                                                                                                    },
+                                                                                                ],
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                Stmt(
+                                                                                    Expr(
+                                                                                        Call {
+                                                                                            callee: r"set_canvas_at",
+                                                                                            args: [
+                                                                                                LvalueToRvalue(
+                                                                                                    Identifier(
+                                                                                                        r"c",
+                                                                                                    ),
+                                                                                                ),
+                                                                                                LvalueToRvalue(
+                                                                                                    Identifier(
+                                                                                                        r"x",
+                                                                                                    ),
+                                                                                                ),
+                                                                                                LvalueToRvalue(
+                                                                                                    Identifier(
+                                                                                                        r"y",
+                                                                                                    ),
+                                                                                                ),
+                                                                                                Call {
+                                                                                                    callee: r"colour_mix_with_ratio",
+                                                                                                    args: [
+                                                                                                        LvalueToRvalue(
+                                                                                                            Identifier(
+                                                                                                                r"BLACK",
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                        LvalueToRvalue(
+                                                                                                            Identifier(
+                                                                                                                r"paint",
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                        LvalueToRvalue(
+                                                                                                            Identifier(
+                                                                                                                r"colour_ratio",
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        },
                                                                                     ),
-                                                                                ],
-                                                                            ),
-                                                                            on_false: None,
+                                                                                ),
+                                                                            ],
+                                                                        ),
+                                                                        on_false: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"c",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"red_sphere",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Alias(
+                                                    r"sphere",
+                                                ),
+                                                fields: Some(
+                                                    [
+                                                        (
+                                                            r"centre",
+                                                            Call {
+                                                                callee: r"vector_of",
+                                                                args: [
+                                                                    RealLiteral(
+                                                                        RealLiteral {
+                                                                            repr: "0.5",
+                                                                            value: 0.5,
+                                                                        },
+                                                                    ),
+                                                                    RealLiteral(
+                                                                        RealLiteral {
+                                                                            repr: "0.5",
+                                                                            value: 0.5,
+                                                                        },
+                                                                    ),
+                                                                    IntegerLiteral(
+                                                                        IntegerLiteral {
+                                                                            repr: "3",
+                                                                            value: 3,
                                                                         },
                                                                     ),
                                                                 ],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"c",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"red_sphere",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Alias(
-                                                        r"sphere",
-                                                    ),
-                                                    fields: Some(
-                                                        [
-                                                            (
-                                                                r"centre",
-                                                                Call {
-                                                                    callee: r"vector_of",
-                                                                    args: [
-                                                                        RealLiteral(
-                                                                            RealLiteral {
-                                                                                repr: "0.5",
-                                                                                value: 0.5,
-                                                                            },
-                                                                        ),
-                                                                        RealLiteral(
-                                                                            RealLiteral {
-                                                                                repr: "0.5",
-                                                                                value: 0.5,
-                                                                            },
-                                                                        ),
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
-                                                                                repr: "3",
-                                                                                value: 3,
-                                                                            },
-                                                                        ),
-                                                                    ],
-                                                                },
-                                                            ),
-                                                            (
-                                                                r"radius",
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            (
-                                                                r"colour",
-                                                                LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"RED",
-                                                                    ),
-                                                                ),
-                                                            ),
-                                                        ],
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"green_sphere",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Alias(
-                                                        r"sphere",
-                                                    ),
-                                                    fields: Some(
-                                                        [
-                                                            (
-                                                                r"centre",
-                                                                Call {
-                                                                    callee: r"vector_of",
-                                                                    args: [
-                                                                        RealLiteral(
-                                                                            RealLiteral {
-                                                                                repr: "-0.8",
-                                                                                value: -0.8,
-                                                                            },
-                                                                        ),
-                                                                        RealLiteral(
-                                                                            RealLiteral {
-                                                                                repr: "-0.5",
-                                                                                value: -0.5,
-                                                                            },
-                                                                        ),
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
-                                                                                repr: "4",
-                                                                                value: 4,
-                                                                            },
-                                                                        ),
-                                                                    ],
-                                                                },
-                                                            ),
-                                                            (
-                                                                r"radius",
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "3",
-                                                                        value: 3,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            (
-                                                                r"colour",
-                                                                LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"GREEN",
-                                                                    ),
-                                                                ),
-                                                            ),
-                                                        ],
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"blue_plane",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Alias(
-                                                        r"plane",
-                                                    ),
-                                                    fields: Some(
-                                                        [
-                                                            (
-                                                                r"point",
-                                                                Call {
-                                                                    callee: r"vector_of",
-                                                                    args: [
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
-                                                                                repr: "0",
-                                                                                value: 0,
-                                                                            },
-                                                                        ),
-                                                                        RealLiteral(
-                                                                            RealLiteral {
-                                                                                repr: "-1.5",
-                                                                                value: -1.5,
-                                                                            },
-                                                                        ),
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
-                                                                                repr: "5",
-                                                                                value: 5,
-                                                                            },
-                                                                        ),
-                                                                    ],
-                                                                },
-                                                            ),
-                                                            (
-                                                                r"normal",
-                                                                Call {
-                                                                    callee: r"vector_of",
-                                                                    args: [
-                                                                        RealLiteral(
-                                                                            RealLiteral {
-                                                                                repr: "0.2",
-                                                                                value: 0.2,
-                                                                            },
-                                                                        ),
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
-                                                                                repr: "1",
-                                                                                value: 1,
-                                                                            },
-                                                                        ),
-                                                                        RealLiteral(
-                                                                            RealLiteral {
-                                                                                repr: "-0.1",
-                                                                                value: -0.1,
-                                                                            },
-                                                                        ),
-                                                                    ],
-                                                                },
-                                                            ),
-                                                            (
-                                                                r"colour",
-                                                                LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"BLUE",
-                                                                    ),
-                                                                ),
-                                                            ),
-                                                        ],
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"scene",
-                                            t: None,
-                                            initialiser: Some(
-                                                New {
-                                                    t: Array(
-                                                        ArrayDescription {
-                                                            t: Alias(
-                                                                r"object",
-                                                            ),
-                                                            length: Some(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "3",
-                                                                        value: 3,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                    fields: None,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Identifier(
-                                                    r"scene",
-                                                ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            },
-                                            rhs: Call {
-                                                callee: r"sphere_to_object",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"red_sphere",
+                                                            },
                                                         ),
-                                                    ),
-                                                ],
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Identifier(
-                                                    r"scene",
-                                                ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
-                                                    },
-                                                ),
-                                            },
-                                            rhs: Call {
-                                                callee: r"sphere_to_object",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"green_sphere",
+                                                        (
+                                                            r"radius",
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
                                                         ),
-                                                    ),
-                                                ],
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Index {
-                                                lhs: Identifier(
-                                                    r"scene",
-                                                ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "3",
-                                                        value: 3,
-                                                    },
-                                                ),
-                                            },
-                                            rhs: Call {
-                                                callee: r"plane_to_object",
-                                                args: [
-                                                    LvalueToRvalue(
-                                                        Identifier(
-                                                            r"blue_plane",
-                                                        ),
-                                                    ),
-                                                ],
-                                            },
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"height",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "36",
-                                                        value: 36,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Expr(
-                                            Call {
-                                                callee: r"render_canvas",
-                                                args: [
-                                                    Call {
-                                                        callee: r"trace_rays",
-                                                        args: [
+                                                        (
+                                                            r"colour",
                                                             LvalueToRvalue(
                                                                 Identifier(
-                                                                    r"height",
+                                                                    r"RED",
                                                                 ),
                                                             ),
-                                                            BinOp {
-                                                                op: Mul,
-                                                                lhs: BinOp {
-                                                                    op: Div,
-                                                                    lhs: LvalueToRvalue(
-                                                                        Identifier(
-                                                                            r"height",
-                                                                        ),
-                                                                    ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
-                                                                            repr: "9",
-                                                                            value: 9,
+                                                        ),
+                                                    ],
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"green_sphere",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Alias(
+                                                    r"sphere",
+                                                ),
+                                                fields: Some(
+                                                    [
+                                                        (
+                                                            r"centre",
+                                                            Call {
+                                                                callee: r"vector_of",
+                                                                args: [
+                                                                    RealLiteral(
+                                                                        RealLiteral {
+                                                                            repr: "-0.8",
+                                                                            value: -0.8,
                                                                         },
                                                                     ),
+                                                                    RealLiteral(
+                                                                        RealLiteral {
+                                                                            repr: "-0.5",
+                                                                            value: -0.5,
+                                                                        },
+                                                                    ),
+                                                                    IntegerLiteral(
+                                                                        IntegerLiteral {
+                                                                            repr: "4",
+                                                                            value: 4,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                            },
+                                                        ),
+                                                        (
+                                                            r"radius",
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "3",
+                                                                    value: 3,
                                                                 },
+                                                            ),
+                                                        ),
+                                                        (
+                                                            r"colour",
+                                                            LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"GREEN",
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ],
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"blue_plane",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Alias(
+                                                    r"plane",
+                                                ),
+                                                fields: Some(
+                                                    [
+                                                        (
+                                                            r"point",
+                                                            Call {
+                                                                callee: r"vector_of",
+                                                                args: [
+                                                                    IntegerLiteral(
+                                                                        IntegerLiteral {
+                                                                            repr: "0",
+                                                                            value: 0,
+                                                                        },
+                                                                    ),
+                                                                    RealLiteral(
+                                                                        RealLiteral {
+                                                                            repr: "-1.5",
+                                                                            value: -1.5,
+                                                                        },
+                                                                    ),
+                                                                    IntegerLiteral(
+                                                                        IntegerLiteral {
+                                                                            repr: "5",
+                                                                            value: 5,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                            },
+                                                        ),
+                                                        (
+                                                            r"normal",
+                                                            Call {
+                                                                callee: r"vector_of",
+                                                                args: [
+                                                                    RealLiteral(
+                                                                        RealLiteral {
+                                                                            repr: "0.2",
+                                                                            value: 0.2,
+                                                                        },
+                                                                    ),
+                                                                    IntegerLiteral(
+                                                                        IntegerLiteral {
+                                                                            repr: "1",
+                                                                            value: 1,
+                                                                        },
+                                                                    ),
+                                                                    RealLiteral(
+                                                                        RealLiteral {
+                                                                            repr: "-0.1",
+                                                                            value: -0.1,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                            },
+                                                        ),
+                                                        (
+                                                            r"colour",
+                                                            LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"BLUE",
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ],
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"scene",
+                                        t: None,
+                                        initialiser: Some(
+                                            New {
+                                                t: Array(
+                                                    ArrayDescription {
+                                                        t: Alias(
+                                                            r"object",
+                                                        ),
+                                                        length: Some(
+                                                            IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "3",
+                                                                    value: 3,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                fields: None,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"scene",
+                                            ),
+                                            index: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        },
+                                        rhs: Call {
+                                            callee: r"sphere_to_object",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"red_sphere",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"scene",
+                                            ),
+                                            index: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        },
+                                        rhs: Call {
+                                            callee: r"sphere_to_object",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"green_sphere",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Index {
+                                            lhs: Identifier(
+                                                r"scene",
+                                            ),
+                                            index: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "3",
+                                                    value: 3,
+                                                },
+                                            ),
+                                        },
+                                        rhs: Call {
+                                            callee: r"plane_to_object",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"blue_plane",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"height",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "36",
+                                                    value: 36,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Expr(
+                                        Call {
+                                            callee: r"render_canvas",
+                                            args: [
+                                                Call {
+                                                    callee: r"trace_rays",
+                                                    args: [
+                                                        LvalueToRvalue(
+                                                            Identifier(
+                                                                r"height",
+                                                            ),
+                                                        ),
+                                                        BinOp {
+                                                            op: Mul,
+                                                            lhs: BinOp {
+                                                                op: Div,
+                                                                lhs: LvalueToRvalue(
+                                                                    Identifier(
+                                                                        r"height",
+                                                                    ),
+                                                                ),
                                                                 rhs: IntegerLiteral(
                                                                     IntegerLiteral {
-                                                                        repr: "16",
-                                                                        value: 16,
+                                                                        repr: "9",
+                                                                        value: 9,
                                                                     },
                                                                 ),
                                                             },
-                                                            LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"scene",
-                                                                ),
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "16",
+                                                                    value: 16,
+                                                                },
                                                             ),
-                                                        ],
-                                                    },
-                                                ],
-                                            },
-                                        ),
+                                                        },
+                                                        LvalueToRvalue(
+                                                            Identifier(
+                                                                r"scene",
+                                                            ),
+                                                        ),
+                                                    ],
+                                                },
+                                            ],
+                                        },
                                     ),
-                                ],
-                            ),
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/real_comparisons.txt
+++ b/tests/parser/pass/real_comparisons.txt
@@ -1,198 +1,138 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Eq,
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Ne,
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Lt,
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Le,
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Gt,
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Ge,
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "NaN",
-                                                        value: NaN,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: Some(
-                                                Real,
+                            [
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Eq,
+                                            lhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
                                             ),
-                                            initialiser: Some(
-                                                BinOp {
-                                                    op: Plus,
-                                                    lhs: BinOp {
-                                                        op: Plus,
-                                                        lhs: RealLiteral(
-                                                            RealLiteral {
-                                                                repr: "0.1",
-                                                                value: 0.1,
-                                                            },
-                                                        ),
-                                                        rhs: RealLiteral(
-                                                            RealLiteral {
-                                                                repr: "0.1",
-                                                                value: 0.1,
-                                                            },
-                                                        ),
-                                                    },
-                                                    rhs: RealLiteral(
-                                                        RealLiteral {
-                                                            repr: "0.1",
-                                                            value: 0.1,
-                                                        },
-                                                    ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
                                                 },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"a",
-                                                ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Ne,
+                                            lhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"a",
-                                                    ),
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.3",
-                                                        value: 0.3,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: Some(
-                                                Real,
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Lt,
+                                            lhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
                                             ),
-                                            initialiser: Some(
-                                                BinOp {
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Le,
+                                            lhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Gt,
+                                            lhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                        },
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Ge,
+                                            lhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                        },
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Plus,
+                                                lhs: BinOp {
                                                     op: Plus,
                                                     lhs: RealLiteral(
                                                         RealLiteral {
@@ -202,48 +142,105 @@
                                                     ),
                                                     rhs: RealLiteral(
                                                         RealLiteral {
-                                                            repr: "0.2",
-                                                            value: 0.2,
+                                                            repr: "0.1",
+                                                            value: 0.1,
                                                         },
                                                     ),
                                                 },
+                                                rhs: RealLiteral(
+                                                    RealLiteral {
+                                                        repr: "0.1",
+                                                        value: 0.1,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"a",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"a",
+                                                ),
+                                            ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.3",
+                                                    value: 0.3,
+                                                },
                                             ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: Some(
+                                            BinOp {
+                                                op: Plus,
+                                                lhs: RealLiteral(
+                                                    RealLiteral {
+                                                        repr: "0.1",
+                                                        value: 0.1,
+                                                    },
+                                                ),
+                                                rhs: RealLiteral(
+                                                    RealLiteral {
+                                                        repr: "0.2",
+                                                        value: 0.2,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"b",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: BinOp {
+                                            op: Eq,
+                                            lhs: LvalueToRvalue(
                                                 Identifier(
                                                     r"b",
                                                 ),
                                             ),
+                                            rhs: RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.3",
+                                                    value: 0.3,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: BinOp {
-                                                op: Eq,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"b",
-                                                    ),
-                                                ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.3",
-                                                        value: 0.3,
-                                                    },
-                                                ),
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/real_literals.txt
+++ b/tests/parser/pass/real_literals.txt
@@ -1,465 +1,462 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"a",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.0",
-                                                        value: 0.0,
-                                                    },
-                                                ),
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"a",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.0",
+                                                    value: 0.0,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"a",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"a",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "3.14",
-                                                        value: 3.14,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "3.14",
+                                                    value: 3.14,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"b",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"b",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"c",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "1.5",
-                                                        value: 1.5,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"c",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "1.5",
+                                                    value: 1.5,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"c",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"c",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"d",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.5",
-                                                        value: 0.5,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"d",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.5",
+                                                    value: 0.5,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"d",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"d",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"e",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "10.25",
-                                                        value: 10.25,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"e",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "10.25",
+                                                    value: 10.25,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"e",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"e",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"f",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.001",
-                                                        value: 0.001,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"f",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.001",
+                                                    value: 0.001,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"f",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"f",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"g",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "999.999999999999",
-                                                        value: 999.999999999999,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"g",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "999.999999999999",
+                                                    value: 999.999999999999,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"g",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"g",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"h",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.12345678901234",
-                                                        value: 0.12345678901234,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"h",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.12345678901234",
+                                                    value: 0.12345678901234,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"h",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"h",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"i",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "2.71828182845904",
-                                                        value: 2.71828182845904,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"i",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "2.71828182845904",
+                                                    value: 2.71828182845904,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"i",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"i",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"j",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "1.11111111111111",
-                                                        value: 1.11111111111111,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"j",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "1.11111111111111",
+                                                    value: 1.11111111111111,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"j",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"j",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"k",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.00000000000001",
-                                                        value: 1e-14,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"k",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.00000000000001",
+                                                    value: 1e-14,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"k",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"k",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"l",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "12345.6789012345",
-                                                        value: 12345.6789012345,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"l",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "12345.6789012345",
+                                                    value: 12345.6789012345,
+                                                },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"l",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"l",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"m",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"m",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "NaN",
+                                                    value: NaN,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"m",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"n",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: ".5",
+                                                    value: 0.5,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"n",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"o",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "-.5",
+                                                    value: -0.5,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"o",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"p",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "+.5",
+                                                    value: 0.5,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"p",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"q",
+                                        t: None,
+                                        initialiser: Some(
+                                            UnOp {
+                                                op: Minus,
+                                                operand: RealLiteral(
                                                     RealLiteral {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
                                                 ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"q",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"m",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"n",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: ".5",
-                                                        value: 0.5,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"n",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"o",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "-.5",
-                                                        value: -0.5,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"o",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"p",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "+.5",
-                                                        value: 0.5,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"p",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"q",
-                                            t: None,
-                                            initialiser: Some(
-                                                UnOp {
-                                                    op: Minus,
-                                                    operand: RealLiteral(
-                                                        RealLiteral {
-                                                            repr: "NaN",
-                                                            value: NaN,
-                                                        },
-                                                    ),
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"r",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "Inf",
+                                                    value: inf,
                                                 },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"q",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"r",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"r",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"s",
+                                        t: None,
+                                        initialiser: Some(
+                                            UnOp {
+                                                op: Minus,
+                                                operand: RealLiteral(
                                                     RealLiteral {
                                                         repr: "Inf",
                                                         value: inf,
                                                     },
                                                 ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"s",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"r",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"s",
-                                            t: None,
-                                            initialiser: Some(
-                                                UnOp {
-                                                    op: Minus,
-                                                    operand: RealLiteral(
-                                                        RealLiteral {
-                                                            repr: "Inf",
-                                                            value: inf,
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"s",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/records.txt
+++ b/tests/parser/pass/records.txt
@@ -1,360 +1,339 @@
-(
-    Program(
-        [
-            Type(
-                TypeDecl {
-                    name: r"point",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"x",
-                                    t: Real,
+Program(
+    [
+        Type(
+            TypeDecl {
+                name: r"point",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"x",
+                                t: Real,
+                            },
+                            FieldDescription {
+                                name: r"y",
+                                t: Real,
+                            },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"point_of",
+                arguments: [
+                    (
+                        r"x",
+                        Real,
+                    ),
+                    (
+                        r"y",
+                        Real,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"point",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"x",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"x",
+                                            ),
+                                        ),
+                                    ),
+                                    (
+                                        r"y",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"y",
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"squared_distance",
+                arguments: [
+                    (
+                        r"from",
+                        Alias(
+                            r"point",
+                        ),
+                    ),
+                    (
+                        r"to",
+                        Alias(
+                            r"point",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Real,
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Return {
+                                        value: BinOp {
+                                            op: Plus,
+                                            lhs: BinOp {
+                                                op: Mul,
+                                                lhs: BinOp {
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"from",
+                                                            ),
+                                                            member_name: r"x",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"to",
+                                                            ),
+                                                            member_name: r"x",
+                                                        },
+                                                    ),
+                                                },
+                                                rhs: BinOp {
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"from",
+                                                            ),
+                                                            member_name: r"x",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"to",
+                                                            ),
+                                                            member_name: r"x",
+                                                        },
+                                                    ),
+                                                },
+                                            },
+                                            rhs: BinOp {
+                                                op: Mul,
+                                                lhs: BinOp {
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"from",
+                                                            ),
+                                                            member_name: r"y",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"to",
+                                                            ),
+                                                            member_name: r"y",
+                                                        },
+                                                    ),
+                                                },
+                                                rhs: BinOp {
+                                                    op: Minus,
+                                                    lhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"from",
+                                                            ),
+                                                            member_name: r"y",
+                                                        },
+                                                    ),
+                                                    rhs: LvalueToRvalue(
+                                                        Member {
+                                                            lhs: Identifier(
+                                                                r"to",
+                                                            ),
+                                                            member_name: r"y",
+                                                        },
+                                                    ),
+                                                },
+                                            },
+                                        },
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"middle",
+                arguments: [
+                    (
+                        r"a",
+                        Alias(
+                            r"point",
+                        ),
+                    ),
+                    (
+                        r"b",
+                        Alias(
+                            r"point",
+                        ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        Call {
+                            callee: r"point_of",
+                            args: [
+                                BinOp {
+                                    op: Div,
+                                    lhs: BinOp {
+                                        op: Plus,
+                                        lhs: LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"a",
+                                                ),
+                                                member_name: r"x",
+                                            },
+                                        ),
+                                        rhs: LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"b",
+                                                ),
+                                                member_name: r"x",
+                                            },
+                                        ),
+                                    },
+                                    rhs: IntegerLiteral(
+                                        IntegerLiteral {
+                                            repr: "2",
+                                            value: 2,
+                                        },
+                                    ),
                                 },
-                                FieldDescription {
-                                    name: r"y",
-                                    t: Real,
+                                BinOp {
+                                    op: Div,
+                                    lhs: BinOp {
+                                        op: Plus,
+                                        lhs: LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"a",
+                                                ),
+                                                member_name: r"y",
+                                            },
+                                        ),
+                                        rhs: LvalueToRvalue(
+                                            Member {
+                                                lhs: Identifier(
+                                                    r"b",
+                                                ),
+                                                member_name: r"y",
+                                            },
+                                        ),
+                                    },
+                                    rhs: IntegerLiteral(
+                                        IntegerLiteral {
+                                            repr: "2",
+                                            value: 2,
+                                        },
+                                    ),
                                 },
                             ],
                         },
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"point_of",
-                    arguments: [
-                        (
-                            r"x",
-                            Real,
-                        ),
-                        (
-                            r"y",
-                            Real,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
-                                t: Alias(
-                                    r"point",
-                                ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"x",
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"x",
-                                                ),
-                                            ),
-                                        ),
-                                        (
-                                            r"y",
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"y",
-                                                ),
-                                            ),
-                                        ),
-                                    ],
-                                ),
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"squared_distance",
-                    arguments: [
-                        (
-                            r"from",
-                            Alias(
-                                r"point",
-                            ),
-                        ),
-                        (
-                            r"to",
-                            Alias(
-                                r"point",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Real,
-                    ),
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Return {
-                                            value: BinOp {
-                                                op: Plus,
-                                                lhs: BinOp {
-                                                    op: Mul,
-                                                    lhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"from",
-                                                                ),
-                                                                member_name: r"x",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"to",
-                                                                ),
-                                                                member_name: r"x",
-                                                            },
-                                                        ),
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"from",
-                                                                ),
-                                                                member_name: r"x",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"to",
-                                                                ),
-                                                                member_name: r"x",
-                                                            },
-                                                        ),
-                                                    },
-                                                },
-                                                rhs: BinOp {
-                                                    op: Mul,
-                                                    lhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"from",
-                                                                ),
-                                                                member_name: r"y",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"to",
-                                                                ),
-                                                                member_name: r"y",
-                                                            },
-                                                        ),
-                                                    },
-                                                    rhs: BinOp {
-                                                        op: Minus,
-                                                        lhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"from",
-                                                                ),
-                                                                member_name: r"y",
-                                                            },
-                                                        ),
-                                                        rhs: LvalueToRvalue(
-                                                            Member {
-                                                                lhs: Identifier(
-                                                                    r"to",
-                                                                ),
-                                                                member_name: r"y",
-                                                            },
-                                                        ),
-                                                    },
-                                                },
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"middle",
-                    arguments: [
-                        (
-                            r"a",
-                            Alias(
-                                r"point",
-                            ),
-                        ),
-                        (
-                            r"b",
-                            Alias(
-                                r"point",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            Call {
-                                callee: r"point_of",
-                                args: [
-                                    BinOp {
-                                        op: Div,
-                                        lhs: BinOp {
-                                            op: Plus,
-                                            lhs: LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"a",
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"p1",
+                                        t: None,
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"point_of",
+                                                args: [
+                                                    RealLiteral(
+                                                        RealLiteral {
+                                                            repr: "0.0",
+                                                            value: 0.0,
+                                                        },
                                                     ),
-                                                    member_name: r"x",
-                                                },
-                                            ),
-                                            rhs: LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"b",
+                                                    RealLiteral(
+                                                        RealLiteral {
+                                                            repr: "0.0",
+                                                            value: 0.0,
+                                                        },
                                                     ),
-                                                    member_name: r"x",
-                                                },
-                                            ),
-                                        },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
-                                                repr: "2",
-                                                value: 2,
+                                                ],
                                             },
                                         ),
                                     },
-                                    BinOp {
-                                        op: Div,
-                                        lhs: BinOp {
-                                            op: Plus,
-                                            lhs: LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"a",
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"p2",
+                                        t: None,
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"point_of",
+                                                args: [
+                                                    RealLiteral(
+                                                        RealLiteral {
+                                                            repr: "3.0",
+                                                            value: 3.0,
+                                                        },
                                                     ),
-                                                    member_name: r"y",
-                                                },
-                                            ),
-                                            rhs: LvalueToRvalue(
-                                                Member {
-                                                    lhs: Identifier(
-                                                        r"b",
+                                                    RealLiteral(
+                                                        RealLiteral {
+                                                            repr: "4.0",
+                                                            value: 4.0,
+                                                        },
                                                     ),
-                                                    member_name: r"y",
-                                                },
-                                            ),
-                                        },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
-                                                repr: "2",
-                                                value: 2,
+                                                ],
                                             },
                                         ),
                                     },
-                                ],
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"p1",
-                                            t: None,
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"point_of",
-                                                    args: [
-                                                        RealLiteral(
-                                                            RealLiteral {
-                                                                repr: "0.0",
-                                                                value: 0.0,
-                                                            },
-                                                        ),
-                                                        RealLiteral(
-                                                            RealLiteral {
-                                                                repr: "0.0",
-                                                                value: 0.0,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"p2",
-                                            t: None,
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"point_of",
-                                                    args: [
-                                                        RealLiteral(
-                                                            RealLiteral {
-                                                                repr: "3.0",
-                                                                value: 3.0,
-                                                            },
-                                                        ),
-                                                        RealLiteral(
-                                                            RealLiteral {
-                                                                repr: "4.0",
-                                                                value: 4.0,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"mid",
-                                            t: None,
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"middle",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"p1",
-                                                            ),
-                                                        ),
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"p2",
-                                                            ),
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: Call {
-                                                callee: r"squared_distance",
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"mid",
+                                        t: None,
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"middle",
                                                 args: [
                                                     LvalueToRvalue(
                                                         Identifier(
@@ -368,15 +347,33 @@
                                                     ),
                                                 ],
                                             },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: Call {
+                                            callee: r"squared_distance",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"p1",
+                                                    ),
+                                                ),
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"p2",
+                                                    ),
+                                                ),
+                                            ],
                                         },
-                                    ),
-                                ],
-                            ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/recursive_function.txt
+++ b/tests/parser/pass/recursive_function.txt
@@ -1,142 +1,139 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"fibonacci",
-                    arguments: [
-                        (
-                            r"n",
-                            Int,
-                        ),
-                    ],
-                    return_type: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"fibonacci",
+                arguments: [
+                    (
+                        r"n",
                         Int,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        If {
-                                            condition: BinOp {
-                                                op: Le,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"n",
-                                                    ),
+                            [
+                                Stmt(
+                                    If {
+                                        condition: BinOp {
+                                            op: Le,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"n",
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "2",
-                                                        value: 2,
+                                            ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "2",
+                                                    value: 2,
+                                                },
+                                            ),
+                                        },
+                                        on_true: Block(
+                                            [
+                                                Stmt(
+                                                    Return {
+                                                        value: IntegerLiteral(
+                                                            IntegerLiteral {
+                                                                repr: "1",
+                                                                value: 1,
+                                                            },
+                                                        ),
                                                     },
                                                 ),
-                                            },
-                                            on_true: Block(
+                                            ],
+                                        ),
+                                        on_false: Some(
+                                            Block(
                                                 [
                                                     Stmt(
                                                         Return {
-                                                            value: IntegerLiteral(
-                                                                IntegerLiteral {
-                                                                    repr: "1",
-                                                                    value: 1,
+                                                            value: BinOp {
+                                                                op: Plus,
+                                                                lhs: Call {
+                                                                    callee: r"fibonacci",
+                                                                    args: [
+                                                                        BinOp {
+                                                                            op: Minus,
+                                                                            lhs: LvalueToRvalue(
+                                                                                Identifier(
+                                                                                    r"n",
+                                                                                ),
+                                                                            ),
+                                                                            rhs: IntegerLiteral(
+                                                                                IntegerLiteral {
+                                                                                    repr: "1",
+                                                                                    value: 1,
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    ],
                                                                 },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: Some(
-                                                Block(
-                                                    [
-                                                        Stmt(
-                                                            Return {
-                                                                value: BinOp {
-                                                                    op: Plus,
-                                                                    lhs: Call {
-                                                                        callee: r"fibonacci",
-                                                                        args: [
-                                                                            BinOp {
-                                                                                op: Minus,
-                                                                                lhs: LvalueToRvalue(
-                                                                                    Identifier(
-                                                                                        r"n",
-                                                                                    ),
+                                                                rhs: Call {
+                                                                    callee: r"fibonacci",
+                                                                    args: [
+                                                                        BinOp {
+                                                                            op: Minus,
+                                                                            lhs: LvalueToRvalue(
+                                                                                Identifier(
+                                                                                    r"n",
                                                                                 ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
-                                                                                        repr: "1",
-                                                                                        value: 1,
-                                                                                    },
-                                                                                ),
-                                                                            },
-                                                                        ],
-                                                                    },
-                                                                    rhs: Call {
-                                                                        callee: r"fibonacci",
-                                                                        args: [
-                                                                            BinOp {
-                                                                                op: Minus,
-                                                                                lhs: LvalueToRvalue(
-                                                                                    Identifier(
-                                                                                        r"n",
-                                                                                    ),
-                                                                                ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
-                                                                                        repr: "2",
-                                                                                        value: 2,
-                                                                                    },
-                                                                                ),
-                                                                            },
-                                                                        ],
-                                                                    },
+                                                                            ),
+                                                                            rhs: IntegerLiteral(
+                                                                                IntegerLiteral {
+                                                                                    repr: "2",
+                                                                                    value: 2,
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    ],
                                                                 },
                                                             },
-                                                        ),
-                                                    ],
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: Call {
-                                                callee: r"fibonacci",
-                                                args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "10",
-                                                            value: 10,
                                                         },
                                                     ),
                                                 ],
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Print {
+                                        value: Call {
+                                            callee: r"fibonacci",
+                                            args: [
+                                                IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "10",
+                                                        value: 10,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/recursive_types.txt
+++ b/tests/parser/pass/recursive_types.txt
@@ -1,403 +1,400 @@
-(
-    Program(
-        [
-            Type(
-                TypeDecl {
-                    name: r"linked_list",
-                    t: Record(
-                        RecordDescription {
-                            fields: [
-                                FieldDescription {
-                                    name: r"data",
-                                    t: Int,
-                                },
-                                FieldDescription {
-                                    name: r"tail",
-                                    t: Alias(
-                                        r"linked_list",
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"EMPTY",
-                    t: Some(
-                        Alias(
-                            r"linked_list",
-                        ),
-                    ),
-                    initialiser: Some(
-                        Null,
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"singleton",
-                    arguments: [
-                        (
-                            r"data",
-                            Int,
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            New {
+Program(
+    [
+        Type(
+            TypeDecl {
+                name: r"linked_list",
+                t: Record(
+                    RecordDescription {
+                        fields: [
+                            FieldDescription {
+                                name: r"data",
+                                t: Int,
+                            },
+                            FieldDescription {
+                                name: r"tail",
                                 t: Alias(
                                     r"linked_list",
                                 ),
-                                fields: Some(
-                                    [
-                                        (
-                                            r"data",
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"data",
-                                                ),
-                                            ),
-                                        ),
-                                        (
-                                            r"tail",
-                                            LvalueToRvalue(
-                                                Identifier(
-                                                    r"EMPTY",
-                                                ),
-                                            ),
-                                        ),
-                                    ],
-                                ),
                             },
+                        ],
+                    },
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"EMPTY",
+                t: Some(
+                    Alias(
+                        r"linked_list",
+                    ),
+                ),
+                initialiser: Some(
+                    Null,
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"singleton",
+                arguments: [
+                    (
+                        r"data",
+                        Int,
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        New {
+                            t: Alias(
+                                r"linked_list",
+                            ),
+                            fields: Some(
+                                [
+                                    (
+                                        r"data",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"data",
+                                            ),
+                                        ),
+                                    ),
+                                    (
+                                        r"tail",
+                                        LvalueToRvalue(
+                                            Identifier(
+                                                r"EMPTY",
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"empty",
+                arguments: [],
+                return_type: Some(
+                    Alias(
+                        r"linked_list",
+                    ),
+                ),
+                body: Some(
+                    Expression(
+                        LvalueToRvalue(
+                            Identifier(
+                                r"EMPTY",
+                            ),
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"empty",
-                    arguments: [],
-                    return_type: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"is_empty",
+                arguments: [
+                    (
+                        r"l",
                         Alias(
                             r"linked_list",
                         ),
                     ),
-                    body: Some(
-                        Expression(
-                            LvalueToRvalue(
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        BinOp {
+                            op: Eq,
+                            lhs: LvalueToRvalue(
+                                Identifier(
+                                    r"l",
+                                ),
+                            ),
+                            rhs: LvalueToRvalue(
                                 Identifier(
                                     r"EMPTY",
                                 ),
                             ),
-                        ),
+                        },
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"is_empty",
-                    arguments: [
-                        (
-                            r"l",
-                            Alias(
-                                r"linked_list",
-                            ),
-                        ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            BinOp {
-                                op: Eq,
-                                lhs: LvalueToRvalue(
-                                    Identifier(
-                                        r"l",
-                                    ),
-                                ),
-                                rhs: LvalueToRvalue(
-                                    Identifier(
-                                        r"EMPTY",
-                                    ),
-                                ),
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"length",
-                    arguments: [
-                        (
-                            r"l",
-                            Alias(
-                                r"linked_list",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
-                        Int,
-                    ),
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"result",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        While {
-                                            condition: UnOp {
-                                                op: Not,
-                                                operand: Call {
-                                                    callee: r"is_empty",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"l",
-                                                            ),
-                                                        ),
-                                                    ],
-                                                },
-                                            },
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"result",
-                                                            ),
-                                                            rhs: BinOp {
-                                                                op: Plus,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"result",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"l",
-                                                            ),
-                                                            rhs: LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"l",
-                                                                    ),
-                                                                    member_name: r"tail",
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"result",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"reverse_list",
-                    arguments: [
-                        (
-                            r"l",
-                            Alias(
-                                r"linked_list",
-                            ),
-                        ),
-                    ],
-                    return_type: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"length",
+                arguments: [
+                    (
+                        r"l",
                         Alias(
                             r"linked_list",
                         ),
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"result",
-                                            t: None,
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"empty",
-                                                    args: [],
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"result",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
                                                 },
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        While {
-                                            condition: UnOp {
-                                                op: Not,
-                                                operand: Call {
-                                                    callee: r"is_empty",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"l",
-                                                            ),
-                                                        ),
-                                                    ],
-                                                },
-                                            },
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"result",
-                                                            ),
-                                                            rhs: New {
-                                                                t: Alias(
-                                                                    r"linked_list",
-                                                                ),
-                                                                fields: Some(
-                                                                    [
-                                                                        (
-                                                                            r"data",
-                                                                            LvalueToRvalue(
-                                                                                Member {
-                                                                                    lhs: Identifier(
-                                                                                        r"l",
-                                                                                    ),
-                                                                                    member_name: r"data",
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        (
-                                                                            r"tail",
-                                                                            LvalueToRvalue(
-                                                                                Identifier(
-                                                                                    r"result",
-                                                                                ),
-                                                                            ),
-                                                                        ),
-                                                                    ],
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"l",
-                                                            ),
-                                                            rhs: LvalueToRvalue(
-                                                                Member {
-                                                                    lhs: Identifier(
-                                                                        r"l",
-                                                                    ),
-                                                                    member_name: r"tail",
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"result",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"list",
-                                            t: None,
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"singleton",
-                                                    args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "1",
-                                                                value: 1,
-                                                            },
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: Call {
-                                                callee: r"length",
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    While {
+                                        condition: UnOp {
+                                            op: Not,
+                                            operand: Call {
+                                                callee: r"is_empty",
                                                 args: [
                                                     LvalueToRvalue(
                                                         Identifier(
-                                                            r"list",
+                                                            r"l",
                                                         ),
                                                     ),
                                                 ],
                                             },
                                         },
-                                    ),
-                                ],
-                            ),
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"result",
+                                                        ),
+                                                        rhs: BinOp {
+                                                            op: Plus,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"result",
+                                                                ),
+                                                            ),
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"l",
+                                                        ),
+                                                        rhs: LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Identifier(
+                                                                    r"l",
+                                                                ),
+                                                                member_name: r"tail",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"result",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"reverse_list",
+                arguments: [
+                    (
+                        r"l",
+                        Alias(
+                            r"linked_list",
+                        ),
+                    ),
+                ],
+                return_type: Some(
+                    Alias(
+                        r"linked_list",
+                    ),
+                ),
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"result",
+                                        t: None,
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"empty",
+                                                args: [],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    While {
+                                        condition: UnOp {
+                                            op: Not,
+                                            operand: Call {
+                                                callee: r"is_empty",
+                                                args: [
+                                                    LvalueToRvalue(
+                                                        Identifier(
+                                                            r"l",
+                                                        ),
+                                                    ),
+                                                ],
+                                            },
+                                        },
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"result",
+                                                        ),
+                                                        rhs: New {
+                                                            t: Alias(
+                                                                r"linked_list",
+                                                            ),
+                                                            fields: Some(
+                                                                [
+                                                                    (
+                                                                        r"data",
+                                                                        LvalueToRvalue(
+                                                                            Member {
+                                                                                lhs: Identifier(
+                                                                                    r"l",
+                                                                                ),
+                                                                                member_name: r"data",
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    (
+                                                                        r"tail",
+                                                                        LvalueToRvalue(
+                                                                            Identifier(
+                                                                                r"result",
+                                                                            ),
+                                                                        ),
+                                                                    ),
+                                                                ],
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"l",
+                                                        ),
+                                                        rhs: LvalueToRvalue(
+                                                            Member {
+                                                                lhs: Identifier(
+                                                                    r"l",
+                                                                ),
+                                                                member_name: r"tail",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"result",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"list",
+                                        t: None,
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"singleton",
+                                                args: [
+                                                    IntegerLiteral(
+                                                        IntegerLiteral {
+                                                            repr: "1",
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: Call {
+                                            callee: r"length",
+                                            args: [
+                                                LvalueToRvalue(
+                                                    Identifier(
+                                                        r"list",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/routine_redefinition.txt
+++ b/tests/parser/pass/routine_redefinition.txt
@@ -1,35 +1,32 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"foo",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"foo",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [],
-                            ),
+                            [],
                         ),
                     ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"foo",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"foo",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [],
-                            ),
+                            [],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/shadow.txt
+++ b/tests/parser/pass/shadow.txt
@@ -1,102 +1,99 @@
-(
-    Program(
-        [
-            Var(
-                VarDecl {
-                    name: r"x",
-                    t: Some(
-                        Int,
+Program(
+    [
+        Var(
+            VarDecl {
+                name: r"x",
+                t: Some(
+                    Int,
+                ),
+                initialiser: Some(
+                    IntegerLiteral(
+                        IntegerLiteral {
+                            repr: "0",
+                            value: 0,
+                        },
                     ),
-                    initialiser: Some(
-                        IntegerLiteral(
-                            IntegerLiteral {
-                                repr: "0",
-                                value: 0,
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"x",
-                                                ),
+                            [
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"x",
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"x",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"x",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"x",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    If {
+                                        condition: BoolLiteral(
+                                            True,
+                                        ),
+                                        on_true: Block(
+                                            [
+                                                VarDecl(
+                                                    VarDecl {
+                                                        name: r"x",
+                                                        t: None,
+                                                        initialiser: Some(
+                                                            BoolLiteral(
+                                                                True,
+                                                            ),
+                                                        ),
                                                     },
                                                 ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"x",
+                                                Stmt(
+                                                    Print {
+                                                        value: LvalueToRvalue(
+                                                            Identifier(
+                                                                r"x",
+                                                            ),
+                                                        ),
+                                                    },
                                                 ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        If {
-                                            condition: BoolLiteral(
-                                                True,
-                                            ),
-                                            on_true: Block(
-                                                [
-                                                    VarDecl(
-                                                        VarDecl {
-                                                            name: r"x",
-                                                            t: None,
-                                                            initialiser: Some(
-                                                                BoolLiteral(
-                                                                    True,
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                    Stmt(
-                                                        Print {
-                                                            value: LvalueToRvalue(
-                                                                Identifier(
-                                                                    r"x",
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                            on_false: None,
-                                        },
-                                    ),
-                                ],
-                            ),
+                                            ],
+                                        ),
+                                        on_false: None,
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/type_aliases.txt
+++ b/tests/parser/pass/type_aliases.txt
@@ -1,124 +1,121 @@
-(
-    Program(
-        [
-            Type(
-                TypeDecl {
-                    name: r"kilometers",
-                    t: Real,
-                },
-            ),
-            Type(
-                TypeDecl {
-                    name: r"miles",
-                    t: Real,
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"miles_to_kiometers",
-                    arguments: [
-                        (
-                            r"dist",
-                            Alias(
-                                r"miles",
-                            ),
+Program(
+    [
+        Type(
+            TypeDecl {
+                name: r"kilometers",
+                t: Real,
+            },
+        ),
+        Type(
+            TypeDecl {
+                name: r"miles",
+                t: Real,
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"miles_to_kiometers",
+                arguments: [
+                    (
+                        r"dist",
+                        Alias(
+                            r"miles",
                         ),
-                    ],
-                    return_type: None,
-                    body: Some(
-                        Expression(
-                            Cast {
-                                operand: BinOp {
-                                    op: Mul,
-                                    lhs: Cast {
-                                        operand: LvalueToRvalue(
-                                            Identifier(
-                                                r"dist",
-                                            ),
+                    ),
+                ],
+                return_type: None,
+                body: Some(
+                    Expression(
+                        Cast {
+                            operand: BinOp {
+                                op: Mul,
+                                lhs: Cast {
+                                    operand: LvalueToRvalue(
+                                        Identifier(
+                                            r"dist",
                                         ),
-                                        target: Real,
-                                    },
-                                    rhs: RealLiteral(
-                                        RealLiteral {
-                                            repr: "1.60934",
-                                            value: 1.60934,
-                                        },
                                     ),
+                                    target: Real,
                                 },
-                                target: Alias(
-                                    r"kilometers",
+                                rhs: RealLiteral(
+                                    RealLiteral {
+                                        repr: "1.60934",
+                                        value: 1.60934,
+                                    },
                                 ),
                             },
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"dist",
-                                            t: None,
-                                            initialiser: Some(
-                                                Cast {
-                                                    operand: RealLiteral(
-                                                        RealLiteral {
-                                                            repr: "10.0",
-                                                            value: 10.0,
-                                                        },
-                                                    ),
-                                                    target: Alias(
-                                                        r"miles",
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"result",
-                                            t: Some(
-                                                Alias(
-                                                    r"kilometers",
-                                                ),
-                                            ),
-                                            initialiser: Some(
-                                                Call {
-                                                    callee: r"miles_to_kiometers",
-                                                    args: [
-                                                        LvalueToRvalue(
-                                                            Identifier(
-                                                                r"dist",
-                                                            ),
-                                                        ),
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"result",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
+                            target: Alias(
+                                r"kilometers",
                             ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"dist",
+                                        t: None,
+                                        initialiser: Some(
+                                            Cast {
+                                                operand: RealLiteral(
+                                                    RealLiteral {
+                                                        repr: "10.0",
+                                                        value: 10.0,
+                                                    },
+                                                ),
+                                                target: Alias(
+                                                    r"miles",
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"result",
+                                        t: Some(
+                                            Alias(
+                                                r"kilometers",
+                                            ),
+                                        ),
+                                        initialiser: Some(
+                                            Call {
+                                                callee: r"miles_to_kiometers",
+                                                args: [
+                                                    LvalueToRvalue(
+                                                        Identifier(
+                                                            r"dist",
+                                                        ),
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"result",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/type_conversions.txt
+++ b/tests/parser/pass/type_conversions.txt
@@ -1,214 +1,211 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"i",
-                                            t: Some(
-                                                Int,
-                                            ),
-                                            initialiser: None,
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"r",
-                                            t: Some(
-                                                Real,
-                                            ),
-                                            initialiser: None,
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"b",
-                                            t: Some(
-                                                Bool,
-                                            ),
-                                            initialiser: None,
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"i",
+                                        t: Some(
+                                            Int,
+                                        ),
+                                        initialiser: None,
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"r",
+                                        t: Some(
+                                            Real,
+                                        ),
+                                        initialiser: None,
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"b",
+                                        t: Some(
+                                            Bool,
+                                        ),
+                                        initialiser: None,
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"i",
+                                        ),
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "5",
+                                                value: 5,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"i",
+                                        ),
+                                        rhs: RealLiteral(
+                                            RealLiteral {
+                                                repr: "3.7",
+                                                value: 3.7,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"i",
+                                        ),
+                                        rhs: BoolLiteral(
+                                            True,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"i",
+                                        ),
+                                        rhs: BoolLiteral(
+                                            False,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"r",
+                                        ),
+                                        rhs: RealLiteral(
+                                            RealLiteral {
+                                                repr: "2.5",
+                                                value: 2.5,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"r",
+                                        ),
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "10",
+                                                value: 10,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"r",
+                                        ),
+                                        rhs: BoolLiteral(
+                                            True,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"r",
+                                        ),
+                                        rhs: BoolLiteral(
+                                            False,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"b",
+                                        ),
+                                        rhs: BoolLiteral(
+                                            True,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"b",
+                                        ),
+                                        rhs: BoolLiteral(
+                                            False,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"b",
+                                        ),
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "1",
+                                                value: 1,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"b",
+                                        ),
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "0",
+                                                value: 0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
                                                 r"i",
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "5",
-                                                    value: 5,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"i",
-                                            ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "3.7",
-                                                    value: 3.7,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"i",
-                                            ),
-                                            rhs: BoolLiteral(
-                                                True,
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"i",
-                                            ),
-                                            rhs: BoolLiteral(
-                                                False,
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
                                                 r"r",
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
-                                                    repr: "2.5",
-                                                    value: 2.5,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"r",
-                                            ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "10",
-                                                    value: 10,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"r",
-                                            ),
-                                            rhs: BoolLiteral(
-                                                True,
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"r",
-                                            ),
-                                            rhs: BoolLiteral(
-                                                False,
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
                                                 r"b",
                                             ),
-                                            rhs: BoolLiteral(
-                                                True,
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"b",
-                                            ),
-                                            rhs: BoolLiteral(
-                                                False,
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"b",
-                                            ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "1",
-                                                    value: 1,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"b",
-                                            ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "0",
-                                                    value: 0,
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"i",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"r",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"b",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/variable_declarations.txt
+++ b/tests/parser/pass/variable_declarations.txt
@@ -1,135 +1,132 @@
-(
-    Program(
-        [
-            Var(
-                VarDecl {
-                    name: r"a",
-                    t: Some(
-                        Int,
+Program(
+    [
+        Var(
+            VarDecl {
+                name: r"a",
+                t: Some(
+                    Int,
+                ),
+                initialiser: Some(
+                    IntegerLiteral(
+                        IntegerLiteral {
+                            repr: "0",
+                            value: 0,
+                        },
                     ),
-                    initialiser: Some(
-                        IntegerLiteral(
-                            IntegerLiteral {
-                                repr: "0",
-                                value: 0,
-                            },
-                        ),
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"b",
+                t: None,
+                initialiser: Some(
+                    RealLiteral(
+                        RealLiteral {
+                            repr: "1.5",
+                            value: 1.5,
+                        },
                     ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"b",
-                    t: None,
-                    initialiser: Some(
-                        RealLiteral(
-                            RealLiteral {
-                                repr: "1.5",
-                                value: 1.5,
-                            },
-                        ),
-                    ),
-                },
-            ),
-            Var(
-                VarDecl {
-                    name: r"c",
-                    t: Some(
-                        Int,
-                    ),
-                    initialiser: None,
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
+                ),
+            },
+        ),
+        Var(
+            VarDecl {
+                name: r"c",
+                t: Some(
+                    Int,
+                ),
+                initialiser: None,
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"local",
-                                            t: None,
-                                            initialiser: Some(
-                                                BoolLiteral(
-                                                    True,
-                                                ),
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"local",
+                                        t: None,
+                                        initialiser: Some(
+                                            BoolLiteral(
+                                                True,
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Assignment {
-                                            lhs: Identifier(
-                                                r"c",
-                                            ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
-                                                    repr: "0",
-                                                    value: 0,
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Assignment {
+                                        lhs: Identifier(
+                                            r"c",
+                                        ),
+                                        rhs: IntegerLiteral(
+                                            IntegerLiteral {
+                                                repr: "0",
+                                                value: 0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"another_local",
+                                        t: None,
+                                        initialiser: Some(
+                                            RealLiteral(
+                                                RealLiteral {
+                                                    repr: "0.0",
+                                                    value: 0.0,
                                                 },
                                             ),
-                                        },
-                                    ),
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"another_local",
-                                            t: None,
-                                            initialiser: Some(
-                                                RealLiteral(
-                                                    RealLiteral {
-                                                        repr: "0.0",
-                                                        value: 0.0,
-                                                    },
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"c",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"c",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"local",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"local",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"a",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"a",
-                                                ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Print {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"b",
                                             ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Print {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"b",
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+    ],
 )

--- a/tests/parser/pass/while_loops.txt
+++ b/tests/parser/pass/while_loops.txt
@@ -1,80 +1,105 @@
-(
-    Program(
-        [
-            Routine(
-                RoutineDecl {
-                    name: r"collatz",
-                    arguments: [
-                        (
-                            r"n",
-                            Int,
-                        ),
-                    ],
-                    return_type: Some(
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"collatz",
+                arguments: [
+                    (
+                        r"n",
                         Int,
                     ),
-                    body: Some(
+                ],
+                return_type: Some(
+                    Int,
+                ),
+                body: Some(
+                    Block(
                         Block(
-                            Block(
-                                [
-                                    VarDecl(
-                                        VarDecl {
-                                            name: r"steps",
-                                            t: None,
-                                            initialiser: Some(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "0",
-                                                        value: 0,
-                                                    },
+                            [
+                                VarDecl(
+                                    VarDecl {
+                                        name: r"steps",
+                                        t: None,
+                                        initialiser: Some(
+                                            IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "0",
+                                                    value: 0,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    While {
+                                        condition: BinOp {
+                                            op: Ne,
+                                            lhs: LvalueToRvalue(
+                                                Identifier(
+                                                    r"n",
                                                 ),
                                             ),
+                                            rhs: IntegerLiteral(
+                                                IntegerLiteral {
+                                                    repr: "1",
+                                                    value: 1,
+                                                },
+                                            ),
                                         },
-                                    ),
-                                    Stmt(
-                                        While {
-                                            condition: BinOp {
-                                                op: Ne,
-                                                lhs: LvalueToRvalue(
-                                                    Identifier(
-                                                        r"n",
-                                                    ),
-                                                ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
-                                                        repr: "1",
-                                                        value: 1,
-                                                    },
-                                                ),
-                                            },
-                                            body: Block(
-                                                [
-                                                    Stmt(
-                                                        If {
-                                                            condition: BinOp {
-                                                                op: Eq,
-                                                                lhs: BinOp {
-                                                                    op: Mod,
-                                                                    lhs: LvalueToRvalue(
-                                                                        Identifier(
-                                                                            r"n",
-                                                                        ),
+                                        body: Block(
+                                            [
+                                                Stmt(
+                                                    If {
+                                                        condition: BinOp {
+                                                            op: Eq,
+                                                            lhs: BinOp {
+                                                                op: Mod,
+                                                                lhs: LvalueToRvalue(
+                                                                    Identifier(
+                                                                        r"n",
                                                                     ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
-                                                                            repr: "2",
-                                                                            value: 2,
-                                                                        },
-                                                                    ),
-                                                                },
+                                                                ),
                                                                 rhs: IntegerLiteral(
                                                                     IntegerLiteral {
-                                                                        repr: "0",
-                                                                        value: 0,
+                                                                        repr: "2",
+                                                                        value: 2,
                                                                     },
                                                                 ),
                                                             },
-                                                            on_true: Block(
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "0",
+                                                                    value: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        on_true: Block(
+                                                            [
+                                                                Stmt(
+                                                                    Assignment {
+                                                                        lhs: Identifier(
+                                                                            r"n",
+                                                                        ),
+                                                                        rhs: BinOp {
+                                                                            op: Div,
+                                                                            lhs: LvalueToRvalue(
+                                                                                Identifier(
+                                                                                    r"n",
+                                                                                ),
+                                                                            ),
+                                                                            rhs: IntegerLiteral(
+                                                                                IntegerLiteral {
+                                                                                    repr: "2",
+                                                                                    value: 2,
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        ),
+                                                        on_false: Some(
+                                                            Block(
                                                                 [
                                                                     Stmt(
                                                                         Assignment {
@@ -82,16 +107,25 @@
                                                                                 r"n",
                                                                             ),
                                                                             rhs: BinOp {
-                                                                                op: Div,
-                                                                                lhs: LvalueToRvalue(
-                                                                                    Identifier(
-                                                                                        r"n",
+                                                                                op: Plus,
+                                                                                lhs: BinOp {
+                                                                                    op: Mul,
+                                                                                    lhs: IntegerLiteral(
+                                                                                        IntegerLiteral {
+                                                                                            repr: "3",
+                                                                                            value: 3,
+                                                                                        },
                                                                                     ),
-                                                                                ),
+                                                                                    rhs: LvalueToRvalue(
+                                                                                        Identifier(
+                                                                                            r"n",
+                                                                                        ),
+                                                                                    ),
+                                                                                },
                                                                                 rhs: IntegerLiteral(
                                                                                     IntegerLiteral {
-                                                                                        repr: "2",
-                                                                                        value: 2,
+                                                                                        repr: "1",
+                                                                                        value: 1,
                                                                                     },
                                                                                 ),
                                                                             },
@@ -99,115 +133,78 @@
                                                                     ),
                                                                 ],
                                                             ),
-                                                            on_false: Some(
-                                                                Block(
-                                                                    [
-                                                                        Stmt(
-                                                                            Assignment {
-                                                                                lhs: Identifier(
-                                                                                    r"n",
-                                                                                ),
-                                                                                rhs: BinOp {
-                                                                                    op: Plus,
-                                                                                    lhs: BinOp {
-                                                                                        op: Mul,
-                                                                                        lhs: IntegerLiteral(
-                                                                                            IntegerLiteral {
-                                                                                                repr: "3",
-                                                                                                value: 3,
-                                                                                            },
-                                                                                        ),
-                                                                                        rhs: LvalueToRvalue(
-                                                                                            Identifier(
-                                                                                                r"n",
-                                                                                            ),
-                                                                                        ),
-                                                                                    },
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
-                                                                                            repr: "1",
-                                                                                            value: 1,
-                                                                                        },
-                                                                                    ),
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                    ],
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                    Stmt(
-                                                        Assignment {
-                                                            lhs: Identifier(
-                                                                r"steps",
-                                                            ),
-                                                            rhs: BinOp {
-                                                                op: Plus,
-                                                                lhs: LvalueToRvalue(
-                                                                    Identifier(
-                                                                        r"steps",
-                                                                    ),
-                                                                ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "1",
-                                                                        value: 1,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        },
-                                                    ),
-                                                ],
-                                            ),
-                                        },
-                                    ),
-                                    Stmt(
-                                        Return {
-                                            value: LvalueToRvalue(
-                                                Identifier(
-                                                    r"steps",
+                                                        ),
+                                                    },
                                                 ),
-                                            ),
-                                        },
-                                    ),
-                                ],
-                            ),
-                        ),
-                    ),
-                },
-            ),
-            Routine(
-                RoutineDecl {
-                    name: r"main",
-                    arguments: [],
-                    return_type: None,
-                    body: Some(
-                        Block(
-                            Block(
-                                [
-                                    Stmt(
-                                        Print {
-                                            value: Call {
-                                                callee: r"collatz",
-                                                args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "7",
-                                                            value: 7,
+                                                Stmt(
+                                                    Assignment {
+                                                        lhs: Identifier(
+                                                            r"steps",
+                                                        ),
+                                                        rhs: BinOp {
+                                                            op: Plus,
+                                                            lhs: LvalueToRvalue(
+                                                                Identifier(
+                                                                    r"steps",
+                                                                ),
+                                                            ),
+                                                            rhs: IntegerLiteral(
+                                                                IntegerLiteral {
+                                                                    repr: "1",
+                                                                    value: 1,
+                                                                },
+                                                            ),
                                                         },
-                                                    ),
-                                                ],
-                                            },
-                                        },
-                                    ),
-                                ],
-                            ),
+                                                    },
+                                                ),
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                Stmt(
+                                    Return {
+                                        value: LvalueToRvalue(
+                                            Identifier(
+                                                r"steps",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ],
                         ),
                     ),
-                },
-            ),
-        ],
-    ),
-    [],
+                ),
+            },
+        ),
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Print {
+                                        value: Call {
+                                            callee: r"collatz",
+                                            args: [
+                                                IntegerLiteral(
+                                                    IntegerLiteral {
+                                                        repr: "7",
+                                                        value: 7,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+    ],
 )


### PR DESCRIPTION
У нас нет ни одного теста на recoverable parsing errors (сс #77), но если бы они были, то благодаря этому изменению они бы переехали из `tests/parser/pass` в `tests/parser/fail` и, соответсвенно, не отправлялиьс дальше на AST и т.д.

- Related to #70
