### PR TITLE
ast: more precise `#[expect(dead_code)]` on `RoutinePrototype`

### DIFF
--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -33,9 +33,10 @@ impl ScopeBlock {
 }
 
 #[derive(Debug)]
-#[expect(dead_code, reason = "FIXME")]
 struct RoutinePrototype {
+    #[expect(dead_code, reason = "FIXME")]
     name: RawIdentifier,
+    #[expect(dead_code, reason = "FIXME")]
     args: Vec<Rc<Type>>,
     return_type: Rc<Type>,
 }


### PR DESCRIPTION
Closes #95 