### PR TITLE
Remove `Rc` from types in parser

### DIFF
--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -948,6 +948,8 @@ impl Converter {
             return_type,
             body,
         } = decl;
+        let return_type = return_type.as_ref();
+
         let converted_arguments_types = arguments
             .iter()
             .map(|(name, arg_type)| {
@@ -996,8 +998,6 @@ impl Converter {
                 )
             })
             .collect();
-
-        let return_type = return_type.as_deref();
 
         match body {
             parser::RoutineBody::Block(block) => self.convert_routine_block(

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -604,20 +604,21 @@ impl Parser {
         let ((), next) = self.parse_keyword(Keyword::Array, i)?;
         let (length, next) =
             self.parse_in_brackets(|ctx, i| ctx.try_parse(Self::parse_expr, i), next)?;
-        let (element_type, next) = self.parse_type(next)?;
-        Ok((
-            ArrayDescription {
-                length,
-                t: element_type,
-            },
-            next,
-        ))
+        self.parse_type(next).map(|(element_type, next)| {
+            (
+                ArrayDescription {
+                    length,
+                    t: element_type.into(),
+                },
+                next,
+            )
+        })
     }
 
     fn parse_type<'a, 'b: 'a>(
         &mut self,
         i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Rc<Type>> {
+    ) -> ParsingResult<'a, 'b, Type> {
         self.parse_identifier(i)
             .map(|(ident, next)| (Type::Alias(ident), next))
             .or_else(|_| {
@@ -644,7 +645,6 @@ impl Parser {
                 what: "Type expected, but not found".to_owned(),
                 position: i.position(),
             })
-            .map(|(ty, next)| (Rc::new(ty), next))
     }
 
     fn parse_operators<'a, 'b: 'a>(

--- a/compiler/parser/src/tree.rs
+++ b/compiler/parser/src/tree.rs
@@ -23,7 +23,7 @@ pub struct RealLiteral {
     pub value: Real,
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
 pub enum BoolLiteral {
     True,
     False,
@@ -72,33 +72,33 @@ pub enum Expression {
     Null,
 }
 
-#[derive(Debug, Hash, Clone)]
+#[derive(Debug, Hash)]
 pub struct VarDecl {
     pub name: RawIdentifier,
     pub t: Option<Rc<Type>>,
     pub initialiser: Option<Rc<Expression>>,
 }
 
-#[derive(Debug, Hash, Clone)]
+#[derive(Debug, Hash)]
 pub struct ConstDecl {
     pub name: RawIdentifier,
     pub t: Option<Rc<Type>>,
     pub initialiser: Rc<Expression>,
 }
 
-#[derive(Debug, Hash, Clone)]
+#[derive(Debug, Hash)]
 pub struct TypeDecl {
     pub name: RawIdentifier,
     pub t: Rc<Type>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum RoutineBody {
     Block(Block),
     Expression(Rc<Expression>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RoutineDecl {
     pub name: RawIdentifier,
     pub arguments: Vec<(RawIdentifier, Rc<Type>)>,
@@ -106,7 +106,7 @@ pub struct RoutineDecl {
     pub body: Option<RoutineBody>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum BlockElem {
     Stmt(Statement),
     VarDecl(VarDecl),
@@ -114,10 +114,10 @@ pub enum BlockElem {
     TypeDecl(TypeDecl),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Block(pub Vec<BlockElem>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Statement {
     Assignment {
         lhs: Rc<LvalueExpression>,

--- a/compiler/parser/src/tree.rs
+++ b/compiler/parser/src/tree.rs
@@ -63,10 +63,10 @@ pub enum Expression {
     },
     Cast {
         operand: Rc<Expression>,
-        target: Rc<Type>,
+        target: Type,
     },
     New {
-        t: Rc<Type>,
+        t: Type,
         fields: Option<Vec<(RawIdentifier, Rc<Expression>)>>,
     },
     Null,
@@ -75,21 +75,21 @@ pub enum Expression {
 #[derive(Debug, Hash)]
 pub struct VarDecl {
     pub name: RawIdentifier,
-    pub t: Option<Rc<Type>>,
+    pub t: Option<Type>,
     pub initialiser: Option<Rc<Expression>>,
 }
 
 #[derive(Debug, Hash)]
 pub struct ConstDecl {
     pub name: RawIdentifier,
-    pub t: Option<Rc<Type>>,
+    pub t: Option<Type>,
     pub initialiser: Rc<Expression>,
 }
 
 #[derive(Debug, Hash)]
 pub struct TypeDecl {
     pub name: RawIdentifier,
-    pub t: Rc<Type>,
+    pub t: Type,
 }
 
 #[derive(Debug)]
@@ -101,8 +101,8 @@ pub enum RoutineBody {
 #[derive(Debug)]
 pub struct RoutineDecl {
     pub name: RawIdentifier,
-    pub arguments: Vec<(RawIdentifier, Rc<Type>)>,
-    pub return_type: Option<Rc<Type>>,
+    pub arguments: Vec<(RawIdentifier, Type)>,
+    pub return_type: Option<Type>,
     pub body: Option<RoutineBody>,
 }
 

--- a/compiler/parser/src/types.rs
+++ b/compiler/parser/src/types.rs
@@ -8,7 +8,7 @@ use crate::Expression;
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct FieldDescription {
     pub name: RawIdentifier,
-    pub t: Rc<Type>,
+    pub t: Type,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
@@ -18,7 +18,7 @@ pub struct RecordDescription {
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ArrayDescription {
-    pub t: Rc<Type>,
+    pub t: Box<Type>,
     pub length: Option<Rc<Expression>>,
 }
 


### PR DESCRIPTION
Based on top of #119

Related to:
- #111
- #65

We don't really need the ability to do shallow clones (with one exception, which got fixed in #119) and as for the recursive nature of the types in the parser:
- Aliases are not resolved at this point, so they are just an identifier.
- Fields of a record (along with their types) are stored in a vector.
- For the element type of an array, a `Box` is just fine.