### PR TITLE
ast: small fixes

### DIFF
--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -780,8 +780,8 @@ impl Converter {
                     BlockElem::Decl(self.convert_var_decl(var_decl, false)?.map(LocalDecl::Var))
                 }
                 parser::BlockElem::ConstDecl(const_decl) => BlockElem::Decl(
-                    self.convert_decl(&parser::Declaration::Const(const_decl.clone()), false)
-                        .and_then(TryInto::try_into)?,
+                    self.convert_const_decl(const_decl, false)?
+                        .map(LocalDecl::Const),
                 ),
                 parser::BlockElem::TypeDecl(type_decl) => BlockElem::Decl(
                     self.convert_type_decl(type_decl, false)?
@@ -793,6 +793,38 @@ impl Converter {
         Ok(Block {
             elems: result,
             locals_count: self.leave_block(),
+        })
+    }
+
+    fn convert_const_decl(
+        &mut self,
+        decl: &parser::ConstDecl,
+        is_global: bool,
+    ) -> AnalysisResult<Binding<ConstDecl>> {
+        let parser::ConstDecl {
+            name,
+            t,
+            initialiser,
+        } = decl;
+        let converted_expr = self.convert_expr(initialiser)?;
+        let decl = match t {
+            Some(t) => {
+                let converted_type = self.convert_type(t)?;
+                let converted_expr = cast_to(converted_expr, &converted_type)?;
+                ConstDecl {
+                    t: converted_type,
+                    value: converted_expr.try_constexpr_evaluate()?.as_literal(),
+                }
+            }
+            None => ConstDecl {
+                t: converted_expr.ty,
+                value: converted_expr.value.try_constexpr_evaluate()?.as_literal(),
+            },
+        };
+
+        Ok(Binding {
+            name: self.bind_decl(is_global, name, Decl::Const(decl.clone())),
+            decl,
         })
     }
 
@@ -891,32 +923,8 @@ impl Converter {
                 self.convert_var_decl(decl, is_global)?.map(Decl::Var)
             }
 
-            parser::Declaration::Const(parser::ConstDecl {
-                name,
-                t,
-                initialiser,
-            }) => {
-                let converted_expr = self.convert_expr(initialiser)?;
-                let const_decl: Decl = match t {
-                    Some(t) => {
-                        let converted_type = self.convert_type(t)?;
-                        let converted_expr = cast_to(converted_expr, &converted_type)?;
-                        Decl::Const(ConstDecl {
-                            t: converted_type,
-                            value: converted_expr.try_constexpr_evaluate()?.as_literal(),
-                        })
-                    }
-                    None => Decl::Const(ConstDecl {
-                        t: converted_expr.ty,
-                        value: converted_expr.value.try_constexpr_evaluate()?.as_literal(),
-                    }),
-                };
-
-                let ident = self.bind_decl(is_global, name, const_decl.clone());
-                Binding {
-                    name: ident,
-                    decl: const_decl,
-                }
+            parser::Declaration::Const(decl) => {
+                self.convert_const_decl(decl, is_global)?.map(Decl::Const)
             }
             parser::Declaration::Type(decl) => {
                 self.convert_type_decl(decl, is_global)?.map(Decl::Type)

--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -784,8 +784,8 @@ impl Converter {
                         .and_then(TryInto::try_into)?,
                 ),
                 parser::BlockElem::TypeDecl(type_decl) => BlockElem::Decl(
-                    self.convert_decl(&parser::Declaration::Type(type_decl.clone()), false)
-                        .and_then(TryInto::try_into)?,
+                    self.convert_type_decl(type_decl, false)?
+                        .map(LocalDecl::Type),
                 ),
             })
         }
@@ -793,6 +793,35 @@ impl Converter {
         Ok(Block {
             elems: result,
             locals_count: self.leave_block(),
+        })
+    }
+
+    fn convert_type_decl(
+        &mut self,
+        decl: &parser::TypeDecl,
+        is_global: bool,
+    ) -> AnalysisResult<Binding<TypeDecl>> {
+        let parser::TypeDecl { name, t } = decl;
+        // Binding forward declaration of type for possible recursive usage
+        let ident = self.bind_decl(
+            is_global,
+            name,
+            Decl::Type(TypeDecl::Forward {
+                alias: name.clone(),
+            }),
+        );
+
+        let converted_type = self.convert_type(t)?;
+        let effective_type = self.ident_table.get_effective_type(&converted_type)?;
+        let type_decl = TypeDecl::Full {
+            prescribed: converted_type,
+            effective: effective_type,
+        };
+        // Overriding forward declaration with full one
+        self.rebind_decl(&ident, Decl::Type(type_decl.clone()));
+        Ok(Binding {
+            name: ident,
+            decl: type_decl,
         })
     }
 
@@ -880,28 +909,8 @@ impl Converter {
                     decl: const_decl,
                 }
             }
-            parser::Declaration::Type(parser::TypeDecl { name, t }) => {
-                // Binding forward declaration of type for possible recursive usage
-                let ident = self.bind_decl(
-                    is_global,
-                    name,
-                    Decl::Type(TypeDecl::Forward {
-                        alias: name.clone(),
-                    }),
-                );
-
-                let converted_type = self.convert_type(t)?;
-                let effective_type = self.ident_table.get_effective_type(&converted_type)?;
-                let type_decl = Decl::Type(TypeDecl::Full {
-                    prescribed: converted_type,
-                    effective: effective_type,
-                });
-                // Overriding forward declaration with full one
-                self.rebind_decl(&ident, type_decl.clone());
-                Binding {
-                    name: ident,
-                    decl: type_decl,
-                }
+            parser::Declaration::Type(decl) => {
+                self.convert_type_decl(decl, is_global)?.map(Decl::Type)
             }
             parser::Declaration::Routine(decl) => {
                 if is_global {

--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -115,6 +115,7 @@ impl Converter {
         self.ident_table.rebind(ident, new_decl);
     }
 
+    // FIXME: accept `LocalDecl`
     fn bind_local_decl(&mut self, name: &RawIdentifier, decl: Decl) -> Identifier {
         assert!(
             self.current_scope.len() > 1,
@@ -775,10 +776,9 @@ impl Converter {
                 parser::BlockElem::Stmt(statement) => {
                     BlockElem::Stmt(self.convert_stmt(statement)?)
                 }
-                parser::BlockElem::VarDecl(var_decl) => BlockElem::Decl(
-                    self.convert_decl(&parser::Declaration::Var(var_decl.clone()), false)
-                        .and_then(TryInto::try_into)?,
-                ),
+                parser::BlockElem::VarDecl(var_decl) => {
+                    BlockElem::Decl(self.convert_var_decl(var_decl, false)?.map(LocalDecl::Var))
+                }
                 parser::BlockElem::ConstDecl(const_decl) => BlockElem::Decl(
                     self.convert_decl(&parser::Declaration::Const(const_decl.clone()), false)
                         .and_then(TryInto::try_into)?,
@@ -793,6 +793,62 @@ impl Converter {
         Ok(Block {
             elems: result,
             locals_count: self.leave_block(),
+        })
+    }
+
+    fn convert_var_decl(
+        &mut self,
+        decl: &parser::VarDecl,
+        is_global: bool,
+    ) -> AnalysisResult<Binding<VarDecl>> {
+        let parser::VarDecl {
+            name,
+            t,
+            initialiser,
+        } = decl;
+
+        let loc = if is_global {
+            self.get_fresh_global_location()
+        } else {
+            self.get_fresh_local_location()
+        };
+
+        let decl = match (t, initialiser) {
+            (None, None) => Err(AnalysisError {
+                what: format!("Can not deduce type for variable {name:?}"),
+            })?,
+            (None, Some(expr)) => {
+                let Typed {
+                    value: converted_initialiser,
+                    ty: t,
+                } = self.convert_expr(expr)?;
+                VarDecl {
+                    t,
+                    initialiser: Some(converted_initialiser),
+                    relative_location: loc,
+                }
+            }
+            (Some(t), None) => {
+                let converted_type = self.convert_type(t)?;
+                VarDecl {
+                    t: converted_type,
+                    initialiser: None,
+                    relative_location: loc,
+                }
+            }
+            (Some(t), Some(expr)) => {
+                let converted_type = self.convert_type(t)?;
+                VarDecl {
+                    initialiser: Some(cast_to(self.convert_expr(expr)?, &converted_type)?),
+                    t: converted_type,
+                    relative_location: loc,
+                }
+            }
+        };
+
+        Ok(Binding {
+            name: self.bind_decl(is_global, name, Decl::Var(decl.clone())),
+            decl,
         })
     }
 
@@ -831,55 +887,8 @@ impl Converter {
         is_global: bool,
     ) -> AnalysisResult<Binding> {
         Ok(match decl {
-            parser::Declaration::Var(parser::VarDecl {
-                name,
-                t,
-                initialiser,
-            }) => {
-                let loc = if is_global {
-                    self.get_fresh_global_location()
-                } else {
-                    self.get_fresh_local_location()
-                };
-
-                let var_decl: Decl = match (t, initialiser) {
-                    (None, None) => Err(AnalysisError {
-                        what: format!("Can not deduce type for variable {name:?}"),
-                    })?,
-                    (None, Some(expr)) => {
-                        let Typed {
-                            value: converted_initialiser,
-                            ty: t,
-                        } = self.convert_expr(expr)?;
-                        Decl::Var(VarDecl {
-                            t,
-                            initialiser: Some(converted_initialiser),
-                            relative_location: loc,
-                        })
-                    }
-                    (Some(t), None) => {
-                        let converted_type = self.convert_type(t)?;
-                        Decl::Var(VarDecl {
-                            t: converted_type,
-                            initialiser: None,
-                            relative_location: loc,
-                        })
-                    }
-                    (Some(t), Some(expr)) => {
-                        let converted_type = self.convert_type(t)?;
-                        Decl::Var(VarDecl {
-                            initialiser: Some(cast_to(self.convert_expr(expr)?, &converted_type)?),
-                            t: converted_type,
-                            relative_location: loc,
-                        })
-                    }
-                };
-
-                let ident = self.bind_decl(is_global, name, var_decl.clone());
-                Binding {
-                    name: ident,
-                    decl: var_decl,
-                }
+            parser::Declaration::Var(decl) => {
+                self.convert_var_decl(decl, is_global)?.map(Decl::Var)
             }
 
             parser::Declaration::Const(parser::ConstDecl {

--- a/compiler/ast/src/lib.rs
+++ b/compiler/ast/src/lib.rs
@@ -14,8 +14,8 @@ pub use crate::{
     operators::{BinaryOperator, BoolBinOp, EqBinOp, IntBinOp, RealBinOp, UnaryOperator},
     tree::{
         Binding, Block, BlockElem, BoolLiteral, ConstDecl, Decl, Expression, IdentifierTable,
-        IntegerLiteral, LvalueExpression, Program, RealLiteral, Routine, RoutineBody, RoutineDecl,
-        RoutineSignature, SimpleBinding, SimpleDecl, Statement, TypeDecl, VarDecl,
+        IntegerLiteral, LocalBinding, LocalDecl, LvalueExpression, Program, RealLiteral, Routine,
+        RoutineBody, RoutineDecl, RoutineSignature, Statement, TypeDecl, VarDecl,
     },
     types::{ArrayDescription, FieldDescription, RecordDescription, Type},
 };

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -396,11 +396,7 @@ impl From<SimpleDecl> for Decl {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct SimpleBinding {
-    pub name: Identifier,
-    pub decl: SimpleDecl,
-}
+pub type SimpleBinding = Binding<SimpleDecl>;
 
 impl From<SimpleBinding> for Binding {
     fn from(sb: SimpleBinding) -> Self {

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -380,27 +380,27 @@ pub enum RoutineBody {
 }
 
 #[derive(Debug, Clone)]
-pub enum SimpleDecl {
+pub enum LocalDecl {
     Var(VarDecl),
     Const(ConstDecl),
     Type(TypeDecl),
 }
 
-impl From<SimpleDecl> for Decl {
-    fn from(value: SimpleDecl) -> Self {
+impl From<LocalDecl> for Decl {
+    fn from(value: LocalDecl) -> Self {
         match value {
-            SimpleDecl::Var(var_decl) => Decl::Var(var_decl),
-            SimpleDecl::Type(type_decl) => Decl::Type(type_decl),
-            SimpleDecl::Const(const_decl) => Decl::Const(const_decl),
+            LocalDecl::Var(var_decl) => Decl::Var(var_decl),
+            LocalDecl::Type(type_decl) => Decl::Type(type_decl),
+            LocalDecl::Const(const_decl) => Decl::Const(const_decl),
         }
     }
 }
 
-pub type SimpleBinding = Binding<SimpleDecl>;
+pub type LocalBinding = Binding<LocalDecl>;
 
-impl From<SimpleBinding> for Binding {
-    fn from(sb: SimpleBinding) -> Self {
-        let SimpleBinding { name, decl } = sb;
+impl From<LocalBinding> for Binding {
+    fn from(sb: LocalBinding) -> Self {
+        let LocalBinding { name, decl } = sb;
         Binding {
             name,
             decl: decl.into(),
@@ -411,7 +411,7 @@ impl From<SimpleBinding> for Binding {
 #[derive(Debug, Clone)]
 pub enum BlockElem {
     Stmt(Statement),
-    Decl(SimpleBinding),
+    Decl(LocalBinding),
 }
 
 #[derive(Debug, Clone)]
@@ -468,14 +468,14 @@ pub enum Decl {
     Routine(RoutineDecl),
 }
 
-impl TryFrom<Decl> for SimpleDecl {
+impl TryFrom<Decl> for LocalDecl {
     type Error = AnalysisError;
 
-    fn try_from(value: Decl) -> AnalysisResult<SimpleDecl> {
+    fn try_from(value: Decl) -> AnalysisResult<LocalDecl> {
         match value {
-            Decl::Var(var_decl) => Ok(SimpleDecl::Var(var_decl)),
-            Decl::Type(type_decl) => Ok(SimpleDecl::Type(type_decl)),
-            Decl::Const(const_decl) => Ok(SimpleDecl::Const(const_decl)),
+            Decl::Var(var_decl) => Ok(LocalDecl::Var(var_decl)),
+            Decl::Type(type_decl) => Ok(LocalDecl::Type(type_decl)),
+            Decl::Const(const_decl) => Ok(LocalDecl::Const(const_decl)),
             Decl::Routine(_) => Err(AnalysisError {
                 what: "nested functions are not supported".to_string(),
             }),
@@ -518,12 +518,12 @@ impl Binding {
     }
 }
 
-impl TryFrom<Binding> for SimpleBinding {
+impl TryFrom<Binding> for LocalBinding {
     type Error = AnalysisError;
 
-    fn try_from(value: Binding) -> AnalysisResult<SimpleBinding> {
+    fn try_from(value: Binding) -> AnalysisResult<LocalBinding> {
         let Binding { name, decl } = value;
-        Ok(SimpleBinding {
+        Ok(LocalBinding {
             name,
             decl: decl.try_into()?,
         })

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -162,6 +162,7 @@ impl EvaluatedValue {
 }
 
 impl EvaluatedValue {
+    // FIXME(GrigorenkoPV): introduce Expression::Literal
     pub(crate) fn as_literal(&self) -> Rc<Expression> {
         match self {
             EvaluatedValue::Int(val) => Expression::IntegerLiteral(IntegerLiteral {
@@ -312,6 +313,7 @@ pub struct VarDecl {
     pub relative_location: Location,
 }
 
+/// FIXME(GrigorenkoPV): Typed<Literal>
 #[derive(Debug, Hash, Clone)]
 pub struct ConstDecl {
     pub t: Rc<Type>,

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -489,6 +489,16 @@ pub struct Binding<T = Decl> {
     pub decl: T,
 }
 
+impl<T> Binding<T> {
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Binding<U> {
+        let Self { name, decl } = self;
+        Binding {
+            name,
+            decl: f(decl),
+        }
+    }
+}
+
 impl Binding {
     pub fn ensure_is_type(&self) -> AnalysisResult<&TypeDecl> {
         match &self.decl {

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -200,7 +200,7 @@ impl<'a> Compiler<'a> {
             match block_elem {
                 ast::BlockElem::Stmt(statement) => self.compile_statement(statement)?,
                 ast::BlockElem::Decl(simple_binding) => match &simple_binding.decl {
-                    ast::SimpleDecl::Var(var_decl) => {
+                    ast::LocalDecl::Var(var_decl) => {
                         let initialiser = var_decl
                             .initialiser
                             .clone()
@@ -211,7 +211,8 @@ impl<'a> Compiler<'a> {
                         // Local variable initialisation is just a `push`
                         self.compile_expr(&initialiser)?;
                     }
-                    ast::SimpleDecl::Type(_) | ast::SimpleDecl::Const(_) => (), // Type is compile-time entity (TODO: RTTI?)
+                    // Type is compile-time entity (TODO: RTTI?)
+                    ast::LocalDecl::Type(_) | ast::LocalDecl::Const(_) => (),
                 },
             }
         }

--- a/compiler/interpreter/src/lib.rs
+++ b/compiler/interpreter/src/lib.rs
@@ -8,9 +8,9 @@ use std::{
 
 use ast::{
     ArrayDescription, BinaryOperator, Binding, Block, BlockElem, BoolBinOp, Decl, EqBinOp,
-    Expression, FieldDescription, IntBinOp, IntegerLiteral, LvalueExpression, Program, RealBinOp,
-    RealLiteral, RecordDescription, Routine, RoutineBody, RoutineDecl, SimpleBinding, SimpleDecl,
-    Type, TypeDecl, UnaryOperator, VarDecl,
+    Expression, FieldDescription, IntBinOp, IntegerLiteral, LocalBinding, LocalDecl,
+    LvalueExpression, Program, RealBinOp, RealLiteral, RecordDescription, Routine, RoutineBody,
+    RoutineDecl, Type, TypeDecl, UnaryOperator, VarDecl,
 };
 use common::{
     Identifier, Integer, LoopOrder, Position, RawIdentifier, Real, integer_to_real, real_to_integer,
@@ -450,9 +450,9 @@ impl<'a, W: Write> Interpreter<'a, W> {
         let Block { elems: stmts, .. } = block;
         for stmt in stmts {
             match stmt {
-                BlockElem::Decl(SimpleBinding { name, decl }) => match decl {
-                    SimpleDecl::Const(_) | SimpleDecl::Type(_) => {}
-                    SimpleDecl::Var(VarDecl {
+                BlockElem::Decl(LocalBinding { name, decl }) => match decl {
+                    LocalDecl::Const(_) | LocalDecl::Type(_) => {}
+                    LocalDecl::Var(VarDecl {
                         t,
                         initialiser,
                         relative_location: _,

--- a/tests/ast/pass/arithmetic_operations.txt
+++ b/tests/ast/pass/arithmetic_operations.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -36,7 +36,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -57,7 +57,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -78,7 +78,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: y(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -487,7 +487,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -508,7 +508,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -529,7 +529,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -550,7 +550,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: y(4),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/arrays_and_records.txt
+++ b/tests/ast/pass/arrays_and_records.txt
@@ -743,7 +743,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t(13),
                                                 decl: Var(
                                                     VarDecl {
@@ -1824,7 +1824,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t(13),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/comparison_operators.txt
+++ b/tests/ast/pass/comparison_operators.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -36,7 +36,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -57,7 +57,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -78,7 +78,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: y(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -382,7 +382,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -403,7 +403,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -424,7 +424,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -445,7 +445,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: y(4),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/complex_expressions.txt
+++ b/tests/ast/pass/complex_expressions.txt
@@ -72,7 +72,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -93,7 +93,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -114,7 +114,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -598,7 +598,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -619,7 +619,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -640,7 +640,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(5),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/conditionals.txt
+++ b/tests/ast/pass/conditionals.txt
@@ -110,7 +110,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -162,7 +162,7 @@
                                                 on_true: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: dummy(4),
                                                                 decl: Var(
                                                                     VarDecl {
@@ -356,7 +356,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -408,7 +408,7 @@
                                                 on_true: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: dummy(4),
                                                                 decl: Var(
                                                                     VarDecl {

--- a/tests/ast/pass/constant.txt
+++ b/tests/ast/pass/constant.txt
@@ -231,7 +231,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t(8),
                                                 decl: Var(
                                                     VarDecl {
@@ -286,7 +286,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: LENGTH(9),
                                                 decl: Const(
                                                     ConstDecl {
@@ -333,7 +333,7 @@
                                                             },
                                                         ),
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: LENGTH(10),
                                                                 decl: Const(
                                                                     ConstDecl {
@@ -649,7 +649,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t(8),
                                                 decl: Var(
                                                     VarDecl {
@@ -704,7 +704,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: LENGTH(9),
                                                 decl: Const(
                                                     ConstDecl {
@@ -751,7 +751,7 @@
                                                             },
                                                         ),
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: LENGTH(10),
                                                                 decl: Const(
                                                                     ConstDecl {

--- a/tests/ast/pass/deep_conditionals.txt
+++ b/tests/ast/pass/deep_conditionals.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -36,7 +36,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -57,7 +57,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -78,7 +78,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: d(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -99,7 +99,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: e(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -120,7 +120,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: f(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -141,7 +141,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: g(7),
                                                 decl: Var(
                                                     VarDecl {
@@ -781,7 +781,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -802,7 +802,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -823,7 +823,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -844,7 +844,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: d(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -865,7 +865,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: e(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -886,7 +886,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: f(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -907,7 +907,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: g(7),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/for_loops.txt
+++ b/tests/ast/pass/for_loops.txt
@@ -180,7 +180,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -388,7 +388,7 @@
                                                                                 on_true: Block {
                                                                                     elems: [
                                                                                         Decl(
-                                                                                            SimpleBinding {
+                                                                                            Binding {
                                                                                                 name: t(12),
                                                                                                 decl: Var(
                                                                                                     VarDecl {
@@ -655,7 +655,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: arr(20),
                                                 decl: Var(
                                                     VarDecl {
@@ -888,7 +888,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -1096,7 +1096,7 @@
                                                                                 on_true: Block {
                                                                                     elems: [
                                                                                         Decl(
-                                                                                            SimpleBinding {
+                                                                                            Binding {
                                                                                                 name: t(12),
                                                                                                 decl: Var(
                                                                                                     VarDecl {
@@ -1659,7 +1659,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: arr(20),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/identifiers.txt
+++ b/tests/ast/pass/identifiers.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: кошка(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -36,7 +36,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: ねこ(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -57,7 +57,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: π(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -78,7 +78,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: α(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -99,7 +99,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: 值(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -120,7 +120,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: 变量(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -141,7 +141,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: 고양이(7),
                                                 decl: Var(
                                                     VarDecl {
@@ -162,7 +162,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: pequeño_pingüino(8),
                                                 decl: Var(
                                                     VarDecl {
@@ -183,7 +183,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: 'no_strings(9),
                                                 decl: Var(
                                                     VarDecl {
@@ -204,7 +204,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: _(10),
                                                 decl: Var(
                                                     VarDecl {
@@ -335,7 +335,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: кошка(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -356,7 +356,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: ねこ(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -377,7 +377,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: π(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -398,7 +398,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: α(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -419,7 +419,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: 值(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -440,7 +440,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: 变量(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -461,7 +461,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: 고양이(7),
                                                 decl: Var(
                                                     VarDecl {
@@ -482,7 +482,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: pequeño_pingüino(8),
                                                 decl: Var(
                                                     VarDecl {
@@ -503,7 +503,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: 'no_strings(9),
                                                 decl: Var(
                                                     VarDecl {
@@ -524,7 +524,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: _(10),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/lazy_operators.txt
+++ b/tests/ast/pass/lazy_operators.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -72,7 +72,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -316,7 +316,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -389,7 +389,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(3),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/length.txt
+++ b/tests/ast/pass/length.txt
@@ -130,7 +130,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -163,7 +163,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: s(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -390,7 +390,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -423,7 +423,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: s(6),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/logical_operators.txt
+++ b/tests/ast/pass/logical_operators.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -33,7 +33,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -51,7 +51,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -72,7 +72,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: y(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -242,7 +242,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -260,7 +260,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -278,7 +278,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -299,7 +299,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: y(4),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/nested_control.txt
+++ b/tests/ast/pass/nested_control.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: i(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -56,7 +56,7 @@
                                                 body: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: j(2),
                                                                 decl: Var(
                                                                     VarDecl {
@@ -97,7 +97,7 @@
                                                                 body: Block {
                                                                     elems: [
                                                                         Decl(
-                                                                            SimpleBinding {
+                                                                            Binding {
                                                                                 name: k(3),
                                                                                 decl: Var(
                                                                                     VarDecl {
@@ -138,7 +138,7 @@
                                                                                 body: Block {
                                                                                     elems: [
                                                                                         Decl(
-                                                                                            SimpleBinding {
+                                                                                            Binding {
                                                                                                 name: w(4),
                                                                                                 decl: Var(
                                                                                                     VarDecl {
@@ -179,7 +179,7 @@
                                                                                                 body: Block {
                                                                                                     elems: [
                                                                                                         Decl(
-                                                                                                            SimpleBinding {
+                                                                                                            Binding {
                                                                                                                 name: v(5),
                                                                                                                 decl: Var(
                                                                                                                     VarDecl {
@@ -430,7 +430,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: i(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -471,7 +471,7 @@
                                                 body: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: j(2),
                                                                 decl: Var(
                                                                     VarDecl {
@@ -512,7 +512,7 @@
                                                                 body: Block {
                                                                     elems: [
                                                                         Decl(
-                                                                            SimpleBinding {
+                                                                            Binding {
                                                                                 name: k(3),
                                                                                 decl: Var(
                                                                                     VarDecl {
@@ -553,7 +553,7 @@
                                                                                 body: Block {
                                                                                     elems: [
                                                                                         Decl(
-                                                                                            SimpleBinding {
+                                                                                            Binding {
                                                                                                 name: w(4),
                                                                                                 decl: Var(
                                                                                                     VarDecl {
@@ -594,7 +594,7 @@
                                                                                                 body: Block {
                                                                                                     elems: [
                                                                                                         Decl(
-                                                                                                            SimpleBinding {
+                                                                                                            Binding {
                                                                                                                 name: v(5),
                                                                                                                 decl: Var(
                                                                                                                     VarDecl {

--- a/tests/ast/pass/oob_big.txt
+++ b/tests/ast/pass/oob_big.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -90,7 +90,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/oob_neg.txt
+++ b/tests/ast/pass/oob_neg.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -93,7 +93,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/oob_zero.txt
+++ b/tests/ast/pass/oob_zero.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -90,7 +90,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/raytracer.txt
+++ b/tests/ast/pass/raytracer.txt
@@ -506,7 +506,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: res(18),
                                                 decl: Var(
                                                     VarDecl {
@@ -671,7 +671,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(21),
                                                 decl: Var(
                                                     VarDecl {
@@ -761,7 +761,7 @@
                                                 body: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: prev_x(23),
                                                                 decl: Var(
                                                                     VarDecl {
@@ -3143,7 +3143,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: res(86),
                                                 decl: Var(
                                                     VarDecl {
@@ -3824,7 +3824,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(103),
                                                 decl: Var(
                                                     VarDecl {
@@ -3860,7 +3860,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(104),
                                                 decl: Var(
                                                     VarDecl {
@@ -3922,7 +3922,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(105),
                                                 decl: Var(
                                                     VarDecl {
@@ -4010,7 +4010,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: discriminant(106),
                                                 decl: Var(
                                                     VarDecl {
@@ -4109,7 +4109,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t1(107),
                                                 decl: Var(
                                                     VarDecl {
@@ -4170,7 +4170,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t2(108),
                                                 decl: Var(
                                                     VarDecl {
@@ -4480,7 +4480,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t(112),
                                                 decl: Var(
                                                     VarDecl {
@@ -5391,7 +5391,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: best_intersection(133),
                                                 decl: Var(
                                                     VarDecl {
@@ -5423,7 +5423,7 @@
                                                 body: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: intersection(135),
                                                                 decl: Var(
                                                                     VarDecl {
@@ -5654,7 +5654,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(140),
                                                 decl: Var(
                                                     VarDecl {
@@ -5691,7 +5691,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: virtual_screen_height(141),
                                                 decl: Var(
                                                     VarDecl {
@@ -5714,7 +5714,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: virtual_screen_width(142),
                                                 decl: Var(
                                                     VarDecl {
@@ -5760,7 +5760,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: base(143),
                                                 decl: Var(
                                                     VarDecl {
@@ -5806,7 +5806,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x_orth(144),
                                                 decl: Var(
                                                     VarDecl {
@@ -5852,7 +5852,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: y_orth(145),
                                                 decl: Var(
                                                     VarDecl {
@@ -5898,7 +5898,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: left_bottom(146),
                                                 decl: Var(
                                                     VarDecl {
@@ -6032,7 +6032,7 @@
                                                                 body: Block {
                                                                     elems: [
                                                                         Decl(
-                                                                            SimpleBinding {
+                                                                            Binding {
                                                                                 name: virtual_screen_point(149),
                                                                                 decl: Var(
                                                                                     VarDecl {
@@ -6170,7 +6170,7 @@
                                                                             },
                                                                         ),
                                                                         Decl(
-                                                                            SimpleBinding {
+                                                                            Binding {
                                                                                 name: r(150),
                                                                                 decl: Var(
                                                                                     VarDecl {
@@ -6202,7 +6202,7 @@
                                                                             },
                                                                         ),
                                                                         Decl(
-                                                                            SimpleBinding {
+                                                                            Binding {
                                                                                 name: intersection(151),
                                                                                 decl: Var(
                                                                                     VarDecl {
@@ -6254,7 +6254,7 @@
                                                                                 on_true: Block {
                                                                                     elems: [
                                                                                         Decl(
-                                                                                            SimpleBinding {
+                                                                                            Binding {
                                                                                                 name: colour_ratio(152),
                                                                                                 decl: Var(
                                                                                                     VarDecl {
@@ -6369,7 +6369,7 @@
                                                                                             },
                                                                                         ),
                                                                                         Decl(
-                                                                                            SimpleBinding {
+                                                                                            Binding {
                                                                                                 name: paint(153),
                                                                                                 decl: Var(
                                                                                                     VarDecl {
@@ -6507,7 +6507,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: red_sphere(155),
                                                 decl: Var(
                                                     VarDecl {
@@ -6580,7 +6580,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: green_sphere(156),
                                                 decl: Var(
                                                     VarDecl {
@@ -6653,7 +6653,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: blue_plane(157),
                                                 decl: Var(
                                                     VarDecl {
@@ -6745,7 +6745,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: scene(158),
                                                 decl: Var(
                                                     VarDecl {
@@ -6857,7 +6857,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: height(159),
                                                 decl: Var(
                                                     VarDecl {
@@ -7565,7 +7565,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: res(18),
                                                 decl: Var(
                                                     VarDecl {
@@ -7762,7 +7762,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(21),
                                                 decl: Var(
                                                     VarDecl {
@@ -7852,7 +7852,7 @@
                                                 body: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: prev_x(23),
                                                                 decl: Var(
                                                                     VarDecl {
@@ -10701,7 +10701,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: res(86),
                                                 decl: Var(
                                                     VarDecl {
@@ -11566,7 +11566,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(103),
                                                 decl: Var(
                                                     VarDecl {
@@ -11602,7 +11602,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(104),
                                                 decl: Var(
                                                     VarDecl {
@@ -11664,7 +11664,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(105),
                                                 decl: Var(
                                                     VarDecl {
@@ -11752,7 +11752,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: discriminant(106),
                                                 decl: Var(
                                                     VarDecl {
@@ -11851,7 +11851,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t1(107),
                                                 decl: Var(
                                                     VarDecl {
@@ -11912,7 +11912,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t2(108),
                                                 decl: Var(
                                                     VarDecl {
@@ -12609,7 +12609,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: t(112),
                                                 decl: Var(
                                                     VarDecl {
@@ -13761,7 +13761,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: best_intersection(133),
                                                 decl: Var(
                                                     VarDecl {
@@ -13793,7 +13793,7 @@
                                                 body: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: intersection(135),
                                                                 decl: Var(
                                                                     VarDecl {
@@ -14118,7 +14118,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(140),
                                                 decl: Var(
                                                     VarDecl {
@@ -14155,7 +14155,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: virtual_screen_height(141),
                                                 decl: Var(
                                                     VarDecl {
@@ -14178,7 +14178,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: virtual_screen_width(142),
                                                 decl: Var(
                                                     VarDecl {
@@ -14224,7 +14224,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: base(143),
                                                 decl: Var(
                                                     VarDecl {
@@ -14270,7 +14270,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x_orth(144),
                                                 decl: Var(
                                                     VarDecl {
@@ -14316,7 +14316,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: y_orth(145),
                                                 decl: Var(
                                                     VarDecl {
@@ -14362,7 +14362,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: left_bottom(146),
                                                 decl: Var(
                                                     VarDecl {
@@ -14496,7 +14496,7 @@
                                                                 body: Block {
                                                                     elems: [
                                                                         Decl(
-                                                                            SimpleBinding {
+                                                                            Binding {
                                                                                 name: virtual_screen_point(149),
                                                                                 decl: Var(
                                                                                     VarDecl {
@@ -14634,7 +14634,7 @@
                                                                             },
                                                                         ),
                                                                         Decl(
-                                                                            SimpleBinding {
+                                                                            Binding {
                                                                                 name: r(150),
                                                                                 decl: Var(
                                                                                     VarDecl {
@@ -14666,7 +14666,7 @@
                                                                             },
                                                                         ),
                                                                         Decl(
-                                                                            SimpleBinding {
+                                                                            Binding {
                                                                                 name: intersection(151),
                                                                                 decl: Var(
                                                                                     VarDecl {
@@ -14718,7 +14718,7 @@
                                                                                 on_true: Block {
                                                                                     elems: [
                                                                                         Decl(
-                                                                                            SimpleBinding {
+                                                                                            Binding {
                                                                                                 name: colour_ratio(152),
                                                                                                 decl: Var(
                                                                                                     VarDecl {
@@ -14833,7 +14833,7 @@
                                                                                             },
                                                                                         ),
                                                                                         Decl(
-                                                                                            SimpleBinding {
+                                                                                            Binding {
                                                                                                 name: paint(153),
                                                                                                 decl: Var(
                                                                                                     VarDecl {
@@ -15652,7 +15652,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: red_sphere(155),
                                                 decl: Var(
                                                     VarDecl {
@@ -15725,7 +15725,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: green_sphere(156),
                                                 decl: Var(
                                                     VarDecl {
@@ -15798,7 +15798,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: blue_plane(157),
                                                 decl: Var(
                                                     VarDecl {
@@ -15890,7 +15890,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: scene(158),
                                                 decl: Var(
                                                     VarDecl {
@@ -16002,7 +16002,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: height(159),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/real_comparisons.txt
+++ b/tests/ast/pass/real_comparisons.txt
@@ -141,7 +141,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -213,7 +213,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -425,7 +425,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -497,7 +497,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/real_literals.txt
+++ b/tests/ast/pass/real_literals.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -45,7 +45,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -75,7 +75,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -105,7 +105,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: d(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -135,7 +135,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: e(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -165,7 +165,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: f(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -195,7 +195,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: g(7),
                                                 decl: Var(
                                                     VarDecl {
@@ -225,7 +225,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: h(8),
                                                 decl: Var(
                                                     VarDecl {
@@ -255,7 +255,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: i(9),
                                                 decl: Var(
                                                     VarDecl {
@@ -285,7 +285,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: j(10),
                                                 decl: Var(
                                                     VarDecl {
@@ -315,7 +315,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: k(11),
                                                 decl: Var(
                                                     VarDecl {
@@ -345,7 +345,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: l(12),
                                                 decl: Var(
                                                     VarDecl {
@@ -375,7 +375,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: m(13),
                                                 decl: Var(
                                                     VarDecl {
@@ -405,7 +405,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: n(14),
                                                 decl: Var(
                                                     VarDecl {
@@ -435,7 +435,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: o(15),
                                                 decl: Var(
                                                     VarDecl {
@@ -465,7 +465,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: p(16),
                                                 decl: Var(
                                                     VarDecl {
@@ -495,7 +495,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: q(17),
                                                 decl: Var(
                                                     VarDecl {
@@ -528,7 +528,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: r(18),
                                                 decl: Var(
                                                     VarDecl {
@@ -558,7 +558,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: s(19),
                                                 decl: Var(
                                                     VarDecl {
@@ -616,7 +616,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: a(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -646,7 +646,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -676,7 +676,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: c(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -706,7 +706,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: d(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -736,7 +736,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: e(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -766,7 +766,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: f(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -796,7 +796,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: g(7),
                                                 decl: Var(
                                                     VarDecl {
@@ -826,7 +826,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: h(8),
                                                 decl: Var(
                                                     VarDecl {
@@ -856,7 +856,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: i(9),
                                                 decl: Var(
                                                     VarDecl {
@@ -886,7 +886,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: j(10),
                                                 decl: Var(
                                                     VarDecl {
@@ -916,7 +916,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: k(11),
                                                 decl: Var(
                                                     VarDecl {
@@ -946,7 +946,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: l(12),
                                                 decl: Var(
                                                     VarDecl {
@@ -976,7 +976,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: m(13),
                                                 decl: Var(
                                                     VarDecl {
@@ -1006,7 +1006,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: n(14),
                                                 decl: Var(
                                                     VarDecl {
@@ -1036,7 +1036,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: o(15),
                                                 decl: Var(
                                                     VarDecl {
@@ -1066,7 +1066,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: p(16),
                                                 decl: Var(
                                                     VarDecl {
@@ -1096,7 +1096,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: q(17),
                                                 decl: Var(
                                                     VarDecl {
@@ -1129,7 +1129,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: r(18),
                                                 decl: Var(
                                                     VarDecl {
@@ -1159,7 +1159,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: s(19),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/records.txt
+++ b/tests/ast/pass/records.txt
@@ -414,7 +414,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: p1(11),
                                                 decl: Var(
                                                     VarDecl {
@@ -448,7 +448,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: p2(12),
                                                 decl: Var(
                                                     VarDecl {
@@ -482,7 +482,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: mid(13),
                                                 decl: Var(
                                                     VarDecl {
@@ -1037,7 +1037,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: p1(11),
                                                 decl: Var(
                                                     VarDecl {
@@ -1071,7 +1071,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: p2(12),
                                                 decl: Var(
                                                     VarDecl {
@@ -1105,7 +1105,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: mid(13),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/recursive_types.txt
+++ b/tests/ast/pass/recursive_types.txt
@@ -223,7 +223,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(9),
                                                 decl: Var(
                                                     VarDecl {
@@ -356,7 +356,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(12),
                                                 decl: Var(
                                                     VarDecl {
@@ -479,7 +479,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: list(14),
                                                 decl: Var(
                                                     VarDecl {
@@ -780,7 +780,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(9),
                                                 decl: Var(
                                                     VarDecl {
@@ -946,7 +946,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(12),
                                                 decl: Var(
                                                     VarDecl {
@@ -1102,7 +1102,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: list(14),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/shadow.txt
+++ b/tests/ast/pass/shadow.txt
@@ -43,7 +43,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -80,7 +80,7 @@
                                                 on_true: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: x(3),
                                                                 decl: Var(
                                                                     VarDecl {
@@ -166,7 +166,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: x(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -203,7 +203,7 @@
                                                 on_true: Block {
                                                     elems: [
                                                         Decl(
-                                                            SimpleBinding {
+                                                            Binding {
                                                                 name: x(3),
                                                                 decl: Var(
                                                                     VarDecl {

--- a/tests/ast/pass/type_aliases.txt
+++ b/tests/ast/pass/type_aliases.txt
@@ -95,7 +95,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: dist(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -123,7 +123,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(6),
                                                 decl: Var(
                                                     VarDecl {
@@ -278,7 +278,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: dist(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -306,7 +306,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: result(6),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/type_conversions.txt
+++ b/tests/ast/pass/type_conversions.txt
@@ -15,7 +15,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: i(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -29,7 +29,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: r(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -43,7 +43,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(3),
                                                 decl: Var(
                                                     VarDecl {
@@ -267,7 +267,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: i(1),
                                                 decl: Var(
                                                     VarDecl {
@@ -281,7 +281,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: r(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -295,7 +295,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: b(3),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/variable_declarations.txt
+++ b/tests/ast/pass/variable_declarations.txt
@@ -65,7 +65,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: local(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -96,7 +96,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: another_local(5),
                                                 decl: Var(
                                                     VarDecl {
@@ -228,7 +228,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: local(4),
                                                 decl: Var(
                                                     VarDecl {
@@ -259,7 +259,7 @@
                                             },
                                         ),
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: another_local(5),
                                                 decl: Var(
                                                     VarDecl {

--- a/tests/ast/pass/while_loops.txt
+++ b/tests/ast/pass/while_loops.txt
@@ -31,7 +31,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: steps(2),
                                                 decl: Var(
                                                     VarDecl {
@@ -286,7 +286,7 @@
                                 Block {
                                     elems: [
                                         Decl(
-                                            SimpleBinding {
+                                            Binding {
                                                 name: steps(2),
                                                 decl: Var(
                                                     VarDecl {


### PR DESCRIPTION
Renames `Simple` to `Local`, gets rid of the only `.clone()` we perform on parts of the parse tree.
