### PR TITLE
ast: more small fixes

### DIFF
--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -191,7 +191,7 @@ impl Converter {
             .iter()
             .rev()
             .find_map(|scope_block| scope_block.lookup(name))
-            .map(|id| self.ident_table.get_binding_by_id(id))
+            .map(|id| &self.ident_table[id])
             .ok_or(AnalysisError {
                 what: format!("Unknown name `{name}`"),
             })

--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -43,7 +43,7 @@ struct RoutinePrototype {
 
 #[derive(Debug)]
 struct Converter {
-    ident_table: IdentifierTable,
+    bindings: Bindings,
     current_scope: Vec<Scope>,
     global_count: VarLoc,
     local_count: VarLoc,
@@ -53,16 +53,12 @@ struct Converter {
 impl Converter {
     fn new() -> Self {
         Converter {
-            ident_table: IdentifierTable::default(),
+            bindings: Bindings::default(),
             current_scope: vec![Scope::new()],
             global_count: 0,
             local_count: 0,
             current_routine: None,
         }
-    }
-
-    fn extract_table(self) -> IdentifierTable {
-        self.ident_table
     }
 
     fn enter_block(&mut self) {
@@ -107,14 +103,14 @@ impl Converter {
 
     fn bind_global_decl(&mut self, name: &RawIdentifier, decl: Decl) -> Identifier {
         // TODO: process function forward declaration
-        let ident = self.ident_table.create_binding(name, decl);
+        let ident = self.bindings.create(name, decl);
         self.current_scope[0].bind(&ident);
 
         ident
     }
 
     fn rebind_decl(&mut self, ident: &Identifier, new_decl: Decl) {
-        self.ident_table.rebind(ident, new_decl);
+        self.bindings.rebind(ident, new_decl);
     }
 
     // FIXME: accept `LocalDecl`
@@ -124,7 +120,7 @@ impl Converter {
             "Local name binding in global context"
         );
 
-        let ident = self.ident_table.create_binding(name, decl);
+        let ident = self.bindings.create(name, decl);
         self.current_scope
             .last_mut()
             .expect("At least global context is always present")
@@ -191,7 +187,7 @@ impl Converter {
             .iter()
             .rev()
             .find_map(|scope_block| scope_block.lookup(name))
-            .map(|id| &self.ident_table[id])
+            .map(|id| &self.bindings[id])
             .ok_or(AnalysisError {
                 what: format!("Unknown name `{name}`"),
             })
@@ -276,7 +272,7 @@ impl Converter {
                     value: converted_lhs,
                     ty: t,
                 } = self.convert_lvalue_expr(lhs)?;
-                let effective_lhs_type = self.ident_table.get_effective_type(&t)?;
+                let effective_lhs_type = self.bindings.get_effective_type(&t)?;
                 let member_type = effective_lhs_type.get_field_type(member_name)?;
 
                 Typed {
@@ -297,7 +293,7 @@ impl Converter {
                     ty: rhs_t,
                 } = self.convert_expr(index)?;
                 rhs_t.ensure_is(&Type::Int)?;
-                let effective_lhs_type = self.ident_table.get_effective_type(&lhs_t)?;
+                let effective_lhs_type = self.bindings.get_effective_type(&lhs_t)?;
                 let resulting_type = effective_lhs_type.get_element_type()?;
 
                 Typed {
@@ -436,7 +432,7 @@ impl Converter {
         fields: Option<&[(RawIdentifier, Rc<parser::Expression>)]>,
     ) -> AnalysisResult<Typed> {
         let converted_type = self.convert_type(t)?;
-        let converted_effective_type = self.ident_table.get_effective_type(&converted_type)?;
+        let converted_effective_type = self.bindings.get_effective_type(&converted_type)?;
 
         match &*converted_effective_type {
             Type::Int | Type::Real | Type::Bool | Type::Null | Type::Unit => Err(AnalysisError {
@@ -609,10 +605,9 @@ impl Converter {
                     ty: operand_type,
                 } = self.convert_expr(operand)?;
                 let converted_target_type = self.convert_type(target)?;
-                let operand_effective_type = self.ident_table.get_effective_type(&operand_type)?;
-                let target_effective_type = self
-                    .ident_table
-                    .get_effective_type(&converted_target_type)?;
+                let operand_effective_type = self.bindings.get_effective_type(&operand_type)?;
+                let target_effective_type =
+                    self.bindings.get_effective_type(&converted_target_type)?;
 
                 if operand_effective_type == target_effective_type {
                     Typed {
@@ -900,7 +895,7 @@ impl Converter {
         );
 
         let converted_type = self.convert_type(t)?;
-        let effective_type = self.ident_table.get_effective_type(&converted_type)?;
+        let effective_type = self.bindings.get_effective_type(&converted_type)?;
         let type_decl = TypeDecl::Full {
             prescribed: converted_type,
             effective: effective_type,
@@ -1138,7 +1133,7 @@ impl Converter {
     }
 }
 
-pub fn convert(program: &parser::Program) -> AnalysisResult<(Program, IdentifierTable)> {
+pub fn convert(program: &parser::Program) -> AnalysisResult<(Program, Bindings)> {
     let mut converter = Converter::new();
 
     let converted_program = program
@@ -1148,5 +1143,6 @@ pub fn convert(program: &parser::Program) -> AnalysisResult<(Program, Identifier
         .collect::<AnalysisResult<Vec<Binding>>>()
         .map(Program)?;
 
-    Ok((converted_program, converter.extract_table()))
+    let Converter { bindings, .. } = converter;
+    Ok((converted_program, bindings))
 }

--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, rc::Rc};
 
-use common::{Identifier, Location, LoopOrder, RawIdentifier, VarLoc};
+use common::{BindingId, Identifier, Location, LoopOrder, RawIdentifier, VarLoc};
 
 use crate::{
     operators::UnaryOperator,
@@ -10,23 +10,25 @@ use crate::{
 };
 
 #[derive(Debug, Default)]
-struct ScopeBlock {
-    binders: HashMap<RawIdentifier, usize>,
+struct Scope {
+    binders: HashMap<RawIdentifier, BindingId>,
     locals_in_block: VarLoc,
 }
 
-impl ScopeBlock {
+impl Scope {
     #[must_use]
     fn new() -> Self {
         Self::default()
     }
 
-    fn lookup(&self, name: &RawIdentifier) -> Option<usize> {
+    fn lookup(&self, name: &RawIdentifier) -> Option<BindingId> {
         self.binders.get(name).copied()
     }
 
-    fn bind(&mut self, name: &RawIdentifier, ident: &Identifier) {
-        let _: Option<usize> = self.binders.insert(name.clone(), ident.id);
+    fn bind(&mut self, ident: &Identifier) {
+        let Identifier { raw, id } = ident;
+        let previous = self.binders.insert(raw.to_owned(), *id);
+        debug_assert_eq!(previous, None, "We support rebinds?");
     }
 }
 
@@ -42,7 +44,7 @@ struct RoutinePrototype {
 #[derive(Debug)]
 struct Converter {
     ident_table: IdentifierTable,
-    current_scope: Vec<ScopeBlock>,
+    current_scope: Vec<Scope>,
     global_count: VarLoc,
     local_count: VarLoc,
     current_routine: Option<RoutinePrototype>,
@@ -52,7 +54,7 @@ impl Converter {
     fn new() -> Self {
         Converter {
             ident_table: IdentifierTable::default(),
-            current_scope: vec![ScopeBlock::new()],
+            current_scope: vec![Scope::new()],
             global_count: 0,
             local_count: 0,
             current_routine: None,
@@ -64,7 +66,7 @@ impl Converter {
     }
 
     fn enter_block(&mut self) {
-        self.current_scope.push(ScopeBlock::new())
+        self.current_scope.push(Scope::new())
     }
 
     fn leave_block(&mut self) -> VarLoc {
@@ -106,7 +108,7 @@ impl Converter {
     fn bind_global_decl(&mut self, name: &RawIdentifier, decl: Decl) -> Identifier {
         // TODO: process function forward declaration
         let ident = self.ident_table.create_binding(name, decl);
-        self.current_scope[0].bind(name, &ident);
+        self.current_scope[0].bind(&ident);
 
         ident
     }
@@ -126,7 +128,7 @@ impl Converter {
         self.current_scope
             .last_mut()
             .expect("At least global context is always present")
-            .bind(name, &ident);
+            .bind(&ident);
 
         ident
     }

--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -61,23 +61,21 @@ impl Converter {
         }
     }
 
-    fn enter_block(&mut self) {
-        self.current_scope.push(Scope::new())
-    }
+    fn scoped<T>(&mut self, callback: impl FnOnce(&mut Self) -> T) -> (T, VarLoc) {
+        self.current_scope.push(Scope::new());
 
-    fn leave_block(&mut self) -> VarLoc {
-        assert!(
-            self.current_scope.len() > 1,
-            "No non-global contexts to leave"
-        );
+        let result = callback(self);
 
-        let current_block_locals = self
+        let Scope {
+            binders: _,
+            locals_in_block,
+        } = self
             .current_scope
             .pop()
-            .expect("At least global context is always present")
-            .locals_in_block;
-        self.local_count -= current_block_locals;
-        current_block_locals
+            .expect("Scopes should not be pushed/popped outside of this method");
+
+        self.local_count -= locals_in_block;
+        (result, locals_in_block)
     }
 
     fn get_fresh_global_location(&mut self) -> Location {
@@ -639,60 +637,58 @@ impl Converter {
         order: LoopOrder,
         body: &parser::Block,
     ) -> AnalysisResult<Statement> {
-        self.enter_block(); // For counter is in it's own block
+        let (result, locals_count) = self.scoped(|this| {
+            let counter_loc = this.get_fresh_local_location();
+            Ok(match to {
+                None => {
+                    let Typed {
+                        value: array_expr,
+                        ty: array_type,
+                    } = this.convert_expr(from)?;
+                    let element_type = array_type.get_element_type()?;
+                    let counter_decl = Decl::Var(VarDecl {
+                        t: Rc::clone(element_type),
+                        initialiser: None,
+                        relative_location: counter_loc,
+                    });
 
-        let counter_loc = self.get_fresh_local_location();
-
-        let stmt = match to {
-            None => {
-                let Typed {
-                    value: array_expr,
-                    ty: array_type,
-                } = self.convert_expr(from)?;
-                let element_type = array_type.get_element_type()?;
-                let counter_decl = Decl::Var(VarDecl {
-                    t: Rc::clone(element_type),
-                    initialiser: None,
-                    relative_location: counter_loc,
-                });
-
-                let counter_ident = self.bind_local_decl(counter, counter_decl);
-                let body = self.convert_block(body)?;
-                Statement::ForEach {
-                    counter: counter_ident,
-                    collection: array_expr,
-                    order,
-                    body,
+                    let counter_ident = this.bind_local_decl(counter, counter_decl);
+                    let body = this.convert_block(body)?;
+                    Statement::ForEach {
+                        counter: counter_ident,
+                        collection: array_expr,
+                        order,
+                        body,
+                    }
                 }
-            }
-            Some(to) => {
-                let from = self.convert_expr(from)?;
-                let to = self.convert_expr(to)?;
-                let int_type = Rc::new(Type::Int);
-                let counter_decl = Decl::Var(VarDecl {
-                    t: Rc::clone(&int_type),
-                    initialiser: None,
-                    relative_location: counter_loc,
-                });
-                let counter_ident = self.bind_local_decl(counter, counter_decl);
-                let body = self.convert_block(body)?;
-                Statement::For {
-                    counter: counter_ident,
-                    lower_bound: cast_to(from, &int_type)?,
-                    upper_bound: cast_to(to, &int_type)?,
-                    order,
-                    body,
+                Some(to) => {
+                    let from = this.convert_expr(from)?;
+                    let to = this.convert_expr(to)?;
+                    let int_type = Rc::new(Type::Int);
+                    let counter_decl = Decl::Var(VarDecl {
+                        t: Rc::clone(&int_type),
+                        initialiser: None,
+                        relative_location: counter_loc,
+                    });
+                    let counter_ident = this.bind_local_decl(counter, counter_decl);
+                    let body = this.convert_block(body)?;
+                    Statement::For {
+                        counter: counter_ident,
+                        lower_bound: cast_to(from, &int_type)?,
+                        upper_bound: cast_to(to, &int_type)?,
+                        order,
+                        body,
+                    }
                 }
-            }
-        };
+            })
+        });
 
         assert_eq!(
-            self.leave_block(),
-            1,
+            locals_count, 1,
             "Internal compiler error: mismatched number of locals in `for` counter block"
         );
 
-        Ok(stmt)
+        result
     }
 
     fn convert_stmt(&mut self, stmt: &parser::Statement) -> AnalysisResult<Statement> {
@@ -764,30 +760,31 @@ impl Converter {
     }
 
     fn convert_block(&mut self, block: &parser::Block) -> AnalysisResult<Block> {
-        let mut stmts: Vec<Statement> = Vec::new();
-
-        self.enter_block();
-
-        for block_elem in &block.0 {
-            stmts.push(match block_elem {
-                parser::BlockElem::Stmt(statement) => self.convert_stmt(statement)?,
-                parser::BlockElem::VarDecl(var_decl) => Statement::Declaration(
-                    self.convert_var_decl(var_decl, false)?.map(LocalDecl::Var),
-                ),
-                parser::BlockElem::ConstDecl(const_decl) => Statement::Declaration(
-                    self.convert_const_decl(const_decl, false)?
-                        .map(LocalDecl::Const),
-                ),
-                parser::BlockElem::TypeDecl(type_decl) => Statement::Declaration(
-                    self.convert_type_decl(type_decl, false)?
-                        .map(LocalDecl::Type),
-                ),
-            })
-        }
-
-        Ok(Block {
+        let (result, locals_count) = self.scoped(|this| -> AnalysisResult<_> {
+            block
+                .0
+                .iter()
+                .map(|elem| {
+                    Ok(match elem {
+                        parser::BlockElem::Stmt(statement) => this.convert_stmt(statement)?,
+                        parser::BlockElem::VarDecl(var_decl) => Statement::Declaration(
+                            this.convert_var_decl(var_decl, false)?.map(LocalDecl::Var),
+                        ),
+                        parser::BlockElem::ConstDecl(const_decl) => Statement::Declaration(
+                            this.convert_const_decl(const_decl, false)?
+                                .map(LocalDecl::Const),
+                        ),
+                        parser::BlockElem::TypeDecl(type_decl) => Statement::Declaration(
+                            this.convert_type_decl(type_decl, false)?
+                                .map(LocalDecl::Type),
+                        ),
+                    })
+                })
+                .collect()
+        });
+        result.map(|stmts| Block {
             stmts,
-            locals_count: self.leave_block(),
+            locals_count,
         })
     }
 
@@ -1048,15 +1045,10 @@ impl Converter {
         });
 
         // create a function scope
-        self.enter_block();
-
-        let args_bindings = self.bind_args(args_decls);
-
-        let converted_body = self.convert_block(block)?;
-
+        let ((args_bindings, converted_body), locals_count) =
+            self.scoped(|this| (this.bind_args(args_decls), this.convert_block(block)));
         assert_eq!(
-            self.leave_block(),
-            0,
+            locals_count, 0,
             "Internal compiler error: locals found in function arguments block"
         );
         self.current_routine = None;
@@ -1064,7 +1056,7 @@ impl Converter {
         let decl = RoutineDecl::Full(Routine {
             signature,
             args_bindings,
-            body: RoutineBody::Block(converted_body),
+            body: RoutineBody::Block(converted_body?),
         });
         Ok(Binding {
             name: self.bind_routine(name, decl.clone())?,
@@ -1097,15 +1089,12 @@ impl Converter {
         let return_type = return_type.map(|t| self.convert_type(t)).transpose()?;
 
         // No recursive calls for expression function
-        self.enter_block();
 
-        let args_bindings = self.bind_args(args_decls);
-
-        let expr = self.convert_expr(expression)?;
-
+        let ((args_bindings, expr), locals_count) =
+            self.scoped(|this| (this.bind_args(args_decls), this.convert_expr(expression)));
+        let expr = expr?;
         assert_eq!(
-            self.leave_block(),
-            0,
+            locals_count, 0,
             "Internal compiler error: locals found in function arguments block"
         );
 

--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, rc::Rc};
 
-use common::{Identifier, Location, LoopOrder, RawIdentifier};
+use common::{Identifier, Location, LoopOrder, RawIdentifier, VarLoc};
 
 use crate::{
     operators::UnaryOperator,
@@ -12,7 +12,7 @@ use crate::{
 #[derive(Debug, Default)]
 struct ScopeBlock {
     binders: HashMap<RawIdentifier, usize>,
-    locals_in_block: usize,
+    locals_in_block: VarLoc,
 }
 
 impl ScopeBlock {
@@ -43,8 +43,8 @@ struct RoutinePrototype {
 struct Converter {
     ident_table: IdentifierTable,
     current_scope: Vec<ScopeBlock>,
-    global_count: usize,
-    local_count: usize,
+    global_count: VarLoc,
+    local_count: VarLoc,
     current_routine: Option<RoutinePrototype>,
 }
 
@@ -67,7 +67,7 @@ impl Converter {
         self.current_scope.push(ScopeBlock::new())
     }
 
-    fn leave_block(&mut self) -> usize {
+    fn leave_block(&mut self) -> VarLoc {
         assert!(
             self.current_scope.len() > 1,
             "No non-global contexts to leave"
@@ -83,8 +83,9 @@ impl Converter {
     }
 
     fn get_fresh_global_location(&mut self) -> Location {
+        let res = self.global_count;
         self.global_count += 1;
-        Location::Global(u16::try_from(self.global_count - 1).expect("Too many global variables"))
+        Location::Global(res)
     }
 
     fn get_fresh_local_location(&mut self) -> Location {
@@ -93,14 +94,13 @@ impl Converter {
             "Local name binding in global context"
         );
 
+        let res = self.local_count;
         self.local_count += 1;
         self.current_scope
             .last_mut()
             .expect("At least global context is always present")
             .locals_in_block += 1;
-        Location::Local(
-            u16::try_from(self.local_count - 1).expect("Too many local variables in function"),
-        )
+        Location::Local(res)
     }
 
     fn bind_global_decl(&mut self, name: &RawIdentifier, decl: Decl) -> Identifier {
@@ -988,7 +988,7 @@ impl Converter {
                         t: Rc::clone(t),
                         initialiser: None,
                         relative_location: Location::Argument(
-                            u16::try_from(index).expect("Too many arguments for function"),
+                            index.try_into().expect("Too many arguments for function"),
                         ),
                     },
                 )

--- a/compiler/ast/src/lib.rs
+++ b/compiler/ast/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::{
     convert::convert,
     operators::{BinaryOperator, BoolBinOp, EqBinOp, IntBinOp, RealBinOp, UnaryOperator},
     tree::{
-        Binding, Block, BoolLiteral, ConstDecl, Decl, Expression, IdentifierTable, IntegerLiteral,
+        Binding, Bindings, Block, BoolLiteral, ConstDecl, Decl, Expression, IntegerLiteral,
         LocalBinding, LocalDecl, LvalueExpression, Program, RealLiteral, Routine, RoutineBody,
         RoutineDecl, RoutineSignature, Statement, TypeDecl, VarDecl,
     },

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -1,3 +1,4 @@
+use core::ops::Index;
 use std::rc::Rc;
 
 use derive_where::derive_where;
@@ -584,22 +585,9 @@ impl IdentifierTable {
         self.bindings[ident.id.0].decl = new_decl;
     }
 
-    #[must_use]
-    pub fn get_binding(&self, ident: &Identifier) -> &Binding {
-        let &Identifier { raw: _, id } = ident;
-        self.get_binding_by_id(id)
-    }
-
-    #[must_use]
-    pub fn get_binding_by_id(&self, id: BindingId) -> &Binding {
-        let BindingId(id) = id;
-        &self.bindings[id]
-    }
-
     pub fn get_effective_type(&self, t: &Rc<Type>) -> AnalysisResult<Rc<Type>> {
         match &**t {
-            Type::Alias(identifier) => self
-                .get_binding(identifier)
+            Type::Alias(identifier) => self[identifier]
                 .ensure_is_type()
                 .and_then(TypeDecl::get_effective),
             Type::Int
@@ -610,6 +598,23 @@ impl IdentifierTable {
             | Type::Null
             | Type::Unit => Ok(Rc::clone(t)),
         }
+    }
+}
+
+impl Index<BindingId> for IdentifierTable {
+    type Output = Binding;
+
+    fn index(&self, id: BindingId) -> &Self::Output {
+        let BindingId(id) = id;
+        &self.bindings[id]
+    }
+}
+
+impl Index<&Identifier> for IdentifierTable {
+    type Output = Binding;
+
+    fn index(&self, ident: &Identifier) -> &Self::Output {
+        &self[ident.id]
     }
 }
 

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -542,17 +542,17 @@ impl TryFrom<Binding> for LocalBinding {
 pub struct Program(pub Vec<Binding>);
 
 #[derive(Debug, Default)]
-pub struct IdentifierTable {
-    bindings: Vec<Binding>,
+pub struct Bindings {
+    arena: Vec<Binding>,
 }
 
-impl IdentifierTable {
-    pub fn create_binding(&mut self, name: &RawIdentifier, decl: Decl) -> Identifier {
+impl Bindings {
+    pub fn create(&mut self, name: &RawIdentifier, decl: Decl) -> Identifier {
         let identifier = Identifier {
             raw: name.clone(),
-            id: BindingId(self.bindings.len()),
+            id: BindingId(self.arena.len()),
         };
-        self.bindings.push(Binding {
+        self.arena.push(Binding {
             name: identifier.clone(),
             decl,
         });
@@ -582,7 +582,7 @@ impl IdentifierTable {
     }
 
     pub fn rebind(&mut self, ident: &Identifier, new_decl: Decl) {
-        self.bindings[ident.id.0].decl = new_decl;
+        self.arena[ident.id.0].decl = new_decl;
     }
 
     pub fn get_effective_type(&self, t: &Rc<Type>) -> AnalysisResult<Rc<Type>> {
@@ -601,16 +601,16 @@ impl IdentifierTable {
     }
 }
 
-impl Index<BindingId> for IdentifierTable {
+impl Index<BindingId> for Bindings {
     type Output = Binding;
 
     fn index(&self, id: BindingId) -> &Self::Output {
         let BindingId(id) = id;
-        &self.bindings[id]
+        &self.arena[id]
     }
 }
 
-impl Index<&Identifier> for IdentifierTable {
+impl Index<&Identifier> for Bindings {
     type Output = Binding;
 
     fn index(&self, ident: &Identifier) -> &Self::Output {

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use derive_where::derive_where;
 
 use common::{
-    Identifier, Integer, Location, LoopOrder, Position, RawIdentifier, Real, VarLoc,
+    BindingId, Identifier, Integer, Location, LoopOrder, Position, RawIdentifier, Real, VarLoc,
     integer_to_real, real_to_integer,
 };
 
@@ -547,10 +547,9 @@ pub struct IdentifierTable {
 
 impl IdentifierTable {
     pub fn create_binding(&mut self, name: &RawIdentifier, decl: Decl) -> Identifier {
-        let id = self.bindings.len();
         let identifier = Identifier {
             raw: name.clone(),
-            id,
+            id: BindingId(self.bindings.len()),
         };
         self.bindings.push(Binding {
             name: identifier.clone(),
@@ -582,16 +581,18 @@ impl IdentifierTable {
     }
 
     pub fn rebind(&mut self, ident: &Identifier, new_decl: Decl) {
-        self.bindings[ident.id].decl = new_decl;
+        self.bindings[ident.id.0].decl = new_decl;
     }
 
     #[must_use]
     pub fn get_binding(&self, ident: &Identifier) -> &Binding {
-        &self.bindings[ident.id]
+        let &Identifier { raw: _, id } = ident;
+        self.get_binding_by_id(id)
     }
 
     #[must_use]
-    pub fn get_binding_by_id(&self, id: usize) -> &Binding {
+    pub fn get_binding_by_id(&self, id: BindingId) -> &Binding {
+        let BindingId(id) = id;
         &self.bindings[id]
     }
 

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -3,8 +3,8 @@ use std::rc::Rc;
 use derive_where::derive_where;
 
 use common::{
-    Identifier, Integer, Location, LoopOrder, Position, RawIdentifier, Real, integer_to_real,
-    real_to_integer,
+    Identifier, Integer, Location, LoopOrder, Position, RawIdentifier, Real, VarLoc,
+    integer_to_real, real_to_integer,
 };
 
 use crate::{
@@ -413,7 +413,7 @@ impl From<LocalBinding> for Binding {
 #[derive(Debug, Clone)]
 pub struct Block {
     pub stmts: Vec<Statement>,
-    pub locals_count: usize,
+    pub locals_count: VarLoc,
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/codegen/src/bytecode.rs
+++ b/compiler/codegen/src/bytecode.rs
@@ -3,7 +3,7 @@
 use core::alloc::Layout;
 
 use ast::{BinaryOperator, BoolBinOp, EqBinOp, IntBinOp, RealBinOp, UnaryOperator};
-use common::{Integer, Location, Real};
+use common::{Integer, Location, Real, VarLoc};
 
 trait Encode {
     type Output: Copy;
@@ -54,7 +54,7 @@ pub(crate) enum Instruction {
     /// drop stack top
     Drop,
     // drop n elements from stack
-    DropMany(usize),
+    DropMany(VarLoc),
     /// swaps top and second elements of stack
     Swap,
     /// apply binary operator to stack top
@@ -208,7 +208,7 @@ impl Encode for Instruction {
 
             Instruction::DropMany(n) => Bytecode {
                 opcode: 29,
-                arg64: n.to_le_bytes(),
+                arg16: n.to_le_bytes(),
                 ..zero
             },
 

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -37,9 +37,7 @@ impl<'a> Compiler<'a> {
         match expr {
             LvalueExpression::Identifier(identifier) => {
                 self.bytecode.push(Instruction::AddressOf {
-                    loc: self
-                        .identifiers
-                        .get_binding(identifier)
+                    loc: self.identifiers[identifier]
                         .ensure_is_var()?
                         .relative_location,
                 });
@@ -119,9 +117,7 @@ impl<'a> Compiler<'a> {
             Expression::LvalueToRvalue(lvalue_expression) => match &**lvalue_expression {
                 LvalueExpression::Identifier(identifier) => {
                     self.bytecode.push(Instruction::Load {
-                        loc: self
-                            .identifiers
-                            .get_binding(identifier)
+                        loc: self.identifiers[identifier]
                             .ensure_is_var()?
                             .relative_location,
                     });
@@ -224,9 +220,7 @@ impl<'a> Compiler<'a> {
                     // Microoptimisation: use direct Store instruction instead of calculating address
                     self.compile_expr(rhs)?;
                     self.bytecode.push(Instruction::Store {
-                        loc: self
-                            .identifiers
-                            .get_binding(identifier)
+                        loc: self.identifiers[identifier]
                             .ensure_is_var()?
                             .relative_location,
                     });

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use ast::{
-    AnalysisError, AnalysisResult, Binding, Block, Decl, Expression, IdentifierTable,
-    LvalueExpression, Program, Routine, RoutineBody, RoutineDecl, Statement, Type,
+    AnalysisError, AnalysisResult, Binding, Bindings, Block, Decl, Expression, LvalueExpression,
+    Program, Routine, RoutineBody, RoutineDecl, Statement, Type,
 };
 use common::{Integer, Position, RawIdentifier};
 
@@ -12,16 +12,16 @@ use bytecode::{Instruction, TypeId};
 
 #[derive(Debug)]
 pub struct Compiler<'a> {
-    identifiers: &'a IdentifierTable,
+    bindings: &'a Bindings,
     bytecode: Vec<Instruction>,
     fresh_label_counter: u64,
 }
 
 impl<'a> Compiler<'a> {
     #[must_use]
-    pub fn new(table: &'a IdentifierTable) -> Self {
+    pub fn new(table: &'a Bindings) -> Self {
         Compiler {
-            identifiers: table,
+            bindings: table,
             bytecode: Vec::new(),
             fresh_label_counter: 0,
         }
@@ -37,9 +37,7 @@ impl<'a> Compiler<'a> {
         match expr {
             LvalueExpression::Identifier(identifier) => {
                 self.bytecode.push(Instruction::AddressOf {
-                    loc: self.identifiers[identifier]
-                        .ensure_is_var()?
-                        .relative_location,
+                    loc: self.bindings[identifier].ensure_is_var()?.relative_location,
                 });
                 Ok(())
             }
@@ -63,7 +61,7 @@ impl<'a> Compiler<'a> {
         t: &Rc<Type>,
         fields: &[(RawIdentifier, Rc<Expression>)],
     ) -> AnalysisResult<()> {
-        let effective_type = self.identifiers.get_effective_type(t)?;
+        let effective_type = self.bindings.get_effective_type(t)?;
 
         match &*effective_type {
             Type::Int | Type::Real | Type::Bool | Type::Null | Type::Unit => {
@@ -117,9 +115,7 @@ impl<'a> Compiler<'a> {
             Expression::LvalueToRvalue(lvalue_expression) => match &**lvalue_expression {
                 LvalueExpression::Identifier(identifier) => {
                     self.bytecode.push(Instruction::Load {
-                        loc: self.identifiers[identifier]
-                            .ensure_is_var()?
-                            .relative_location,
+                        loc: self.bindings[identifier].ensure_is_var()?.relative_location,
                     });
                 }
                 LvalueExpression::Member { .. } | LvalueExpression::Index { .. } => {
@@ -220,9 +216,7 @@ impl<'a> Compiler<'a> {
                     // Microoptimisation: use direct Store instruction instead of calculating address
                     self.compile_expr(rhs)?;
                     self.bytecode.push(Instruction::Store {
-                        loc: self.identifiers[identifier]
-                            .ensure_is_var()?
-                            .relative_location,
+                        loc: self.bindings[identifier].ensure_is_var()?.relative_location,
                     });
                 }
                 LvalueExpression::Index { .. } | LvalueExpression::Member { .. } => {
@@ -288,7 +282,7 @@ impl<'a> Compiler<'a> {
                         .ok_or(AnalysisError {
                             what: "placeholder".to_string(),
                         })
-                        .or_else(|_| self.identifiers.get_default_initialiser(&var_decl.t))?;
+                        .or_else(|_| self.bindings.get_default_initialiser(&var_decl.t))?;
                     // Local variable initialisation is just a `push`
                     self.compile_expr(&initialiser)?;
                 }

--- a/compiler/common/src/lib.rs
+++ b/compiler/common/src/lib.rs
@@ -23,10 +23,20 @@ impl Display for RawIdentifier {
     }
 }
 
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub struct BindingId(pub usize);
+
+impl Display for BindingId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self(id) = self;
+        Display::fmt(id, f)
+    }
+}
+
 #[derive(Hash, PartialEq, Eq, Clone)]
 pub struct Identifier {
     pub raw: RawIdentifier,
-    pub id: usize,
+    pub id: BindingId,
 }
 
 impl Debug for Identifier {

--- a/compiler/common/src/lib.rs
+++ b/compiler/common/src/lib.rs
@@ -89,12 +89,14 @@ impl Display for Extent {
     }
 }
 
-///  Variable location and id
+pub type VarLoc = u16;
+
+/// Variable location and id
 #[derive(Debug, Clone, Copy, Hash)]
 pub enum Location {
-    Global(u16),
-    Local(u16),
-    Argument(u16),
+    Global(VarLoc),
+    Local(VarLoc),
+    Argument(VarLoc),
 }
 
 pub type Integer = i64;

--- a/tests/ast/pass/arithmetic_operations.txt
+++ b/tests/ast/pass/arithmetic_operations.txt
@@ -433,8 +433,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/arrays_and_records.txt
+++ b/tests/ast/pass/arrays_and_records.txt
@@ -980,8 +980,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: point(0),
                 decl: Type(

--- a/tests/ast/pass/assert.txt
+++ b/tests/ast/pass/assert.txt
@@ -114,8 +114,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/comparison_operators.txt
+++ b/tests/ast/pass/comparison_operators.txt
@@ -338,8 +338,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/complex_expressions.txt
+++ b/tests/ast/pass/complex_expressions.txt
@@ -489,8 +489,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: add_one(0),
                 decl: Routine(

--- a/tests/ast/pass/conditionals.txt
+++ b/tests/ast/pass/conditionals.txt
@@ -219,8 +219,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: abs(0),
                 decl: Routine(

--- a/tests/ast/pass/constant.txt
+++ b/tests/ast/pass/constant.txt
@@ -366,8 +366,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: LENGTH(0),
                 decl: Const(

--- a/tests/ast/pass/deep_conditionals.txt
+++ b/tests/ast/pass/deep_conditionals.txt
@@ -703,8 +703,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/for_loops.txt
+++ b/tests/ast/pass/for_loops.txt
@@ -800,8 +800,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: array_length(0),
                 decl: Routine(

--- a/tests/ast/pass/function_parameters.txt
+++ b/tests/ast/pass/function_parameters.txt
@@ -111,8 +111,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: a_plus_b(0),
                 decl: Routine(

--- a/tests/ast/pass/function_return.txt
+++ b/tests/ast/pass/function_return.txt
@@ -88,8 +88,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: echo(0),
                 decl: Routine(

--- a/tests/ast/pass/identifiers.txt
+++ b/tests/ast/pass/identifiers.txt
@@ -303,8 +303,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/lazy_operators.txt
+++ b/tests/ast/pass/lazy_operators.txt
@@ -268,8 +268,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: False(0),
                 decl: Routine(

--- a/tests/ast/pass/length.txt
+++ b/tests/ast/pass/length.txt
@@ -222,8 +222,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: square(0),
                 decl: Type(

--- a/tests/ast/pass/logical_operators.txt
+++ b/tests/ast/pass/logical_operators.txt
@@ -210,8 +210,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/nested_control.txt
+++ b/tests/ast/pass/nested_control.txt
@@ -384,8 +384,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/oob_big.txt
+++ b/tests/ast/pass/oob_big.txt
@@ -72,8 +72,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/oob_neg.txt
+++ b/tests/ast/pass/oob_neg.txt
@@ -75,8 +75,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/oob_zero.txt
+++ b/tests/ast/pass/oob_zero.txt
@@ -72,8 +72,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/operator_precedence.txt
+++ b/tests/ast/pass/operator_precedence.txt
@@ -331,8 +331,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: f(0),
                 decl: Routine(

--- a/tests/ast/pass/panic.txt
+++ b/tests/ast/pass/panic.txt
@@ -63,8 +63,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/parse_minus.txt
+++ b/tests/ast/pass/parse_minus.txt
@@ -165,8 +165,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: a(0),
                 decl: Var(

--- a/tests/ast/pass/raytracer.txt
+++ b/tests/ast/pass/raytracer.txt
@@ -6778,8 +6778,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: EPS(0),
                 decl: Var(

--- a/tests/ast/pass/real_comparisons.txt
+++ b/tests/ast/pass/real_comparisons.txt
@@ -263,8 +263,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/real_literals.txt
+++ b/tests/ast/pass/real_literals.txt
@@ -562,8 +562,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/records.txt
+++ b/tests/ast/pass/records.txt
@@ -538,8 +538,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: point(0),
                 decl: Type(

--- a/tests/ast/pass/recursive_function.txt
+++ b/tests/ast/pass/recursive_function.txt
@@ -161,8 +161,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: fibonacci(0),
                 decl: Routine(

--- a/tests/ast/pass/recursive_types.txt
+++ b/tests/ast/pass/recursive_types.txt
@@ -512,8 +512,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: linked_list(0),
                 decl: Type(

--- a/tests/ast/pass/shadow.txt
+++ b/tests/ast/pass/shadow.txt
@@ -114,8 +114,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: x(0),
                 decl: Var(

--- a/tests/ast/pass/type_aliases.txt
+++ b/tests/ast/pass/type_aliases.txt
@@ -166,8 +166,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: kilometers(0),
                 decl: Type(

--- a/tests/ast/pass/type_conversions.txt
+++ b/tests/ast/pass/type_conversions.txt
@@ -221,8 +221,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: main(0),
                 decl: Routine(

--- a/tests/ast/pass/variable_declarations.txt
+++ b/tests/ast/pass/variable_declarations.txt
@@ -152,8 +152,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: a(0),
                 decl: Var(

--- a/tests/ast/pass/while_loops.txt
+++ b/tests/ast/pass/while_loops.txt
@@ -240,8 +240,8 @@
             },
         ],
     ),
-    IdentifierTable {
-        bindings: [
+    Bindings {
+        arena: [
             Binding {
                 name: collatz(0),
                 decl: Routine(

--- a/vm/include/vm/opcodes.hpp
+++ b/vm/include/vm/opcodes.hpp
@@ -34,6 +34,8 @@ enum class Opcode : uint8_t {
   kRet           = 25,
   kPrint         = 26,
   kPanic         = 27,
+  // TODO: NullConst
+  // TODO: DropMany
 };
 
 // Location kind for Load/Store/AddressOf subopcode.


### PR DESCRIPTION
- Based on top of #120
- See also: #97

This PR:
- creates a clear separation between variable counters for `Location`s and `Binding` IDs
- merges `enter_block` and `leave_block` together