### PR TITLE
parser: rewrite in Rust (from Haskell)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ name = "parser"
 version = "0.0.0"
 dependencies = [
  "common",
+ "culpa",
  "derive-where",
  "lexer",
  "testing",

--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -341,7 +341,7 @@ impl Converter {
     fn convert_call(
         &self,
         callee: &RawIdentifier,
-        args: &[Rc<parser::Expression>],
+        args: &[parser::Expression],
     ) -> AnalysisResult<Typed> {
         let RoutineSignature {
             args: formal_args,
@@ -381,7 +381,7 @@ impl Converter {
     fn convert_new(
         &self,
         t: &parser::Type,
-        fields: Option<&[(RawIdentifier, Rc<parser::Expression>)]>,
+        fields: Option<&[(RawIdentifier, parser::Expression)]>,
         array_length: Option<&parser::Expression>,
     ) -> AnalysisResult<Typed> {
         let ty = self.convert_type(t)?;
@@ -702,7 +702,7 @@ impl Converter {
                 to,
                 order,
                 body,
-            } => self.convert_for(counter, from, to.as_deref(), *order, body)?,
+            } => self.convert_for(counter, from, to.as_ref(), *order, body)?,
 
             parser::Statement::Print { value } => {
                 let Typed { value, ty: _ } = self.convert_expr(value)?;

--- a/compiler/ast/src/tests.rs
+++ b/compiler/ast/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{AnalysisResult, convert};
 
 fn get_ast(src: &str) -> AnalysisResult<String> {
     let tokens: Vec<_> = Lexer::from(src).collect();
-    let program = parse_program(&tokens).expect("Failed to parse");
+    let program = parse_program(tokens).expect("Failed to parse");
     convert(&program).map(|res| format!("{res:#?}\n"))
 }
 

--- a/compiler/ast/src/tests.rs
+++ b/compiler/ast/src/tests.rs
@@ -4,8 +4,7 @@ use parser::parse_program;
 use crate::{AnalysisResult, convert};
 
 fn get_ast(src: &str) -> AnalysisResult<String> {
-    let tokens: Vec<_> = Lexer::from(src).collect();
-    let program = parse_program(tokens).expect("Failed to parse");
+    let program = parse_program(Lexer::from(src)).expect("Failed to parse");
     convert(&program).map(|res| format!("{res:#?}\n"))
 }
 

--- a/compiler/compiler/src/main.rs
+++ b/compiler/compiler/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
         eprintln!("{token}")
     }
 
-    let program = match parse_program(tokens.as_slice()) {
+    let program = match parse_program(tokens) {
         Ok(program) => program,
         Err(ParserError::Recoverable { errors, parsed }) => {
             eprintln!("Following errors occurred:");

--- a/compiler/compiler/src/main.rs
+++ b/compiler/compiler/src/main.rs
@@ -6,7 +6,6 @@ use anyhow::Context;
 use ast::convert;
 use interpreter::interpret;
 use lexer::Lexer;
-use parser::ParserError;
 use parser::parse_program;
 
 // TODO: create a Driver module
@@ -20,17 +19,7 @@ fn main() -> anyhow::Result<()> {
         eprintln!("{token}")
     }
 
-    let program = match parse_program(tokens) {
-        Ok(program) => program,
-        Err(ParserError::Recoverable { errors, parsed }) => {
-            eprintln!("Following errors occurred:");
-            for err in errors {
-                eprintln!("\t{err}");
-            }
-            parsed
-        }
-        Err(ParserError::Unrecoverable { error }) => Err(error).context("Parsing error")?,
-    };
+    let program = parse_program(tokens).context("Parsing error")?;
 
     for decl in &program.0 {
         eprintln!("{decl:?}");

--- a/compiler/interpreter/src/tests.rs
+++ b/compiler/interpreter/src/tests.rs
@@ -1,15 +1,6 @@
 use core::fmt;
 
-struct DebugDisplay<T: fmt::Display>(T);
-
-impl<T: fmt::Display> fmt::Debug for DebugDisplay<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self(inner) = self;
-        fmt::Display::fmt(&inner, f)
-    }
-}
-
-fn interpret(src: &str) -> Result<String, DebugDisplay<String>> {
+fn interpret(src: &str) -> Result<String, String> {
     let tokens: Vec<_> = lexer::Lexer::from(src).collect();
     let program = parser::parse_program(tokens).expect("Failed to parse");
     let program = ast::convert(&program).expect("Failed to typecheck");
@@ -21,7 +12,7 @@ fn interpret(src: &str) -> Result<String, DebugDisplay<String>> {
         Err(e) => {
             use fmt::Write;
             writeln!(output, "{e}").expect("Error formatting shouldn't fail");
-            Err(DebugDisplay(output))
+            Err(output)
         }
     }
 }

--- a/compiler/interpreter/src/tests.rs
+++ b/compiler/interpreter/src/tests.rs
@@ -11,7 +11,7 @@ impl<T: fmt::Display> fmt::Debug for DebugDisplay<T> {
 
 fn interpret(src: &str) -> Result<String, DebugDisplay<String>> {
     let tokens: Vec<_> = lexer::Lexer::from(src).collect();
-    let program = parser::parse_program(&tokens).expect("Failed to parse");
+    let program = parser::parse_program(tokens).expect("Failed to parse");
     let program = ast::convert(&program).expect("Failed to typecheck");
     let mut output: Vec<u8> = vec![];
     let result = crate::interpret(&mut output, &program);

--- a/compiler/interpreter/src/tests.rs
+++ b/compiler/interpreter/src/tests.rs
@@ -1,8 +1,7 @@
 use core::fmt;
 
 fn interpret(src: &str) -> Result<String, String> {
-    let tokens: Vec<_> = lexer::Lexer::from(src).collect();
-    let program = parser::parse_program(tokens).expect("Failed to parse");
+    let program = parser::parse_program(lexer::Lexer::from(src)).expect("Failed to parse");
     let program = ast::convert(&program).expect("Failed to typecheck");
     let mut output: Vec<u8> = vec![];
     let result = crate::interpret(&mut output, &program);

--- a/compiler/lexer/src/lib.rs
+++ b/compiler/lexer/src/lib.rs
@@ -8,8 +8,7 @@ mod tokens;
 mod tests;
 
 pub use crate::tokens::{
-    BuiltinTypename, Comment, Identifier, InvalidToken, Keyword, Lexeme, Literal, Operator,
-    TokenKind,
+    BuiltinTypename, Comment, Identifier, InvalidToken, Keyword, Lexeme, Literal, Operator, Token,
 };
 
 trait ImmutableIterator<'a>: Sized + Clone + From<&'a str> {
@@ -145,91 +144,91 @@ fn iterators_to_extent(start: &IndexIterator<'_>, end: &IndexIterator<'_>) -> Ex
 }
 
 /// Processes all the identifier-like lexemes (identifiers, keywords, bool literals and some operators)
-fn name_disambiguation(lexeme: &str) -> TokenKind<'_> {
-    const KNOWN_TOKENS: phf::Map<&str, TokenKind<'static>> = phf_map! {
-        "var" => TokenKind::Keyword(Keyword::Var),
-        "type" => TokenKind::Keyword(Keyword::Type),
-        "routine" => TokenKind::Keyword(Keyword::Routine),
-        "array" => TokenKind::Keyword(Keyword::Array),
-        "record" => TokenKind::Keyword(Keyword::Record),
-        "is" => TokenKind::Keyword(Keyword::Is),
-        "end" => TokenKind::Keyword(Keyword::End),
-        "if" => TokenKind::Keyword(Keyword::If),
-        "then" => TokenKind::Keyword(Keyword::Then),
-        "else" => TokenKind::Keyword(Keyword::Else),
-        "in" => TokenKind::Keyword(Keyword::In),
-        "while" => TokenKind::Keyword(Keyword::While),
-        "for" => TokenKind::Keyword(Keyword::For),
-        "loop" => TokenKind::Keyword(Keyword::Loop),
-        "reverse" => TokenKind::Keyword(Keyword::Reverse),
-        "return"  => TokenKind::Keyword(Keyword::Return),
-        "print" => TokenKind::Keyword(Keyword::Print),
-        "where" => TokenKind::Keyword(Keyword::Where),
-        "null" => TokenKind::Keyword(Keyword::Null),
-        "new" => TokenKind::Keyword(Keyword::New),
-        "constant" => TokenKind::Keyword(Keyword::Constant),
-        "and" => TokenKind::Operator(Operator::And),
-        "or" => TokenKind::Operator(Operator::Or),
-        "xor" => TokenKind::Operator(Operator::Xor),
-        "not" => TokenKind::Operator(Operator::Not),
-        "true" => TokenKind::Literal(Literal::Bool(true)),
-        "false" => TokenKind::Literal(Literal::Bool(false)),
-        "integer" => TokenKind::BuiltinTypename(BuiltinTypename::Integer),
-        "real" => TokenKind::BuiltinTypename(BuiltinTypename::Real),
-        "boolean" => TokenKind::BuiltinTypename(BuiltinTypename::Boolean),
-        "NaN" => TokenKind::Literal(Literal::Real(Real::NAN)),
-        "Inf" => TokenKind::Literal(Literal::Real(Real::INFINITY)),
-        "assert" => TokenKind::Keyword(Keyword::Assert),
-        "panic" => TokenKind::Keyword(Keyword::Panic),
+fn name_disambiguation(lexeme: &str) -> Token<'_> {
+    const KNOWN_TOKENS: phf::Map<&str, Token<'static>> = phf_map! {
+        "var" => Token::Keyword(Keyword::Var),
+        "type" => Token::Keyword(Keyword::Type),
+        "routine" => Token::Keyword(Keyword::Routine),
+        "array" => Token::Keyword(Keyword::Array),
+        "record" => Token::Keyword(Keyword::Record),
+        "is" => Token::Keyword(Keyword::Is),
+        "end" => Token::Keyword(Keyword::End),
+        "if" => Token::Keyword(Keyword::If),
+        "then" => Token::Keyword(Keyword::Then),
+        "else" => Token::Keyword(Keyword::Else),
+        "in" => Token::Keyword(Keyword::In),
+        "while" => Token::Keyword(Keyword::While),
+        "for" => Token::Keyword(Keyword::For),
+        "loop" => Token::Keyword(Keyword::Loop),
+        "reverse" => Token::Keyword(Keyword::Reverse),
+        "return"  => Token::Keyword(Keyword::Return),
+        "print" => Token::Keyword(Keyword::Print),
+        "where" => Token::Keyword(Keyword::Where),
+        "null" => Token::Keyword(Keyword::Null),
+        "new" => Token::Keyword(Keyword::New),
+        "constant" => Token::Keyword(Keyword::Constant),
+        "and" => Token::Operator(Operator::And),
+        "or" => Token::Operator(Operator::Or),
+        "xor" => Token::Operator(Operator::Xor),
+        "not" => Token::Operator(Operator::Not),
+        "true" => Token::Literal(Literal::Bool(true)),
+        "false" => Token::Literal(Literal::Bool(false)),
+        "integer" => Token::BuiltinTypename(BuiltinTypename::Integer),
+        "real" => Token::BuiltinTypename(BuiltinTypename::Real),
+        "boolean" => Token::BuiltinTypename(BuiltinTypename::Boolean),
+        "NaN" => Token::Literal(Literal::Real(Real::NAN)),
+        "Inf" => Token::Literal(Literal::Real(Real::INFINITY)),
+        "assert" => Token::Keyword(Keyword::Assert),
+        "panic" => Token::Keyword(Keyword::Panic),
     };
 
     match KNOWN_TOKENS.get(lexeme) {
         Some(token_value) => token_value.clone(),
-        None => TokenKind::Identifier(Identifier { name: lexeme }),
+        None => Token::Identifier(Identifier { name: lexeme }),
     }
 }
 
-fn nominal_token<'a>(start: &IndexIterator<'a>) -> Option<(TokenKind<'a>, IndexIterator<'a>)> {
+fn nominal_token<'a>(start: &IndexIterator<'a>) -> Option<(Token<'a>, IndexIterator<'a>)> {
     start
         .next()
         .is_some_and(|(ch, _)| is_identifier_start(ch))
         .then(|| start.take_while_map(is_identifier_continue, name_disambiguation))
 }
 
-fn comment_token<'a>(start: &IndexIterator<'a>) -> Option<(TokenKind<'a>, IndexIterator<'a>)> {
+fn comment_token<'a>(start: &IndexIterator<'a>) -> Option<(Token<'a>, IndexIterator<'a>)> {
     start.stars_with("--").map(|comment_start| {
         comment_start.take_while_map(
             |ch| ch != '\n',
-            |comment| TokenKind::Comment(Comment { value: comment }),
+            |comment| Token::Comment(Comment { value: comment }),
         )
     })
 }
 
-fn symbolic_token<'a>(start: &IndexIterator<'a>) -> Option<(TokenKind<'a>, IndexIterator<'a>)> {
-    const KNOWN_TOKENS: &[(&str, TokenKind<'static>)] = &[
-        (":=", TokenKind::Assignment),
-        ("::", TokenKind::Cast),
-        ("..", TokenKind::RangeSymbol),
-        ("/=", TokenKind::Operator(Operator::Ne)),
-        ("<=", TokenKind::Operator(Operator::Le)),
-        (">=", TokenKind::Operator(Operator::Ge)),
-        ("=>", TokenKind::RightArrow),
-        ("(", TokenKind::LeftParenthesis),
-        (")", TokenKind::RightParenthesis),
-        ("[", TokenKind::LeftBracket),
-        ("]", TokenKind::RightBracket),
-        (",", TokenKind::Comma),
-        (".", TokenKind::Dot),
-        (";", TokenKind::Semicolon),
-        (":", TokenKind::Colon),
-        ("+", TokenKind::Operator(Operator::Plus)),
-        ("-", TokenKind::Operator(Operator::Minus)),
-        ("*", TokenKind::Operator(Operator::Mul)),
-        ("/", TokenKind::Operator(Operator::Div)),
-        ("%", TokenKind::Operator(Operator::Mod)),
-        ("=", TokenKind::Operator(Operator::Eq)),
-        ("<", TokenKind::Operator(Operator::Lt)),
-        (">", TokenKind::Operator(Operator::Gt)),
+fn symbolic_token<'a>(start: &IndexIterator<'a>) -> Option<(Token<'a>, IndexIterator<'a>)> {
+    const KNOWN_TOKENS: &[(&str, Token<'static>)] = &[
+        (":=", Token::Assignment),
+        ("::", Token::Cast),
+        ("..", Token::RangeSymbol),
+        ("/=", Token::Operator(Operator::Ne)),
+        ("<=", Token::Operator(Operator::Le)),
+        (">=", Token::Operator(Operator::Ge)),
+        ("=>", Token::RightArrow),
+        ("(", Token::LeftParenthesis),
+        (")", Token::RightParenthesis),
+        ("[", Token::LeftBracket),
+        ("]", Token::RightBracket),
+        (",", Token::Comma),
+        (".", Token::Dot),
+        (";", Token::Semicolon),
+        (":", Token::Colon),
+        ("+", Token::Operator(Operator::Plus)),
+        ("-", Token::Operator(Operator::Minus)),
+        ("*", Token::Operator(Operator::Mul)),
+        ("/", Token::Operator(Operator::Div)),
+        ("%", Token::Operator(Operator::Mod)),
+        ("=", Token::Operator(Operator::Eq)),
+        ("<", Token::Operator(Operator::Lt)),
+        (">", Token::Operator(Operator::Gt)),
     ];
 
     KNOWN_TOKENS
@@ -237,24 +236,24 @@ fn symbolic_token<'a>(start: &IndexIterator<'a>) -> Option<(TokenKind<'a>, Index
         .find_map(|(pattern, token)| start.stars_with(pattern).map(|end| (token.to_owned(), end)))
 }
 
-fn real_literal_from_representation(s: &str) -> TokenKind<'_> {
+fn real_literal_from_representation(s: &str) -> Token<'_> {
     match s.parse() {
-        Ok(value) => TokenKind::Literal(Literal::Real(value)),
-        Err(e) => TokenKind::Invalid(InvalidToken::MalformedReal(e)),
+        Ok(value) => Token::Literal(Literal::Real(value)),
+        Err(e) => Token::Invalid(InvalidToken::MalformedReal(e)),
     }
 }
 
-fn integer_literal_from_representation(s: &str) -> TokenKind<'_> {
+fn integer_literal_from_representation(s: &str) -> Token<'_> {
     match s.parse() {
-        Ok(value) => TokenKind::Literal(Literal::Integer(value)),
-        Err(e) => TokenKind::Invalid(InvalidToken::MalformedInteger(e)),
+        Ok(value) => Token::Literal(Literal::Integer(value)),
+        Err(e) => Token::Invalid(InvalidToken::MalformedInteger(e)),
     }
 }
 
 fn numeric_token<'a>(
     allow_sign: bool,
     begin: &IndexIterator<'a>,
-) -> Option<(TokenKind<'a>, IndexIterator<'a>)> {
+) -> Option<(Token<'a>, IndexIterator<'a>)> {
     let start_digits = if allow_sign && let Some(('-' | '+', it)) = begin.next() {
         it
     } else {
@@ -307,29 +306,29 @@ impl<'src> From<&'src str> for Lexer<'src> {
 }
 
 impl Lexer<'_> {
-    fn update_allow_sign(&mut self, token: &TokenKind<'_>) {
+    fn update_allow_sign(&mut self, token: &Token<'_>) {
         self.allow_sign = match token {
-            TokenKind::Comment(_) => return,
+            Token::Comment(_) => return,
 
-            TokenKind::Assignment
-            | TokenKind::LeftParenthesis
-            | TokenKind::RightBracket
-            | TokenKind::Operator(_)
-            | TokenKind::Semicolon
-            | TokenKind::RangeSymbol
-            | TokenKind::Comma
-            | TokenKind::RightArrow
-            | TokenKind::Keyword(_) => true,
+            Token::Assignment
+            | Token::LeftParenthesis
+            | Token::RightBracket
+            | Token::Operator(_)
+            | Token::Semicolon
+            | Token::RangeSymbol
+            | Token::Comma
+            | Token::RightArrow
+            | Token::Keyword(_) => true,
 
-            TokenKind::Identifier(_)
-            | TokenKind::Literal(_)
-            | TokenKind::BuiltinTypename(_)
-            | TokenKind::LeftBracket
-            | TokenKind::RightParenthesis
-            | TokenKind::Dot
-            | TokenKind::Invalid(_)
-            | TokenKind::Cast
-            | TokenKind::Colon => false,
+            Token::Identifier(_)
+            | Token::Literal(_)
+            | Token::BuiltinTypename(_)
+            | Token::LeftBracket
+            | Token::RightParenthesis
+            | Token::Dot
+            | Token::Invalid(_)
+            | Token::Cast
+            | Token::Colon => false,
         }
     }
 }
@@ -344,15 +343,12 @@ impl<'src> Iterator for Lexer<'src> {
             .or_else(|| nominal_token(&begin))
             .or_else(|| numeric_token(self.allow_sign, &begin))
             .or_else(|| symbolic_token(&begin))
-            .unwrap_or((
-                TokenKind::Invalid(InvalidToken::Unexpected(first_char)),
-                rest,
-            ));
+            .unwrap_or((Token::Invalid(InvalidToken::Unexpected(first_char)), rest));
         self.update_allow_sign(&kind);
         let token = Lexeme {
             extent: iterators_to_extent(&begin, &end),
             text: ImmutableIterator::slice_to_str(&begin, &end),
-            kind,
+            token: kind,
         };
         self.pos = end;
         Some(token)

--- a/compiler/lexer/src/lib.rs
+++ b/compiler/lexer/src/lib.rs
@@ -8,7 +8,7 @@ mod tokens;
 mod tests;
 
 pub use crate::tokens::{
-    BuiltinTypename, Comment, Identifier, InvalidToken, Keyword, Lexeme, Literal, Operator, Token,
+    BuiltinTypename, Comment, Identifier, Keyword, Lexeme, Literal, Operator, Token,
 };
 
 trait ImmutableIterator<'a>: Sized + Clone + From<&'a str> {
@@ -176,8 +176,8 @@ fn name_disambiguation(lexeme: &str) -> Token<'_> {
         "integer" => Token::BuiltinTypename(BuiltinTypename::Integer),
         "real" => Token::BuiltinTypename(BuiltinTypename::Real),
         "boolean" => Token::BuiltinTypename(BuiltinTypename::Boolean),
-        "NaN" => Token::Literal(Literal::Real(Real::NAN)),
-        "Inf" => Token::Literal(Literal::Real(Real::INFINITY)),
+        "NaN" => Token::Literal(Literal::Real(Ok(Real::NAN))),
+        "Inf" => Token::Literal(Literal::Real(Ok(Real::INFINITY))),
         "assert" => Token::Keyword(Keyword::Assert),
         "panic" => Token::Keyword(Keyword::Panic),
     };
@@ -237,17 +237,11 @@ fn symbolic_token<'a>(start: &IndexIterator<'a>) -> Option<(Token<'a>, IndexIter
 }
 
 fn real_literal_from_representation(s: &str) -> Token<'_> {
-    match s.parse() {
-        Ok(value) => Token::Literal(Literal::Real(value)),
-        Err(e) => Token::Invalid(InvalidToken::MalformedReal(e)),
-    }
+    Token::Literal(Literal::Real(s.parse()))
 }
 
 fn integer_literal_from_representation(s: &str) -> Token<'_> {
-    match s.parse() {
-        Ok(value) => Token::Literal(Literal::Integer(value)),
-        Err(e) => Token::Invalid(InvalidToken::MalformedInteger(e)),
-    }
+    Token::Literal(Literal::Integer(s.parse()))
 }
 
 fn numeric_token<'a>(
@@ -326,7 +320,7 @@ impl Lexer<'_> {
             | Token::LeftBracket
             | Token::RightParenthesis
             | Token::Dot
-            | Token::Invalid(_)
+            | Token::Unexpected(_)
             | Token::Cast
             | Token::Colon => false,
         }
@@ -343,7 +337,7 @@ impl<'src> Iterator for Lexer<'src> {
             .or_else(|| nominal_token(&begin))
             .or_else(|| numeric_token(self.allow_sign, &begin))
             .or_else(|| symbolic_token(&begin))
-            .unwrap_or((Token::Invalid(InvalidToken::Unexpected(first_char)), rest));
+            .unwrap_or((Token::Unexpected(first_char), rest));
         self.update_allow_sign(&kind);
         let token = Lexeme {
             extent: iterators_to_extent(&begin, &end),

--- a/compiler/lexer/src/lib.rs
+++ b/compiler/lexer/src/lib.rs
@@ -8,7 +8,7 @@ mod tokens;
 mod tests;
 
 pub use crate::tokens::{
-    BuiltinTypename, Comment, Identifier, InvalidToken, Keyword, Literal, Operator, Token,
+    BuiltinTypename, Comment, Identifier, InvalidToken, Keyword, Lexeme, Literal, Operator,
     TokenKind,
 };
 
@@ -335,7 +335,7 @@ impl Lexer<'_> {
 }
 
 impl<'src> Iterator for Lexer<'src> {
-    type Item = Token<'src>;
+    type Item = Lexeme<'src>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let begin = self.pos.skip(char::is_whitespace);
@@ -349,9 +349,9 @@ impl<'src> Iterator for Lexer<'src> {
                 rest,
             ));
         self.update_allow_sign(&kind);
-        let token = Token {
+        let token = Lexeme {
             extent: iterators_to_extent(&begin, &end),
-            lexeme: ImmutableIterator::slice_to_str(&begin, &end),
+            text: ImmutableIterator::slice_to_str(&begin, &end),
             kind,
         };
         self.pos = end;

--- a/compiler/lexer/src/tests.rs
+++ b/compiler/lexer/src/tests.rs
@@ -40,6 +40,7 @@ testing::tests! {
         lexer_invalid => "lexer_invalid"
         local_type => "local_type"
         logical_operators => "logical_operators"
+        malformed_integer => "malformed_integer"
         nested_control => "nested_control"
         new_array => "new_array"
         new_array_fixed => "new_array_fixed"

--- a/compiler/lexer/src/tokens.rs
+++ b/compiler/lexer/src/tokens.rs
@@ -98,7 +98,7 @@ impl fmt::Display for Comment<'_> {
 }
 
 #[derive(PartialEq, Clone, Debug)]
-pub enum TokenKind<'a> {
+pub enum Token<'a> {
     Identifier(Identifier<'a>),
     Keyword(Keyword),
     Literal(Literal),
@@ -124,38 +124,38 @@ pub enum TokenKind<'a> {
     Colon,
 }
 
-impl fmt::Display for TokenKind<'_> {
+impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TokenKind::Identifier(Identifier { name }) => write!(f, "IDENTIFIER({name})"),
-            TokenKind::Keyword(keyword) => write!(f, "KEYWORD({keyword:?})"),
-            TokenKind::Literal(Literal::Integer(value)) => {
+            Token::Identifier(Identifier { name }) => write!(f, "IDENTIFIER({name})"),
+            Token::Keyword(keyword) => write!(f, "KEYWORD({keyword:?})"),
+            Token::Literal(Literal::Integer(value)) => {
                 write!(f, "INTEGER LITERAL({value})")
             }
-            TokenKind::Literal(Literal::Real(value)) => {
+            Token::Literal(Literal::Real(value)) => {
                 write!(f, "REAL LITERAL({value})")
             }
-            TokenKind::Literal(Literal::Bool(value)) => {
+            Token::Literal(Literal::Bool(value)) => {
                 write!(f, "BOOLEAN LITERAL({value})")
             }
-            TokenKind::BuiltinTypename(builtin_typename) => {
+            Token::BuiltinTypename(builtin_typename) => {
                 write!(f, "TYPENAME({builtin_typename:?})")
             }
-            TokenKind::Operator(operator) => write!(f, "OPERATOR({operator:?})"),
-            TokenKind::Comment(comment) => write!(f, "COMMENT({comment})"),
-            TokenKind::Invalid(problem) => write!(f, "INVALID({problem})"),
-            TokenKind::LeftBracket => write!(f, "LEFT BRACKET"),
-            TokenKind::RightBracket => write!(f, "RIGHT BRACKET"),
-            TokenKind::LeftParenthesis => write!(f, "LEFT PARENTHESIS"),
-            TokenKind::RightParenthesis => write!(f, "RIGHT PARENTHESIS"),
-            TokenKind::RightArrow => write!(f, "FUNCTION ARROW"),
-            TokenKind::Assignment => write!(f, "ASSIGNMENT OPERATOR"),
-            TokenKind::RangeSymbol => write!(f, "RANGE"),
-            TokenKind::Dot => write!(f, "DOT"),
-            TokenKind::Comma => write!(f, "COMMA"),
-            TokenKind::Semicolon => write!(f, "SEMICOLON"),
-            TokenKind::Colon => write!(f, "COLON"),
-            TokenKind::Cast => write!(f, "CAST"),
+            Token::Operator(operator) => write!(f, "OPERATOR({operator:?})"),
+            Token::Comment(comment) => write!(f, "COMMENT({comment})"),
+            Token::Invalid(problem) => write!(f, "INVALID({problem})"),
+            Token::LeftBracket => write!(f, "LEFT BRACKET"),
+            Token::RightBracket => write!(f, "RIGHT BRACKET"),
+            Token::LeftParenthesis => write!(f, "LEFT PARENTHESIS"),
+            Token::RightParenthesis => write!(f, "RIGHT PARENTHESIS"),
+            Token::RightArrow => write!(f, "FUNCTION ARROW"),
+            Token::Assignment => write!(f, "ASSIGNMENT OPERATOR"),
+            Token::RangeSymbol => write!(f, "RANGE"),
+            Token::Dot => write!(f, "DOT"),
+            Token::Comma => write!(f, "COMMA"),
+            Token::Semicolon => write!(f, "SEMICOLON"),
+            Token::Colon => write!(f, "COLON"),
+            Token::Cast => write!(f, "CAST"),
         }
     }
 }
@@ -165,13 +165,17 @@ impl fmt::Display for TokenKind<'_> {
 pub struct Lexeme<'a> {
     pub extent: Extent,
     pub text: &'a str,
-    pub kind: TokenKind<'a>,
+    pub token: Token<'a>,
 }
 
 impl fmt::Display for Lexeme<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { extent, text, kind } = self;
-        write!(f, "{text:?} @ {extent} is {kind}")
+        let Self {
+            extent,
+            text,
+            token,
+        } = self;
+        write!(f, "{text:?} @ {extent} is {token}")
     }
 }
 

--- a/compiler/lexer/src/tokens.rs
+++ b/compiler/lexer/src/tokens.rs
@@ -1,5 +1,5 @@
+use core::fmt;
 use core::num::{ParseFloatError, ParseIntError};
-use core::{error, fmt};
 
 use common::{Extent, Integer, Real};
 
@@ -37,10 +37,10 @@ pub struct Identifier<'a> {
     pub name: &'a str,
 }
 
-#[derive(PartialEq, fmt::Debug, Clone, Copy)]
+#[derive(PartialEq, fmt::Debug, Clone)]
 pub enum Literal {
-    Real(Real),
-    Integer(Integer),
+    Real(Result<Real, ParseFloatError>),
+    Integer(Result<Integer, ParseIntError>),
     Bool(bool),
 }
 
@@ -54,33 +54,6 @@ pub enum BuiltinTypename {
 #[derive(PartialEq, Eq, Hash, fmt::Debug, Clone)]
 pub struct Comment<'a> {
     pub value: &'a str,
-}
-
-#[derive(PartialEq, Eq, fmt::Debug, Clone)]
-pub enum InvalidToken {
-    Unexpected(char),
-    MalformedInteger(ParseIntError),
-    MalformedReal(ParseFloatError),
-}
-
-impl error::Error for InvalidToken {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Unexpected(_) => None,
-            Self::MalformedInteger(e) => Some(e),
-            Self::MalformedReal(e) => Some(e),
-        }
-    }
-}
-
-impl fmt::Display for InvalidToken {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Unexpected(c) => write!(f, "Unexpected character: {c:?}"),
-            Self::MalformedInteger(e) => write!(f, "Malformed integer literal: {e}"),
-            Self::MalformedReal(e) => write!(f, "Malformed real literal: {e}"),
-        }
-    }
 }
 
 impl fmt::Display for Comment<'_> {
@@ -105,7 +78,7 @@ pub enum Token<'a> {
     BuiltinTypename(BuiltinTypename),
     Operator(Operator),
     Comment(Comment<'a>),
-    Invalid(InvalidToken),
+    Unexpected(char),
     LeftBracket,
     RightBracket,
     LeftParenthesis,
@@ -129,10 +102,10 @@ impl fmt::Display for Token<'_> {
         match self {
             Token::Identifier(Identifier { name }) => write!(f, "IDENTIFIER({name})"),
             Token::Keyword(keyword) => write!(f, "KEYWORD({keyword:?})"),
-            Token::Literal(Literal::Integer(value)) => {
+            Token::Literal(Literal::Integer(Ok(value))) => {
                 write!(f, "INTEGER LITERAL({value})")
             }
-            Token::Literal(Literal::Real(value)) => {
+            Token::Literal(Literal::Real(Ok(value))) => {
                 write!(f, "REAL LITERAL({value})")
             }
             Token::Literal(Literal::Bool(value)) => {
@@ -143,7 +116,13 @@ impl fmt::Display for Token<'_> {
             }
             Token::Operator(operator) => write!(f, "OPERATOR({operator:?})"),
             Token::Comment(comment) => write!(f, "COMMENT({comment})"),
-            Token::Invalid(problem) => write!(f, "INVALID({problem})"),
+            Token::Literal(Literal::Integer(Err(e))) => {
+                write!(f, "INVALID(Malformed integer literal: {e})")
+            }
+            Token::Literal(Literal::Real(Err(e))) => {
+                write!(f, "INVALID(Malformed real literal: {e})")
+            }
+            Token::Unexpected(c) => write!(f, "INVALID(Unexpected character: {c:?})"),
             Token::LeftBracket => write!(f, "LEFT BRACKET"),
             Token::RightBracket => write!(f, "RIGHT BRACKET"),
             Token::LeftParenthesis => write!(f, "LEFT PARENTHESIS"),

--- a/compiler/lexer/src/tokens.rs
+++ b/compiler/lexer/src/tokens.rs
@@ -162,20 +162,16 @@ impl fmt::Display for TokenKind<'_> {
 
 // Token description
 #[derive(Debug, Clone, PartialEq)]
-pub struct Token<'a> {
+pub struct Lexeme<'a> {
     pub extent: Extent,
-    pub lexeme: &'a str,
+    pub text: &'a str,
     pub kind: TokenKind<'a>,
 }
 
-impl fmt::Display for Token<'_> {
+impl fmt::Display for Lexeme<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self {
-            extent,
-            lexeme,
-            kind,
-        } = self;
-        write!(f, "{lexeme:?} @ {extent} is {kind}")
+        let Self { extent, text, kind } = self;
+        write!(f, "{text:?} @ {extent} is {kind}")
     }
 }
 

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 common.path = "../common"
 lexer.path = "../lexer"
+culpa.workspace = true
 derive-where.workspace = true
 
 [dev-dependencies]

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -1,19 +1,23 @@
-use core::fmt;
+use core::{fmt, ops::ControlFlow};
 use std::rc::Rc;
 
-use common::{Extent, LoopOrder, Position, RawIdentifier, Real};
+use culpa::throws;
+
+use common::{LoopOrder, Position, RawIdentifier};
 use lexer::{
-    BuiltinTypename, Identifier as TokenIdentifier, InvalidToken, Keyword, Lexeme,
-    Literal as TokenLiteral, Token,
+    BuiltinTypename, Identifier as TokenIdentifier, Keyword, Lexeme, Literal as TokenLiteral, Token,
 };
 
+mod parser;
 mod tree;
 mod types;
 
 #[cfg(test)]
 mod tests;
 
+use crate::parser::TokenKind;
 pub use crate::{
+    parser::Parser,
     tree::{
         Block, BlockElem, ConstDecl, Declaration, Expression, Literal, LvalueExpression, Operator,
         Program, RoutineBody, RoutineDecl, Statement, TypeDecl, VarDecl,
@@ -21,55 +25,8 @@ pub use crate::{
     types::{ArrayDescription, FieldDescription, RecordDescription, Type},
 };
 
-pub trait TokenIterator<'a, 'b: 'a>: Clone + Copy {
-    fn current(&self) -> Option<&'a Lexeme<'b>>;
-    fn position(&self) -> Position;
-    #[must_use]
-    fn next(&self) -> Self;
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct IndexedIterator<'a, 'b: 'a> {
-    underlying: &'a [Lexeme<'b>],
-    index: usize,
-    pos: Position,
-}
-
-impl<'a, 'b> From<&'a [Lexeme<'b>]> for IndexedIterator<'a, 'b> {
-    fn from(value: &'a [Lexeme<'b>]) -> Self {
-        IndexedIterator {
-            underlying: value,
-            index: 0,
-            pos: match value.first() {
-                Some(t) => t.extent.start,
-                None => Position { line: 0, column: 0 },
-            },
-        }
-    }
-}
-
-impl<'a, 'b> TokenIterator<'a, 'b> for IndexedIterator<'a, 'b> {
-    fn current(&self) -> Option<&'a Lexeme<'b>> {
-        self.underlying.get(self.index)
-    }
-
-    fn position(&self) -> Position {
-        self.pos
-    }
-
-    fn next(&self) -> Self {
-        IndexedIterator {
-            underlying: self.underlying,
-            index: self.index + 1,
-            pos: match self.underlying.get(self.index + 1) {
-                Some(t) => t.extent.start,
-                None => self.underlying[self.index].extent.end,
-            },
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[must_use]
 pub struct ParsingError {
     pub what: String,
     pub position: Position,
@@ -84,1164 +41,490 @@ impl fmt::Display for ParsingError {
 
 impl core::error::Error for ParsingError {}
 
-#[derive(Debug, Default)]
-pub struct Parser {
-    pub recovered_errors: Vec<ParsingError>,
-}
+type ParsingResult<T> = Result<T, ParsingError>;
 
-type ParsingResult<'a, 'b, T> = Result<(T, IndexedIterator<'a, 'b>), ParsingError>; // For hard errors
+const OPERATORS_PRECEDENCE_TABLE: &[&[Operator]] = &[
+    &[Operator::And, Operator::Or, Operator::Xor],
+    &[
+        Operator::Lt,
+        Operator::Le,
+        Operator::Ne,
+        Operator::Eq,
+        Operator::Gt,
+        Operator::Ge,
+    ],
+    &[Operator::Plus, Operator::Minus],
+    &[Operator::Mul, Operator::Div, Operator::Mod],
+];
 
-trait ParsingFunction<'a, 'b: 'a, T>:
-    FnMut(&mut Parser, IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, T>
-{
-}
+// For `#[throws]`
+use ParsingError as Error;
 
-impl<'a, 'b: 'a, T, F> ParsingFunction<'a, 'b, T> for F where
-    F: FnMut(&mut Parser, IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, T>
-{
-}
-
-impl Parser {
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
+    #[throws]
+    fn eat_identifier(&mut self) -> RawIdentifier {
+        let lexeme = self.eat_lexeme(TokenKind::Identifier)?;
+        let Token::Identifier(TokenIdentifier { name }) = lexeme.token else {
+            unreachable!("We ate `TokenKind::Identifier` but got {lexeme:?}")
+        };
+        RawIdentifier {
+            name: name.to_owned(),
+        }
     }
 
-    fn report_recovered(&mut self, reason: String, position: Position) {
-        self.recovered_errors.push(ParsingError {
-            what: reason,
-            position,
-        });
+    #[throws]
+    fn eat_literal(&mut self) -> Literal {
+        let lexeme = self.eat_lexeme(TokenKind::Literal)?;
+        let Token::Literal(literal) = lexeme.token else {
+            unreachable!("We ate `TokenKind::Literal` but got {lexeme:?}")
+        };
+        match literal {
+            TokenLiteral::Integer(value) => Literal::Integer {
+                value,
+                repr: lexeme.text.to_owned(),
+            },
+            TokenLiteral::Real(value) => Literal::Real {
+                value,
+                repr: lexeme.text.to_owned(),
+            },
+            TokenLiteral::Bool(value) => Literal::Bool { value },
+        }
     }
 
-    fn skip_unused<'a, 'b: 'a>(
+    #[throws]
+    fn parse_array_type(&mut self) -> ArrayDescription {
+        self.eat(Keyword::Array)?;
+        self.eat(Token::LeftBracket)?;
+        let length = if self.check(Token::RightBracket) {
+            None
+        } else {
+            Some(self.parse_expr()?)
+        };
+        self.eat(Token::RightBracket)?;
+        let t = self.parse_type()?;
+        ArrayDescription {
+            t: Box::new(t),
+            length,
+        }
+    }
+
+    #[throws]
+    fn parse_record_type(&mut self) -> RecordDescription {
+        self.eat(Keyword::Record)?;
+        let mut fields = vec![];
+        while !self.try_eat(Keyword::End) {
+            self.eat(Keyword::Var)?;
+            let name = self.eat_identifier()?;
+            self.eat(Keyword::Is)?;
+            let t = self.parse_type()?;
+            self.eat(Token::Semicolon)?;
+            fields.push(FieldDescription { name, t });
+        }
+        RecordDescription { fields }
+    }
+
+    #[throws]
+    fn parse_in_parens_comma_sep<T>(
         &mut self,
-        mut i: IndexedIterator<'a, 'b>,
-    ) -> IndexedIterator<'a, 'b> {
-        while let Some(token) = i.current() {
-            match token {
-                Lexeme {
-                    token: Token::Invalid(t @ InvalidToken::Unexpected(_)),
-                    extent: Extent { start, .. },
-                    ..
-                } => {
-                    self.report_recovered(t.to_string(), *start);
-                }
-                Lexeme {
-                    token: Token::Comment(_),
-                    ..
-                } => {}
-                _ => break,
+        parser: fn(&mut Self) -> ParsingResult<T>,
+    ) -> Vec<T> {
+        self.eat(Token::LeftParenthesis)?;
+        let mut result = vec![];
+        while !self.try_eat(Token::RightParenthesis) {
+            result.push(parser(self)?);
+            if self.try_eat(Token::RightParenthesis) {
+                break;
             }
-
-            i = i.next();
+            self.eat(Token::Comma)?;
         }
-        i
+        result
     }
 
-    fn next<'a, 'b: 'a>(&mut self, i: IndexedIterator<'a, 'b>) -> IndexedIterator<'a, 'b> {
-        self.skip_unused(i.next())
-    }
-
-    // Parsing combinators
-
-    /// Parses with `parser` until it fails
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "Better composition with other APIs"
-    )]
-    fn parse_many<'a, 'b: 'a, T>(
-        &mut self,
-        mut parser: impl ParsingFunction<'a, 'b, T>,
-        mut i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Vec<T>> {
-        let mut result = Vec::new();
-
-        while let Ok((parsed, next)) = parser(self, i) {
-            result.push(parsed);
-            i = next;
+    #[throws]
+    fn parse_type(&mut self) -> Type {
+        if self.try_eat(BuiltinTypename::Integer) {
+            Type::Int
+        } else if self.try_eat(BuiltinTypename::Real) {
+            Type::Real
+        } else if self.try_eat(BuiltinTypename::Boolean) {
+            Type::Bool
+        } else if self.check(Keyword::Array) {
+            Type::Array(self.parse_array_type()?)
+        } else if self.check(Keyword::Record) {
+            Type::Record(self.parse_record_type()?)
+        } else {
+            Type::Alias(self.eat_identifier()?)
         }
-
-        Ok((result, i))
     }
 
-    /// Parses with `parser` till the end
-    fn parse_all<'a, 'b: 'a, T>(
-        &mut self,
-        mut parser: impl ParsingFunction<'a, 'b, T>,
-        mut i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Vec<T>> {
-        let mut result = Vec::new();
-
-        while i.current().is_some() {
-            let (parsed, next) = parser(self, i)?;
-            result.push(parsed);
-            i = next;
+    #[throws]
+    fn parse_colon_type(&mut self) -> Option<Type> {
+        if self.try_eat(Token::Colon) {
+            Some(self.parse_type()?)
+        } else {
+            None
         }
-
-        Ok((result, i))
     }
 
-    /// Parses one of two alternatives
-    fn parse_one_of<'a, 'b: 'a, T>(
-        &mut self,
-        mut l: impl ParsingFunction<'a, 'b, T>,
-        mut r: impl ParsingFunction<'a, 'b, T>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, T> {
-        l(self, i).or_else(|first_err| {
-            r(self, i).map_err(|second_err| ParsingError {
-                what: format!(
-                    "Following parses failed\n{}\n{}",
-                    first_err.what, second_err.what
-                ),
-                position: first_err.position,
-            })
+    #[throws]
+    fn parse_var_decl(&mut self) -> VarDecl {
+        self.eat(Keyword::Var)?;
+        let name = self.eat_identifier()?;
+        let t = self.parse_colon_type()?;
+        let initialiser = if self.try_eat(Keyword::Is) {
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+        self.eat(Token::Semicolon)?;
+        VarDecl {
+            name,
+            t,
+            initialiser,
+        }
+    }
+
+    #[throws]
+    fn parse_const_decl(&mut self) -> ConstDecl {
+        self.eat(Keyword::Constant)?;
+        let name = self.eat_identifier()?;
+        let t = self.parse_colon_type()?;
+        self.eat(Keyword::Is)?;
+        let initialiser = self.parse_expr()?;
+        self.eat(Token::Semicolon)?;
+        ConstDecl {
+            name,
+            t,
+            initialiser,
+        }
+    }
+
+    #[throws]
+    fn parse_type_decl(&mut self) -> TypeDecl {
+        self.eat(Keyword::Type)?;
+        let name = self.eat_identifier()?;
+        self.eat(Keyword::Is)?;
+        let t = self.parse_type()?;
+        self.eat(Token::Semicolon)?;
+        TypeDecl { name, t }
+    }
+
+    #[throws]
+    fn parse_lvalue(&mut self, ident: RawIdentifier) -> Rc<LvalueExpression> {
+        let mut lhs = Rc::new(LvalueExpression::Identifier(ident));
+        loop {
+            if self.try_eat(Token::Dot) {
+                let member_name = self.eat_identifier()?;
+                lhs = Rc::new(LvalueExpression::Member { lhs, member_name });
+            } else if self.try_eat(Token::LeftBracket) {
+                let index = self.parse_expr()?;
+                self.eat(Token::RightBracket)?;
+                lhs = Rc::new(LvalueExpression::Index { lhs, index });
+            } else {
+                break lhs;
+            }
+        }
+    }
+
+    #[throws]
+    fn parse_new(&mut self) -> Rc<Expression> {
+        self.eat(Keyword::New)?;
+        let array_length = if self.try_eat(Token::LeftBracket) {
+            let len = self.parse_expr()?;
+            self.eat(Token::RightBracket)?;
+            Some(len)
+        } else {
+            None
+        };
+        let t = self.parse_type()?;
+        let fields = if self.try_eat(Keyword::Where) {
+            let mut fields = vec![];
+            while !self.try_eat(Keyword::End) {
+                let name = self.eat_identifier()?;
+                self.eat(Keyword::Is)?;
+                let init = self.parse_expr()?;
+                self.eat(Token::Semicolon)?;
+                fields.push((name, init));
+            }
+            Some(fields)
+        } else {
+            None
+        };
+        Rc::new(Expression::New {
+            t,
+            fields,
+            array_length,
         })
     }
 
-    /// Parses with `parser`, parses with `right` and drops latter value
-    fn parse_before<'a, 'b: 'a, T>(
-        &mut self,
-        mut parser: impl ParsingFunction<'a, 'b, T>,
-        mut right: impl ParsingFunction<'a, 'b, ()>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, T> {
-        let (res, next) = parser(self, i)?;
-        let ((), next) = right(self, next)?;
-        Ok((res, next))
+    #[throws]
+    fn try_parse_unop(&mut self, op: Operator) -> Option<Expression> {
+        if self.try_eat(op) {
+            Some(Expression::UnOp {
+                op,
+                operand: self.parse_atom()?,
+            })
+        } else {
+            None
+        }
     }
 
-    ///  parses with `left`, parses with `parser` and drops former value
-    fn parse_after<'a, 'b: 'a, T>(
-        &mut self,
-        mut left: impl ParsingFunction<'a, 'b, ()>,
-        mut parser: impl ParsingFunction<'a, 'b, T>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, T> {
-        let ((), next) = left(self, i)?;
-        parser(self, next)
-    }
-
-    /// parse_after and parse_before combined
-    fn parse_between<'a, 'b: 'a, T>(
-        &mut self,
-        mut left: impl ParsingFunction<'a, 'b, ()>,
-        mut parser: impl ParsingFunction<'a, 'b, T>,
-        mut right: impl ParsingFunction<'a, 'b, ()>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, T> {
-        let ((), next) = left(self, i)?;
-        let (res, next) = parser(self, next)?;
-        let ((), next) = right(self, next)?;
-        Ok((res, next))
-    }
-
-    /// Parses with `parser`, successfully return None on failure
-    fn try_parse<'a, 'b: 'a, T>(
-        &mut self,
-        mut parser: impl ParsingFunction<'a, 'b, T>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Option<T>> {
-        parser(self, i)
-            .map(|(val, i)| (Some(val), i))
-            .or_else(|_| Ok((None, i)))
-    }
-
-    /// Parse a list of `parser` values, separated by `sep`
-    fn parse_many_sep_by<'a, 'b: 'a, T>(
-        &mut self,
-        mut parser: impl ParsingFunction<'a, 'b, T>,
-        mut sep: impl ParsingFunction<'a, 'b, ()>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Vec<T>> {
-        let mut result = Vec::new();
-
-        let Ok((first_parsed, rest)) = parser(self, i) else {
-            return Ok((Vec::new(), i));
+    #[throws]
+    fn parse_atom(&mut self) -> Rc<Expression> {
+        let mut result = if self.try_eat(Token::LeftParenthesis) {
+            let res = self.parse_expr()?;
+            self.eat(Token::RightParenthesis)?;
+            res
+        } else if self.try_eat(Keyword::Null) {
+            Rc::new(Expression::Null)
+        } else if self.check(Keyword::New) {
+            self.parse_new()?
+        } else if self.check(TokenKind::Literal) {
+            Rc::new(Expression::Literal(self.eat_literal()?))
+        } else if let Some(unop) = self.try_parse_unop(Operator::Not)? {
+            Rc::new(unop)
+        } else if let Some(unop) = self.try_parse_unop(Operator::Minus)? {
+            Rc::new(unop)
+        } else {
+            let ident = self.eat_identifier()?;
+            Rc::new(if self.check(Token::LeftParenthesis) {
+                Expression::Call {
+                    callee: ident,
+                    args: self.parse_in_parens_comma_sep(Self::parse_expr)?,
+                }
+            } else {
+                Expression::LvalueToRvalue(self.parse_lvalue(ident)?)
+            })
         };
 
-        result.push(first_parsed);
-
-        let mut next = rest;
-
-        while let Ok(((), rest)) = sep(self, next) {
-            next = rest;
-            let (elem, rest) = parser(self, next)?;
-            next = rest;
-            result.push(elem);
+        while self.try_eat(Token::Cast) {
+            let ty = self.parse_type()?;
+            result = Rc::new(Expression::Cast {
+                operand: result,
+                target: ty,
+            })
         }
-
-        Ok((result, next))
+        result
     }
 
-    // / Parsers `l`, `rep`, `r`, drops the values in centre
-    fn parse_def<'a, 'b: 'a, T, U>(
-        &mut self,
-        mut l: impl ParsingFunction<'a, 'b, T>,
-        mut rep: impl ParsingFunction<'a, 'b, ()>,
-        mut r: impl ParsingFunction<'a, 'b, U>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, (T, U)> {
-        let (lhs, next) = l(self, i)?;
-        let ((), next) = rep(self, next)?;
-        let (rhs, end) = r(self, next)?;
-        Ok(((lhs, rhs), end))
-    }
-
-    // Parsers for primitives
-
-    fn parse_identifier<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, RawIdentifier> {
-        match i.current() {
-            Some(&Lexeme {
-                token: Token::Identifier(TokenIdentifier { name }),
-                ..
-            }) => Ok((
-                RawIdentifier {
-                    name: name.to_owned(),
-                },
-                self.next(i),
-            )),
-            Some(token) => Err(ParsingError {
-                what: format!("Identifier expected, {token} found"),
-                position: i.position(),
-            }),
-            None => Err(ParsingError {
-                what: "Identifier expected, EOF found".to_owned(),
-                position: i.position(),
-            }),
-        }
-    }
-
-    fn parse_literal<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Literal> {
-        match i.current() {
-            Some(&Lexeme {
-                token: Token::Literal(TokenLiteral::Real(value)),
-                text,
-                ..
-            }) => Ok((
-                Literal::Real {
-                    repr: text.to_owned(),
-                    value,
-                },
-                self.next(i),
-            )),
-
-            Some(&Lexeme {
-                token: Token::Invalid(ref t @ InvalidToken::MalformedReal(_)),
-                extent: Extent { start, .. },
-                text,
-            }) => {
-                self.recovered_errors.push(ParsingError {
-                    position: start,
-                    what: t.to_string(),
-                });
-
-                Ok((
-                    Literal::Real {
-                        repr: text.to_owned(),
-                        value: Real::NAN,
-                    },
-                    self.next(i),
-                ))
-            }
-
-            Some(&Lexeme {
-                token: Token::Literal(TokenLiteral::Integer(value)),
-                text,
-                ..
-            }) => Ok((
-                Literal::Integer {
-                    repr: text.to_owned(),
-                    value,
-                },
-                self.next(i),
-            )),
-
-            Some(&Lexeme {
-                token: Token::Invalid(ref t @ InvalidToken::MalformedInteger(_)),
-                extent: Extent { start, .. },
-                text,
-            }) => {
-                self.recovered_errors.push(ParsingError {
-                    position: start,
-                    what: t.to_string(),
-                });
-                Ok((
-                    Literal::Integer {
-                        repr: text.to_owned(),
-                        value: 0,
-                    },
-                    self.next(i),
-                ))
-            }
-
-            Some(&Lexeme {
-                token: Token::Literal(TokenLiteral::Bool(value)),
-                ..
-            }) => Ok((Literal::Bool { value }, self.next(i))),
-
-            Some(token) => Err(ParsingError {
-                what: format!("Literal expected, {token} found"),
-                position: i.position(),
-            }),
-            None => Err(ParsingError {
-                what: "Literal expected, EOF found".to_owned(),
-                position: i.position(),
-            }),
-        }
-    }
-
-    fn parse_known_kind<'a, 'b: 'a>(
-        &mut self,
-        expected_kind: &Token<'a>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        match i.current() {
-            Some(Lexeme { token: kind, .. }) if kind == expected_kind => Ok(((), self.next(i))),
-            Some(token) => Err(ParsingError {
-                what: format!("Token of kind {expected_kind} expected, token {token} found"),
-                position: token.extent.start,
-            }),
-            None => Err(ParsingError {
-                what: format!("Token of kind {expected_kind} expected, token EOF found"),
-                position: i.position(),
-            }),
-        }
-    }
-
-    fn parse_keyword<'a, 'b: 'a>(
-        &mut self,
-        keyword: Keyword,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::Keyword(keyword), i)
-    }
-
-    fn parse_semicolon<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::Semicolon, i)
-    }
-
-    fn parse_assn<'a, 'b: 'a>(&mut self, i: IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::Assignment, i)
-    }
-
-    fn parse_comma<'a, 'b: 'a>(&mut self, i: IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::Comma, i)
-    }
-
-    fn parse_colon<'a, 'b: 'a>(&mut self, i: IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::Colon, i)
-    }
-
-    fn parse_kw_end<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_keyword(Keyword::End, i)
-    }
-
-    fn parse_kw_loop<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_keyword(Keyword::Loop, i)
-    }
-
-    fn parse_kw_where<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_keyword(Keyword::Where, i)
-    }
-
-    fn parse_kw_is<'a, 'b: 'a>(&mut self, i: IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, ()> {
-        self.parse_keyword(Keyword::Is, i)
-    }
-
-    fn parse_left_bracket<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::LeftBracket, i)
-    }
-
-    fn parse_right_bracket<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::RightBracket, i)
-    }
-
-    fn parse_in_brackets<'a, 'b: 'a, T>(
-        &mut self,
-        parser: impl ParsingFunction<'a, 'b, T>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, T> {
-        self.parse_between(
-            Self::parse_left_bracket,
-            parser,
-            Self::parse_right_bracket,
-            i,
-        )
-    }
-
-    fn parse_left_parenthesis<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::LeftParenthesis, i)
-    }
-
-    fn parse_right_parenthesis<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&Token::RightParenthesis, i)
-    }
-
-    fn parse_in_parentheses<'a, 'b: 'a, T>(
-        &mut self,
-        parser: impl ParsingFunction<'a, 'b, T>,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, T> {
-        self.parse_between(
-            Self::parse_left_parenthesis,
-            parser,
-            Self::parse_right_parenthesis,
-            i,
-        )
-    }
-
-    fn parse_field_description<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, FieldDescription> {
-        let ((), next) = self.parse_keyword(Keyword::Var, i)?;
-        let (ident, next) = self.parse_identifier(next)?;
-        let ((), next) = self.parse_kw_is(next)?;
-        let (t, next) = self.parse_type(next)?;
-
-        Ok((FieldDescription { name: ident, t }, next))
-    }
-
-    fn parse_record_desc<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, RecordDescription> {
-        let ((), next) = self.parse_keyword(Keyword::Record, i)?;
-        let (fields, next) = self.parse_many(
-            |ctx, i| ctx.parse_before(Self::parse_field_description, Self::parse_semicolon, i),
-            next,
-        )?;
-
-        let ((), next) = self.parse_keyword(Keyword::End, next)?;
-        Ok((RecordDescription { fields }, next))
-    }
-
-    fn parse_array_desc<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ArrayDescription> {
-        let ((), next) = self.parse_keyword(Keyword::Array, i)?;
-        let (length, next) =
-            self.parse_in_brackets(|ctx, i| ctx.try_parse(Self::parse_expr, i), next)?;
-        self.parse_type(next).map(|(element_type, next)| {
-            (
-                ArrayDescription {
-                    length,
-                    t: element_type.into(),
-                },
-                next,
-            )
-        })
-    }
-
-    fn parse_type<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Type> {
-        self.parse_identifier(i)
-            .map(|(ident, next)| (Type::Alias(ident), next))
-            .or_else(|_| {
-                self.parse_known_kind(&Token::BuiltinTypename(BuiltinTypename::Real), i)
-                    .map(|((), next)| (Type::Real, next))
-            })
-            .or_else(|_| {
-                self.parse_known_kind(&Token::BuiltinTypename(BuiltinTypename::Integer), i)
-                    .map(|((), next)| (Type::Int, next))
-            })
-            .or_else(|_| {
-                self.parse_known_kind(&Token::BuiltinTypename(BuiltinTypename::Boolean), i)
-                    .map(|((), next)| (Type::Bool, next))
-            })
-            .or_else(|_| {
-                self.parse_array_desc(i)
-                    .map(|(arr_desc, i)| (Type::Array(arr_desc), i))
-            })
-            .or_else(|_| {
-                self.parse_record_desc(i)
-                    .map(|(rec_desc, i)| (Type::Record(rec_desc), i))
-            })
-            .map_err(|_err| ParsingError {
-                what: "Type expected, but not found".to_owned(),
-                position: i.position(),
-            })
-    }
-
-    fn parse_operators<'a, 'b: 'a>(
-        &mut self,
-        mut ops: impl Iterator<Item = &'static [Operator]> + Clone,
-        mut atom: impl ParsingFunction<'a, 'b, Rc<Expression>> + Clone,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Rc<Expression>> {
-        match ops.next() {
-            Some(operators) => {
-                let (mut head, mut next) = self.parse_operators(ops.clone(), atom.clone(), i)?;
-                while let Some(Lexeme {
-                    token: Token::Operator(op),
-                    ..
-                }) = next.current()
-                    && operators.contains(op)
-                {
-                    next = self.next(next);
-                    let (rhs, rest) = self.parse_operators(ops.clone(), atom.clone(), next)?;
-                    next = rest;
-                    head = Rc::new(Expression::BinOp {
-                        op: *op,
-                        lhs: head,
-                        rhs,
-                    });
+    #[throws]
+    fn parse_binops(&mut self, operators: &[&[Operator]]) -> Rc<Expression> {
+        let Some((operators, rest)) = operators.split_first() else {
+            return self.parse_atom()?;
+        };
+        let mut lhs = self.parse_binops(rest)?;
+        'level: loop {
+            for op in operators.iter().copied() {
+                if self.try_eat(op) {
+                    let rhs = self.parse_binops(rest)?;
+                    lhs = Rc::new(Expression::BinOp { op, lhs, rhs });
+                    continue 'level;
                 }
-
-                Ok((head, next))
             }
-            None => atom(self, i),
+            break;
         }
+        lhs
     }
 
-    fn parse_lvalue_expr<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Rc<LvalueExpression>> {
-        let (ident, next) = self.parse_identifier(i)?;
-        let mut next = next;
+    #[throws]
+    pub fn parse_expr(&mut self) -> Rc<Expression> {
+        self.parse_binops(OPERATORS_PRECEDENCE_TABLE)?
+    }
 
-        let mut result = Rc::new(LvalueExpression::Identifier(ident));
-
-        loop {
-            match next.current() {
-                Some(Lexeme {
-                    token: Token::Dot, ..
-                }) => {
-                    next = self.next(next);
-                    let (field_name, rest) = self.parse_identifier(next)?;
-                    result = Rc::new(LvalueExpression::Member {
-                        lhs: result,
-                        member_name: field_name,
-                    });
-                    next = rest;
-                }
-                Some(Lexeme {
-                    token: Token::LeftBracket,
-                    ..
-                }) => {
-                    let (index, rest) = self.parse_in_brackets(Self::parse_expr, next)?;
-                    result = Rc::new(LvalueExpression::Index { lhs: result, index });
-                    next = rest;
-                }
-                _ => break,
+    #[throws]
+    fn parse_if(&mut self) -> Statement {
+        self.eat(Keyword::If)?;
+        let condition = self.parse_expr()?;
+        self.eat(Keyword::Then)?;
+        let (on_true, found_else) = self.parse_block_until(|this| {
+            if this.try_eat(Keyword::Else) {
+                ControlFlow::Break(true)
+            } else if this.try_eat(Keyword::End) {
+                ControlFlow::Break(false)
+            } else {
+                ControlFlow::Continue(())
             }
-        }
-
-        Ok((result, next))
-    }
-
-    fn parse_unop<'a, 'b: 'a>(
-        &mut self,
-        op: Operator,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Rc<Expression>> {
-        self.parse_after(
-            |ctx, i| ctx.parse_known_kind(&Token::Operator(op), i),
-            Self::parse_atom,
-            i,
-        )
-        .map(|(atom, i)| (Rc::new(Expression::UnOp { op, operand: atom }), i))
-    }
-
-    fn parse_new<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Rc<Expression>> {
-        self.parse_after(
-            |ctx, i| ctx.parse_keyword(Keyword::New, i),
-            |ctx, i| {
-                let (array_length, i) =
-                    ctx.try_parse(|ctx, i| ctx.parse_in_brackets(Self::parse_expr, i), i)?;
-                let (t, next) = ctx.parse_type(i)?;
-                let (fields, next) = ctx.try_parse(
-                    |ctx, i| {
-                        ctx.parse_between(
-                            Self::parse_kw_where,
-                            |ctx, i| {
-                                ctx.parse_many(
-                                    |ctx, i| {
-                                        ctx.parse_before(
-                                            |ctx, i| {
-                                                ctx.parse_def(
-                                                    Self::parse_identifier,
-                                                    Self::parse_kw_is,
-                                                    Self::parse_expr,
-                                                    i,
-                                                )
-                                            },
-                                            Self::parse_semicolon,
-                                            i,
-                                        )
-                                    },
-                                    i,
-                                )
-                            },
-                            Self::parse_kw_end,
-                            i,
-                        )
-                    },
-                    next,
-                )?;
-
-                Ok((
-                    Rc::new(Expression::New {
-                        t,
-                        fields,
-                        array_length,
-                    }),
-                    next,
-                ))
-            },
-            i,
-        )
-    }
-
-    fn parse_call<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Rc<Expression>> {
-        let (callee, next) = self.parse_identifier(i)?;
-        let (args, next) = self.parse_in_parentheses(
-            |ctx, i| ctx.parse_many_sep_by(Self::parse_expr, Self::parse_comma, i),
-            next,
-        )?;
-
-        Ok((Rc::new(Expression::Call { callee, args }), next))
-    }
-
-    fn parse_atom<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Rc<Expression>> {
-        // TODO: replace `.or_else()`-es with `match i.current()` or `if/else` for better error handling
-        let (mut head, mut next) = self
-            .parse_call(i)
-            .or_else(|_| {
-                self.parse_keyword(Keyword::Null, i)
-                    .map(|((), next)| (Rc::new(Expression::Null), next))
-            })
-            .or_else(|_| {
-                self.parse_literal(i)
-                    .map(|(literal, next)| (Rc::new(Expression::Literal(literal)), next))
-            })
-            .or_else(|_| self.parse_unop(Operator::Not, i))
-            .or_else(|_| self.parse_unop(Operator::Minus, i))
-            .or_else(|_| self.parse_new(i))
-            .or_else(|_| self.parse_in_parentheses(Self::parse_expr, i))
-            .or_else(|_| {
-                self.parse_lvalue_expr(i)
-                    .map(|(lvalue, next)| (Rc::new(Expression::LvalueToRvalue(lvalue)), next))
-            })?;
-
-        while let Some(Lexeme {
-            token: Token::Cast, ..
-        }) = next.current()
-        {
-            next = self.next(next);
-            let (t, rest) = self.parse_type(next)?;
-            head = Rc::new(Expression::Cast {
-                operand: head,
-                target: t,
-            });
-            next = rest;
-        }
-
-        Ok((head, next))
-    }
-
-    pub fn parse_expr<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Rc<Expression>> {
-        const OPERATORS_PRECEDENCE_TABLE: &[&[Operator]] = &[
-            &[Operator::And, Operator::Or, Operator::Xor],
-            &[
-                Operator::Lt,
-                Operator::Le,
-                Operator::Ne,
-                Operator::Eq,
-                Operator::Gt,
-                Operator::Ge,
-            ],
-            &[Operator::Plus, Operator::Minus],
-            &[Operator::Mul, Operator::Div, Operator::Mod],
-        ];
-
-        self.parse_operators(
-            OPERATORS_PRECEDENCE_TABLE.iter().copied(),
-            Self::parse_atom,
-            i,
-        )
-    }
-
-    pub fn parse_var_decl<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, VarDecl> {
-        let ((), next) = self.parse_keyword(Keyword::Var, i)?;
-        let (name, next) = self.parse_identifier(next)?;
-        let (t, next) = self.try_parse(
-            |ctx, i| ctx.parse_after(Self::parse_colon, Self::parse_type, i),
-            next,
-        )?;
-        let (initialiser, next) = self.try_parse(
-            |ctx, i| ctx.parse_after(Self::parse_kw_is, Self::parse_expr, i),
-            next,
-        )?;
-        let ((), next) = self.parse_semicolon(next)?;
-
-        Ok((
-            VarDecl {
-                name,
-                t,
-                initialiser,
-            },
-            next,
-        ))
-    }
-
-    pub fn parse_const_decl<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, ConstDecl> {
-        let ((), next) = self.parse_keyword(Keyword::Constant, i)?;
-        let (name, next) = self.parse_identifier(next)?;
-        let (t, next) = self.try_parse(
-            |ctx, i: IndexedIterator<'_, '_>| {
-                ctx.parse_after(Self::parse_colon, Self::parse_type, i)
-            },
-            next,
-        )?;
-        let (initialiser, next) = self.parse_after(Self::parse_kw_is, Self::parse_expr, next)?;
-        let ((), next) = self.parse_semicolon(next)?;
-
-        Ok((
-            ConstDecl {
-                name,
-                t,
-                initialiser,
-            },
-            next,
-        ))
-    }
-
-    pub fn parse_type_decl<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, TypeDecl> {
-        let ((), next) = self.parse_keyword(Keyword::Type, i)?;
-        let (name, next) = self.parse_identifier(next)?;
-        let (t, next) = self.parse_after(Self::parse_kw_is, Self::parse_type, next)?;
-        let ((), next) = self.parse_semicolon(next)?;
-
-        Ok((TypeDecl { name, t }, next))
-    }
-
-    fn parse_assignment<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Statement> {
-        let (lhs, next) = self.parse_lvalue_expr(i)?;
-        let ((), next) = self.parse_assn(next)?;
-        let (rhs, next) = self.parse_expr(next)?;
-        let ((), next) = self.parse_semicolon(next)?;
-
-        Ok((Statement::Assignment { lhs, rhs }, next))
-    }
-    fn parse_if<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Statement> {
-        let next = self.next(i);
-        let (condition, next) = self.parse_expr(next)?;
-        let ((), next) = self.parse_keyword(Keyword::Then, next)?;
-        let (on_true, next) = self.parse_block(next)?;
-        let (on_false, next) = self.try_parse(
-            |ctx, i| {
-                ctx.parse_after(
-                    |ctx, i| ctx.parse_keyword(Keyword::Else, i),
-                    Self::parse_block,
-                    i,
-                )
-            },
-            next,
-        )?;
-
-        let ((), next) = self.parse_kw_end(next)?;
-
-        Ok((
-            Statement::If {
-                condition,
-                on_true,
-                on_false,
-            },
-            next,
-        ))
-    }
-
-    pub fn parse_statement<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Statement> {
-        match i.current() {
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::If),
-                ..
-            }) => self.parse_if(i),
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::While),
-                ..
-            }) => {
-                let next = self.next(i);
-                let (condition, next) = self.parse_expr(next)?;
-
-                let (body, next) = self.parse_between(
-                    Self::parse_kw_loop,
-                    Self::parse_block,
-                    Self::parse_kw_end,
-                    next,
-                )?;
-
-                Ok((Statement::While { condition, body }, next))
-            }
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Print),
-                ..
-            }) => {
-                let next = self.next(i);
-                let (expr, next) = self.parse_expr(next)?;
-                let ((), next) = self.parse_semicolon(next)?;
-
-                Ok((Statement::Print { value: expr }, next))
-            }
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Return),
-                ..
-            }) => {
-                let next = self.next(i);
-                let (expr, next) = self.parse_expr(next)?;
-                let ((), next) = self.parse_semicolon(next)?;
-
-                Ok((Statement::Return { value: expr }, next))
-            }
-            Some(&Lexeme {
-                token: Token::Keyword(Keyword::Panic),
-                extent: Extent { start: pos, end: _ },
-                text: _,
-            }) => {
-                let next = self.next(i);
-                let ((), next) = self.parse_semicolon(next)?;
-                Ok((Statement::Panic { pos }, next))
-            }
-
-            Some(&Lexeme {
-                token: Token::Keyword(Keyword::Assert),
-                extent: Extent { start: pos, end: _ },
-                text: _,
-            }) => {
-                let next = self.next(i);
-                let (value, next) = self.parse_expr(next)?;
-                let ((), next) = self.parse_semicolon(next)?;
-                Ok((Statement::Assert { value, pos }, next))
-            }
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::For),
-                ..
-            }) => {
-                let next = self.next(i);
-                let (counter, next) = self.parse_identifier(next)?;
-
-                let ((), next) = self.parse_keyword(Keyword::In, next)?;
-
-                let (from, next) = self.parse_expr(next)?;
-
-                let ((), next) = self.parse_known_kind(&Token::RangeSymbol, next)?;
-                let (to, next) = self.try_parse(Self::parse_expr, next)?;
-                let (order, next) =
-                    self.try_parse(|ctx, i| ctx.parse_keyword(Keyword::Reverse, i), next)?;
-
-                let order = order.map_or(LoopOrder::Direct, |()| LoopOrder::Reversed);
-
-                let (body, next) = self.parse_between(
-                    Self::parse_kw_loop,
-                    Self::parse_block,
-                    Self::parse_kw_end,
-                    next,
-                )?;
-
-                Ok((
-                    Statement::For {
-                        counter,
-                        from,
-                        to,
-                        order,
-                        body,
-                    },
-                    next,
-                ))
-            }
-
-            Some(Lexeme {
-                token: Token::Identifier(_),
-                ..
-            }) => self.parse_one_of(
-                Self::parse_assignment,
-                |ctx, i| {
-                    ctx.parse_before(Self::parse_call, Self::parse_semicolon, i)
-                        .map(|(call_expr, next)| (Statement::Expr(call_expr), next))
-                },
-                i,
-            ),
-
-            Some(token) => Err(ParsingError {
-                what: format!("Statement expected, {token} found"),
-                position: i.position(),
-            }),
-
-            None => Err(ParsingError {
-                what: "Statement expected, EOF found".to_owned(),
-                position: i.position(),
-            }),
-        }
-    }
-
-    pub fn parse_block_elem<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, BlockElem> {
-        match i.current() {
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Var),
-                ..
-            }) => self
-                .parse_var_decl(i)
-                .map(|(decl, next)| (BlockElem::VarDecl(decl), next)),
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Constant),
-                ..
-            }) => self
-                .parse_const_decl(i)
-                .map(|(decl, next)| (BlockElem::ConstDecl(decl), next)),
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Type),
-                ..
-            }) => self
-                .parse_type_decl(i)
-                .map(|(decl, next)| (BlockElem::TypeDecl(decl), next)),
-
-            Some(_) => self
-                .parse_statement(i)
-                .map(|(stmt, next)| (BlockElem::Stmt(stmt), next)),
-
-            None => Err(ParsingError {
-                what: "Statement or declaration expected, EOF found".to_owned(),
-                position: i.position(),
-            }),
-        }
-    }
-
-    pub fn parse_block<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Block> {
-        self.parse_many(Self::parse_block_elem, i)
-            .map(|(elems, next)| (Block(elems), next))
-    }
-
-    pub fn parse_routine_decl<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, RoutineDecl> {
-        let ((), next) = self.parse_keyword(Keyword::Routine, i)?;
-        let (name, next) = self.parse_identifier(next)?;
-
-        let (args, next) = self.parse_in_parentheses(
-            |ctx, i| {
-                ctx.parse_many_sep_by(
-                    |ctx, i| {
-                        ctx.parse_def(
-                            Self::parse_identifier,
-                            Self::parse_colon,
-                            Self::parse_type,
-                            i,
-                        )
-                    },
-                    Self::parse_comma,
-                    i,
-                )
-            },
-            next,
-        )?;
-
-        let (return_type, next) = self.try_parse(
-            |ctx, i| ctx.parse_after(Self::parse_colon, Self::parse_type, i),
-            next,
-        )?;
-
-        match next.current() {
-            Some(Lexeme {
-                token: Token::RightArrow,
-                ..
-            }) => {
-                let next = self.next(next);
-                let (expr, next) =
-                    self.parse_before(Self::parse_expr, Self::parse_semicolon, next)?;
-                Ok((
-                    RoutineDecl {
-                        name,
-                        arguments: args,
-                        return_type,
-                        body: Some(RoutineBody::Expression(expr)),
-                    },
-                    next,
-                ))
-            }
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Is),
-                ..
-            }) => {
-                let (body, next) = self.parse_between(
-                    Self::parse_kw_is,
-                    Self::parse_block,
-                    Self::parse_kw_end,
-                    next,
-                )?;
-
-                Ok((
-                    RoutineDecl {
-                        name,
-                        arguments: args,
-                        return_type,
-                        body: Some(RoutineBody::Block(body)),
-                    },
-                    next,
-                ))
-            }
-
-            Some(Lexeme {
-                token: Token::Semicolon,
-                ..
-            }) => Ok((
-                RoutineDecl {
-                    name,
-                    arguments: args,
-                    return_type,
-                    body: None,
-                },
-                self.next(next),
-            )),
-            Some(t) => Err(ParsingError {
-                what: format!("Function body or `;` expected, {t} found"),
-                position: next.position(),
-            }),
-            None => Err(ParsingError {
-                what: "Function body or `;` expected, EOF found".to_owned(),
-                position: next.position(),
-            }),
-        }
-    }
-
-    pub fn parse_declaration<'a, 'b: 'a>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, Declaration> {
-        match i.current() {
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Var),
-                ..
-            }) => self
-                .parse_var_decl(i)
-                .map(|(decl, next)| (Declaration::Var(decl), next)),
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Constant),
-                ..
-            }) => self
-                .parse_const_decl(i)
-                .map(|(decl, next)| (Declaration::Const(decl), next)),
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Type),
-                ..
-            }) => self
-                .parse_type_decl(i)
-                .map(|(decl, next)| (Declaration::Type(decl), next)),
-
-            Some(Lexeme {
-                token: Token::Keyword(Keyword::Routine),
-                ..
-            }) => self
-                .parse_routine_decl(i)
-                .map(|(decl, next)| (Declaration::Routine(decl), next)),
-
-            Some(t) => Err(ParsingError {
-                what: format!("Declaration expected, {t} found"),
-                position: i.position(),
-            }),
-            None => Err(ParsingError {
-                what: "Declaration expected, EOF found".to_owned(),
-                position: i.position(),
-            }),
-        }
-    }
-
-    pub fn finish<T>(self, parsed: T) -> ParserResult<T> {
-        let Self { recovered_errors } = self;
-        if recovered_errors.is_empty() {
-            Ok(parsed)
+        })?;
+        let on_false = if found_else {
+            Some(self.parse_block_until_kw(Keyword::End)?)
         } else {
-            Err(ParserError::Recoverable {
-                errors: recovered_errors,
-                parsed,
-            })
+            None
+        };
+        Statement::If {
+            condition,
+            on_true,
+            on_false,
         }
+    }
+
+    #[throws]
+    fn parse_loop(&mut self) -> Block {
+        self.eat(Keyword::Loop)?;
+        self.parse_block_until_kw(Keyword::End)?
+    }
+
+    #[throws]
+    fn parse_statement(&mut self) -> Statement {
+        if self.check(Keyword::If) {
+            self.parse_if()?
+        } else if self.try_eat(Keyword::While) {
+            let condition = self.parse_expr()?;
+            let body = self.parse_loop()?;
+            Statement::While { condition, body }
+        } else if self.try_eat(Keyword::For) {
+            let counter = self.eat_identifier()?;
+            self.eat(Keyword::In)?;
+
+            let from = self.parse_expr()?;
+            self.eat(Token::RangeSymbol)?;
+            let to = if self.check(Keyword::Loop) || self.check(Keyword::Reverse) {
+                None
+            } else {
+                Some(self.parse_expr()?)
+            };
+            let order = if self.try_eat(Keyword::Reverse) {
+                LoopOrder::Reversed
+            } else {
+                LoopOrder::Direct
+            };
+            let body = self.parse_loop()?;
+            Statement::For {
+                counter,
+                from,
+                to,
+                order,
+                body,
+            }
+        } else if self.try_eat(Keyword::Return) {
+            let value = self.parse_expr()?;
+            self.eat(Token::Semicolon)?;
+            Statement::Return { value }
+        } else if self.try_eat(Keyword::Print) {
+            let value = self.parse_expr()?;
+            self.eat(Token::Semicolon)?;
+            Statement::Print { value }
+        } else if let Some(Lexeme { extent, .. }) = self.try_eat_lexeme(Keyword::Panic) {
+            self.eat(Token::Semicolon)?;
+            Statement::Panic { pos: extent.start }
+        } else if let Some(Lexeme { extent, .. }) = self.try_eat_lexeme(Keyword::Assert) {
+            let value = self.parse_expr()?;
+            self.eat(Token::Semicolon)?;
+            Statement::Assert {
+                value,
+                pos: extent.start,
+            }
+        } else {
+            let ident = self.eat_identifier()?;
+            let stmt = if self.check(Token::LeftParenthesis) {
+                let args = self.parse_in_parens_comma_sep(Self::parse_expr)?;
+                Statement::Expr(Rc::new(Expression::Call {
+                    callee: ident,
+                    args,
+                }))
+            } else {
+                let lhs = self.parse_lvalue(ident)?;
+                self.eat(Token::Assignment)?;
+                let rhs = self.parse_expr()?;
+                Statement::Assignment { lhs, rhs }
+            };
+            self.eat(Token::Semicolon)?;
+            stmt
+        }
+    }
+
+    #[throws]
+    fn parse_block_elem(&mut self) -> BlockElem {
+        if self.check(Keyword::Var) {
+            BlockElem::VarDecl(self.parse_var_decl()?)
+        } else if self.check(Keyword::Constant) {
+            BlockElem::ConstDecl(self.parse_const_decl()?)
+        } else if self.check(Keyword::Type) {
+            BlockElem::TypeDecl(self.parse_type_decl()?)
+        } else {
+            BlockElem::Stmt(self.parse_statement()?)
+        }
+    }
+
+    #[throws]
+    fn parse_block_until<T>(
+        &mut self,
+        callback: impl Fn(&mut Self) -> ControlFlow<T>,
+    ) -> (Block, T) {
+        let mut elems = vec![];
+        loop {
+            match callback(self) {
+                ControlFlow::Continue(()) => elems.push(self.parse_block_elem()?),
+                ControlFlow::Break(t) => break (Block(elems), t),
+            }
+        }
+    }
+
+    #[throws]
+    fn parse_block_until_kw(&mut self, kw: Keyword) -> Block {
+        let (block, ()) = self.parse_block_until(|this| {
+            if this.try_eat(kw) {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })?;
+        block
+    }
+
+    #[throws]
+    fn parse_routine_decl(&mut self) -> RoutineDecl {
+        self.eat(Keyword::Routine)?;
+        let name = self.eat_identifier()?;
+        let arguments = self.parse_in_parens_comma_sep(|this| {
+            let name = this.eat_identifier()?;
+            this.eat(Token::Colon)?;
+            let ty = this.parse_type()?;
+            Ok((name, ty))
+        })?;
+        let return_type = self.parse_colon_type()?;
+        let body = if self.try_eat(Keyword::Is) {
+            Some(RoutineBody::Block(self.parse_block_until_kw(Keyword::End)?))
+        } else if self.try_eat(Token::RightArrow) {
+            let body = self.parse_expr()?;
+            self.eat(Token::Semicolon)?;
+            Some(RoutineBody::Expression(body))
+        } else {
+            self.eat(Token::Semicolon)?;
+            None
+        };
+        RoutineDecl {
+            name,
+            arguments,
+            return_type,
+            body,
+        }
+    }
+
+    #[throws]
+    fn parse_declaration(&mut self) -> Declaration {
+        if self.check(Keyword::Var) {
+            Declaration::Var(self.parse_var_decl()?)
+        } else if self.check(Keyword::Constant) {
+            Declaration::Const(self.parse_const_decl()?)
+        } else if self.check(Keyword::Type) {
+            Declaration::Type(self.parse_type_decl()?)
+        } else {
+            Declaration::Routine(self.parse_routine_decl()?)
+        }
+    }
+
+    #[throws]
+    pub fn parse_program(&mut self) -> Program {
+        let mut result = vec![];
+        while !self.eof() {
+            result.push(self.parse_declaration()?);
+        }
+        Program(result)
     }
 }
 
 #[derive(Debug)]
+#[must_use]
 pub enum ParserError<T> {
     Unrecoverable {
         error: ParsingError,
@@ -1277,10 +560,8 @@ impl<T: fmt::Debug> fmt::Display for ParserError<T> {
 
 impl<T: fmt::Debug> core::error::Error for ParserError<T> {}
 
-pub fn parse_program(tokens: &[Lexeme<'_>]) -> ParserResult<Program> {
-    let mut parser = Parser::new();
-    let start = parser.skip_unused(IndexedIterator::from(tokens));
-    let (decls, tail) = parser.parse_all(Parser::parse_declaration, start)?;
-    debug_assert_eq!(tail.current(), None, "EOF not reached during parsing");
-    parser.finish(Program(decls))
+pub fn parse_program(tokens: Vec<Lexeme<'_>>) -> ParserResult<Program> {
+    let mut parser = Parser::new(tokens.into_iter());
+    let program = parser.parse_program()?;
+    parser.finish(program)
 }

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -1,9 +1,9 @@
-use core::{fmt, ops::ControlFlow};
+use core::{error, fmt, ops::ControlFlow};
 use std::rc::Rc;
 
 use culpa::throws;
 
-use common::{LoopOrder, Position, RawIdentifier};
+use common::{Extent, LoopOrder, Position, RawIdentifier, Real};
 use lexer::{
     BuiltinTypename, Identifier as TokenIdentifier, Keyword, Lexeme, Literal as TokenLiteral, Token,
 };
@@ -39,7 +39,7 @@ impl fmt::Display for ParsingError {
     }
 }
 
-impl core::error::Error for ParsingError {}
+impl error::Error for ParsingError {}
 
 type ParsingResult<T> = Result<T, ParsingError>;
 
@@ -72,6 +72,27 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         }
     }
 
+    fn recover_invalid_literal<T, E>(
+        &mut self,
+        literal: Result<T, E>,
+        default: T,
+        extent: Extent,
+    ) -> T
+    where
+        E: error::Error,
+    {
+        match literal {
+            Ok(literal) => literal,
+            Err(error) => {
+                self.push_error(ParsingError {
+                    position: extent.start,
+                    what: format!("Malformed literal: {error}"),
+                });
+                default
+            }
+        }
+    }
+
     #[throws]
     fn eat_literal(&mut self) -> Literal {
         let lexeme = self.eat_lexeme(TokenKind::Literal)?;
@@ -80,11 +101,11 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         };
         match literal {
             TokenLiteral::Integer(value) => Literal::Integer {
-                value,
+                value: self.recover_invalid_literal(value, 0, lexeme.extent),
                 repr: lexeme.text.to_owned(),
             },
             TokenLiteral::Real(value) => Literal::Real {
-                value,
+                value: self.recover_invalid_literal(value, Real::NAN, lexeme.extent),
                 repr: lexeme.text.to_owned(),
             },
             TokenLiteral::Bool(value) => Literal::Bool { value },
@@ -558,7 +579,7 @@ impl<T: fmt::Debug> fmt::Display for ParserError<T> {
     }
 }
 
-impl<T: fmt::Debug> core::error::Error for ParserError<T> {}
+impl<T: fmt::Debug> error::Error for ParserError<T> {}
 
 pub fn parse_program(tokens: Vec<Lexeme<'_>>) -> ParserResult<Program> {
     let mut parser = Parser::new(tokens.into_iter());

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use common::{Extent, LoopOrder, Position, RawIdentifier, Real};
 use lexer::{
     BuiltinTypename, Identifier as TokenIdentifier, InvalidToken, Keyword, Lexeme,
-    Literal as TokenLiteral, TokenKind,
+    Literal as TokenLiteral, Token,
 };
 
 mod tree;
@@ -121,14 +121,14 @@ impl Parser {
         while let Some(token) = i.current() {
             match token {
                 Lexeme {
-                    kind: TokenKind::Invalid(t @ InvalidToken::Unexpected(_)),
+                    token: Token::Invalid(t @ InvalidToken::Unexpected(_)),
                     extent: Extent { start, .. },
                     ..
                 } => {
                     self.report_recovered(t.to_string(), *start);
                 }
                 Lexeme {
-                    kind: TokenKind::Comment(_),
+                    token: Token::Comment(_),
                     ..
                 } => {}
                 _ => break,
@@ -297,7 +297,7 @@ impl Parser {
     ) -> ParsingResult<'a, 'b, RawIdentifier> {
         match i.current() {
             Some(&Lexeme {
-                kind: TokenKind::Identifier(TokenIdentifier { name }),
+                token: Token::Identifier(TokenIdentifier { name }),
                 ..
             }) => Ok((
                 RawIdentifier {
@@ -322,7 +322,7 @@ impl Parser {
     ) -> ParsingResult<'a, 'b, Literal> {
         match i.current() {
             Some(&Lexeme {
-                kind: TokenKind::Literal(TokenLiteral::Real(value)),
+                token: Token::Literal(TokenLiteral::Real(value)),
                 text,
                 ..
             }) => Ok((
@@ -334,7 +334,7 @@ impl Parser {
             )),
 
             Some(&Lexeme {
-                kind: TokenKind::Invalid(ref t @ InvalidToken::MalformedReal(_)),
+                token: Token::Invalid(ref t @ InvalidToken::MalformedReal(_)),
                 extent: Extent { start, .. },
                 text,
             }) => {
@@ -353,7 +353,7 @@ impl Parser {
             }
 
             Some(&Lexeme {
-                kind: TokenKind::Literal(TokenLiteral::Integer(value)),
+                token: Token::Literal(TokenLiteral::Integer(value)),
                 text,
                 ..
             }) => Ok((
@@ -365,7 +365,7 @@ impl Parser {
             )),
 
             Some(&Lexeme {
-                kind: TokenKind::Invalid(ref t @ InvalidToken::MalformedInteger(_)),
+                token: Token::Invalid(ref t @ InvalidToken::MalformedInteger(_)),
                 extent: Extent { start, .. },
                 text,
             }) => {
@@ -383,7 +383,7 @@ impl Parser {
             }
 
             Some(&Lexeme {
-                kind: TokenKind::Literal(TokenLiteral::Bool(value)),
+                token: Token::Literal(TokenLiteral::Bool(value)),
                 ..
             }) => Ok((Literal::Bool { value }, self.next(i))),
 
@@ -400,11 +400,11 @@ impl Parser {
 
     fn parse_known_kind<'a, 'b: 'a>(
         &mut self,
-        expected_kind: &TokenKind<'a>,
+        expected_kind: &Token<'a>,
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, ()> {
         match i.current() {
-            Some(Lexeme { kind, .. }) if kind == expected_kind => Ok(((), self.next(i))),
+            Some(Lexeme { token: kind, .. }) if kind == expected_kind => Ok(((), self.next(i))),
             Some(token) => Err(ParsingError {
                 what: format!("Token of kind {expected_kind} expected, token {token} found"),
                 position: token.extent.start,
@@ -421,26 +421,26 @@ impl Parser {
         keyword: Keyword,
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::Keyword(keyword), i)
+        self.parse_known_kind(&Token::Keyword(keyword), i)
     }
 
     fn parse_semicolon<'a, 'b: 'a>(
         &mut self,
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::Semicolon, i)
+        self.parse_known_kind(&Token::Semicolon, i)
     }
 
     fn parse_assn<'a, 'b: 'a>(&mut self, i: IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::Assignment, i)
+        self.parse_known_kind(&Token::Assignment, i)
     }
 
     fn parse_comma<'a, 'b: 'a>(&mut self, i: IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::Comma, i)
+        self.parse_known_kind(&Token::Comma, i)
     }
 
     fn parse_colon<'a, 'b: 'a>(&mut self, i: IndexedIterator<'a, 'b>) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::Colon, i)
+        self.parse_known_kind(&Token::Colon, i)
     }
 
     fn parse_kw_end<'a, 'b: 'a>(
@@ -472,14 +472,14 @@ impl Parser {
         &mut self,
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::LeftBracket, i)
+        self.parse_known_kind(&Token::LeftBracket, i)
     }
 
     fn parse_right_bracket<'a, 'b: 'a>(
         &mut self,
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::RightBracket, i)
+        self.parse_known_kind(&Token::RightBracket, i)
     }
 
     fn parse_in_brackets<'a, 'b: 'a, T>(
@@ -499,14 +499,14 @@ impl Parser {
         &mut self,
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::LeftParenthesis, i)
+        self.parse_known_kind(&Token::LeftParenthesis, i)
     }
 
     fn parse_right_parenthesis<'a, 'b: 'a>(
         &mut self,
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, ()> {
-        self.parse_known_kind(&TokenKind::RightParenthesis, i)
+        self.parse_known_kind(&Token::RightParenthesis, i)
     }
 
     fn parse_in_parentheses<'a, 'b: 'a, T>(
@@ -573,15 +573,15 @@ impl Parser {
         self.parse_identifier(i)
             .map(|(ident, next)| (Type::Alias(ident), next))
             .or_else(|_| {
-                self.parse_known_kind(&TokenKind::BuiltinTypename(BuiltinTypename::Real), i)
+                self.parse_known_kind(&Token::BuiltinTypename(BuiltinTypename::Real), i)
                     .map(|((), next)| (Type::Real, next))
             })
             .or_else(|_| {
-                self.parse_known_kind(&TokenKind::BuiltinTypename(BuiltinTypename::Integer), i)
+                self.parse_known_kind(&Token::BuiltinTypename(BuiltinTypename::Integer), i)
                     .map(|((), next)| (Type::Int, next))
             })
             .or_else(|_| {
-                self.parse_known_kind(&TokenKind::BuiltinTypename(BuiltinTypename::Boolean), i)
+                self.parse_known_kind(&Token::BuiltinTypename(BuiltinTypename::Boolean), i)
                     .map(|((), next)| (Type::Bool, next))
             })
             .or_else(|_| {
@@ -608,7 +608,7 @@ impl Parser {
             Some(operators) => {
                 let (mut head, mut next) = self.parse_operators(ops.clone(), atom.clone(), i)?;
                 while let Some(Lexeme {
-                    kind: TokenKind::Operator(op),
+                    token: Token::Operator(op),
                     ..
                 }) = next.current()
                     && operators.contains(op)
@@ -641,8 +641,7 @@ impl Parser {
         loop {
             match next.current() {
                 Some(Lexeme {
-                    kind: TokenKind::Dot,
-                    ..
+                    token: Token::Dot, ..
                 }) => {
                     next = self.next(next);
                     let (field_name, rest) = self.parse_identifier(next)?;
@@ -653,7 +652,7 @@ impl Parser {
                     next = rest;
                 }
                 Some(Lexeme {
-                    kind: TokenKind::LeftBracket,
+                    token: Token::LeftBracket,
                     ..
                 }) => {
                     let (index, rest) = self.parse_in_brackets(Self::parse_expr, next)?;
@@ -673,7 +672,7 @@ impl Parser {
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, Rc<Expression>> {
         self.parse_after(
-            |ctx, i| ctx.parse_known_kind(&TokenKind::Operator(op), i),
+            |ctx, i| ctx.parse_known_kind(&Token::Operator(op), i),
             Self::parse_atom,
             i,
         )
@@ -771,8 +770,7 @@ impl Parser {
             })?;
 
         while let Some(Lexeme {
-            kind: TokenKind::Cast,
-            ..
+            token: Token::Cast, ..
         }) = next.current()
         {
             next = self.next(next);
@@ -923,12 +921,12 @@ impl Parser {
     ) -> ParsingResult<'a, 'b, Statement> {
         match i.current() {
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::If),
+                token: Token::Keyword(Keyword::If),
                 ..
             }) => self.parse_if(i),
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::While),
+                token: Token::Keyword(Keyword::While),
                 ..
             }) => {
                 let next = self.next(i);
@@ -945,7 +943,7 @@ impl Parser {
             }
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Print),
+                token: Token::Keyword(Keyword::Print),
                 ..
             }) => {
                 let next = self.next(i);
@@ -956,7 +954,7 @@ impl Parser {
             }
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Return),
+                token: Token::Keyword(Keyword::Return),
                 ..
             }) => {
                 let next = self.next(i);
@@ -966,7 +964,7 @@ impl Parser {
                 Ok((Statement::Return { value: expr }, next))
             }
             Some(&Lexeme {
-                kind: TokenKind::Keyword(Keyword::Panic),
+                token: Token::Keyword(Keyword::Panic),
                 extent: Extent { start: pos, end: _ },
                 text: _,
             }) => {
@@ -976,7 +974,7 @@ impl Parser {
             }
 
             Some(&Lexeme {
-                kind: TokenKind::Keyword(Keyword::Assert),
+                token: Token::Keyword(Keyword::Assert),
                 extent: Extent { start: pos, end: _ },
                 text: _,
             }) => {
@@ -987,7 +985,7 @@ impl Parser {
             }
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::For),
+                token: Token::Keyword(Keyword::For),
                 ..
             }) => {
                 let next = self.next(i);
@@ -997,7 +995,7 @@ impl Parser {
 
                 let (from, next) = self.parse_expr(next)?;
 
-                let ((), next) = self.parse_known_kind(&TokenKind::RangeSymbol, next)?;
+                let ((), next) = self.parse_known_kind(&Token::RangeSymbol, next)?;
                 let (to, next) = self.try_parse(Self::parse_expr, next)?;
                 let (order, next) =
                     self.try_parse(|ctx, i| ctx.parse_keyword(Keyword::Reverse, i), next)?;
@@ -1024,7 +1022,7 @@ impl Parser {
             }
 
             Some(Lexeme {
-                kind: TokenKind::Identifier(_),
+                token: Token::Identifier(_),
                 ..
             }) => self.parse_one_of(
                 Self::parse_assignment,
@@ -1053,21 +1051,21 @@ impl Parser {
     ) -> ParsingResult<'a, 'b, BlockElem> {
         match i.current() {
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Var),
+                token: Token::Keyword(Keyword::Var),
                 ..
             }) => self
                 .parse_var_decl(i)
                 .map(|(decl, next)| (BlockElem::VarDecl(decl), next)),
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Constant),
+                token: Token::Keyword(Keyword::Constant),
                 ..
             }) => self
                 .parse_const_decl(i)
                 .map(|(decl, next)| (BlockElem::ConstDecl(decl), next)),
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Type),
+                token: Token::Keyword(Keyword::Type),
                 ..
             }) => self
                 .parse_type_decl(i)
@@ -1124,7 +1122,7 @@ impl Parser {
 
         match next.current() {
             Some(Lexeme {
-                kind: TokenKind::RightArrow,
+                token: Token::RightArrow,
                 ..
             }) => {
                 let next = self.next(next);
@@ -1142,7 +1140,7 @@ impl Parser {
             }
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Is),
+                token: Token::Keyword(Keyword::Is),
                 ..
             }) => {
                 let (body, next) = self.parse_between(
@@ -1164,7 +1162,7 @@ impl Parser {
             }
 
             Some(Lexeme {
-                kind: TokenKind::Semicolon,
+                token: Token::Semicolon,
                 ..
             }) => Ok((
                 RoutineDecl {
@@ -1192,28 +1190,28 @@ impl Parser {
     ) -> ParsingResult<'a, 'b, Declaration> {
         match i.current() {
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Var),
+                token: Token::Keyword(Keyword::Var),
                 ..
             }) => self
                 .parse_var_decl(i)
                 .map(|(decl, next)| (Declaration::Var(decl), next)),
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Constant),
+                token: Token::Keyword(Keyword::Constant),
                 ..
             }) => self
                 .parse_const_decl(i)
                 .map(|(decl, next)| (Declaration::Const(decl), next)),
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Type),
+                token: Token::Keyword(Keyword::Type),
                 ..
             }) => self
                 .parse_type_decl(i)
                 .map(|(decl, next)| (Declaration::Type(decl), next)),
 
             Some(Lexeme {
-                kind: TokenKind::Keyword(Keyword::Routine),
+                token: Token::Keyword(Keyword::Routine),
                 ..
             }) => self
                 .parse_routine_decl(i)

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -3,8 +3,8 @@ use std::rc::Rc;
 
 use common::{Extent, LoopOrder, Position, RawIdentifier, Real};
 use lexer::{
-    BuiltinTypename, Identifier as TokenIdentifier, InvalidToken, Keyword, Literal as TokenLiteral,
-    Token, TokenKind,
+    BuiltinTypename, Identifier as TokenIdentifier, InvalidToken, Keyword, Lexeme,
+    Literal as TokenLiteral, TokenKind,
 };
 
 mod tree;
@@ -22,7 +22,7 @@ pub use crate::{
 };
 
 pub trait TokenIterator<'a, 'b: 'a>: Clone + Copy {
-    fn current(&self) -> Option<&'a Token<'b>>;
+    fn current(&self) -> Option<&'a Lexeme<'b>>;
     fn position(&self) -> Position;
     #[must_use]
     fn next(&self) -> Self;
@@ -30,13 +30,13 @@ pub trait TokenIterator<'a, 'b: 'a>: Clone + Copy {
 
 #[derive(Clone, Copy, Debug)]
 pub struct IndexedIterator<'a, 'b: 'a> {
-    underlying: &'a [Token<'b>],
+    underlying: &'a [Lexeme<'b>],
     index: usize,
     pos: Position,
 }
 
-impl<'a, 'b> From<&'a [Token<'b>]> for IndexedIterator<'a, 'b> {
-    fn from(value: &'a [Token<'b>]) -> Self {
+impl<'a, 'b> From<&'a [Lexeme<'b>]> for IndexedIterator<'a, 'b> {
+    fn from(value: &'a [Lexeme<'b>]) -> Self {
         IndexedIterator {
             underlying: value,
             index: 0,
@@ -49,7 +49,7 @@ impl<'a, 'b> From<&'a [Token<'b>]> for IndexedIterator<'a, 'b> {
 }
 
 impl<'a, 'b> TokenIterator<'a, 'b> for IndexedIterator<'a, 'b> {
-    fn current(&self) -> Option<&'a Token<'b>> {
+    fn current(&self) -> Option<&'a Lexeme<'b>> {
         self.underlying.get(self.index)
     }
 
@@ -120,14 +120,14 @@ impl Parser {
     ) -> IndexedIterator<'a, 'b> {
         while let Some(token) = i.current() {
             match token {
-                Token {
+                Lexeme {
                     kind: TokenKind::Invalid(t @ InvalidToken::Unexpected(_)),
                     extent: Extent { start, .. },
                     ..
                 } => {
                     self.report_recovered(t.to_string(), *start);
                 }
-                Token {
+                Lexeme {
                     kind: TokenKind::Comment(_),
                     ..
                 } => {}
@@ -296,7 +296,7 @@ impl Parser {
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, RawIdentifier> {
         match i.current() {
-            Some(&Token {
+            Some(&Lexeme {
                 kind: TokenKind::Identifier(TokenIdentifier { name }),
                 ..
             }) => Ok((
@@ -321,22 +321,22 @@ impl Parser {
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, Literal> {
         match i.current() {
-            Some(&Token {
+            Some(&Lexeme {
                 kind: TokenKind::Literal(TokenLiteral::Real(value)),
-                lexeme,
+                text,
                 ..
             }) => Ok((
                 Literal::Real {
-                    repr: lexeme.to_owned(),
+                    repr: text.to_owned(),
                     value,
                 },
                 self.next(i),
             )),
 
-            Some(&Token {
+            Some(&Lexeme {
                 kind: TokenKind::Invalid(ref t @ InvalidToken::MalformedReal(_)),
                 extent: Extent { start, .. },
-                lexeme,
+                text,
             }) => {
                 self.recovered_errors.push(ParsingError {
                     position: start,
@@ -345,29 +345,29 @@ impl Parser {
 
                 Ok((
                     Literal::Real {
-                        repr: lexeme.to_owned(),
+                        repr: text.to_owned(),
                         value: Real::NAN,
                     },
                     self.next(i),
                 ))
             }
 
-            Some(&Token {
+            Some(&Lexeme {
                 kind: TokenKind::Literal(TokenLiteral::Integer(value)),
-                lexeme,
+                text,
                 ..
             }) => Ok((
                 Literal::Integer {
-                    repr: lexeme.to_owned(),
+                    repr: text.to_owned(),
                     value,
                 },
                 self.next(i),
             )),
 
-            Some(&Token {
+            Some(&Lexeme {
                 kind: TokenKind::Invalid(ref t @ InvalidToken::MalformedInteger(_)),
                 extent: Extent { start, .. },
-                lexeme,
+                text,
             }) => {
                 self.recovered_errors.push(ParsingError {
                     position: start,
@@ -375,14 +375,14 @@ impl Parser {
                 });
                 Ok((
                     Literal::Integer {
-                        repr: lexeme.to_owned(),
+                        repr: text.to_owned(),
                         value: 0,
                     },
                     self.next(i),
                 ))
             }
 
-            Some(&Token {
+            Some(&Lexeme {
                 kind: TokenKind::Literal(TokenLiteral::Bool(value)),
                 ..
             }) => Ok((Literal::Bool { value }, self.next(i))),
@@ -404,7 +404,7 @@ impl Parser {
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, ()> {
         match i.current() {
-            Some(Token { kind, .. }) if kind == expected_kind => Ok(((), self.next(i))),
+            Some(Lexeme { kind, .. }) if kind == expected_kind => Ok(((), self.next(i))),
             Some(token) => Err(ParsingError {
                 what: format!("Token of kind {expected_kind} expected, token {token} found"),
                 position: token.extent.start,
@@ -607,7 +607,7 @@ impl Parser {
         match ops.next() {
             Some(operators) => {
                 let (mut head, mut next) = self.parse_operators(ops.clone(), atom.clone(), i)?;
-                while let Some(Token {
+                while let Some(Lexeme {
                     kind: TokenKind::Operator(op),
                     ..
                 }) = next.current()
@@ -640,7 +640,7 @@ impl Parser {
 
         loop {
             match next.current() {
-                Some(Token {
+                Some(Lexeme {
                     kind: TokenKind::Dot,
                     ..
                 }) => {
@@ -652,7 +652,7 @@ impl Parser {
                     });
                     next = rest;
                 }
-                Some(Token {
+                Some(Lexeme {
                     kind: TokenKind::LeftBracket,
                     ..
                 }) => {
@@ -770,7 +770,7 @@ impl Parser {
                     .map(|(lvalue, next)| (Rc::new(Expression::LvalueToRvalue(lvalue)), next))
             })?;
 
-        while let Some(Token {
+        while let Some(Lexeme {
             kind: TokenKind::Cast,
             ..
         }) = next.current()
@@ -922,12 +922,12 @@ impl Parser {
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, Statement> {
         match i.current() {
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::If),
                 ..
             }) => self.parse_if(i),
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::While),
                 ..
             }) => {
@@ -944,7 +944,7 @@ impl Parser {
                 Ok((Statement::While { condition, body }, next))
             }
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Print),
                 ..
             }) => {
@@ -955,7 +955,7 @@ impl Parser {
                 Ok((Statement::Print { value: expr }, next))
             }
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Return),
                 ..
             }) => {
@@ -965,20 +965,20 @@ impl Parser {
 
                 Ok((Statement::Return { value: expr }, next))
             }
-            Some(&Token {
+            Some(&Lexeme {
                 kind: TokenKind::Keyword(Keyword::Panic),
                 extent: Extent { start: pos, end: _ },
-                lexeme: _,
+                text: _,
             }) => {
                 let next = self.next(i);
                 let ((), next) = self.parse_semicolon(next)?;
                 Ok((Statement::Panic { pos }, next))
             }
 
-            Some(&Token {
+            Some(&Lexeme {
                 kind: TokenKind::Keyword(Keyword::Assert),
                 extent: Extent { start: pos, end: _ },
-                lexeme: _,
+                text: _,
             }) => {
                 let next = self.next(i);
                 let (value, next) = self.parse_expr(next)?;
@@ -986,7 +986,7 @@ impl Parser {
                 Ok((Statement::Assert { value, pos }, next))
             }
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::For),
                 ..
             }) => {
@@ -1023,7 +1023,7 @@ impl Parser {
                 ))
             }
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Identifier(_),
                 ..
             }) => self.parse_one_of(
@@ -1052,21 +1052,21 @@ impl Parser {
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, BlockElem> {
         match i.current() {
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Var),
                 ..
             }) => self
                 .parse_var_decl(i)
                 .map(|(decl, next)| (BlockElem::VarDecl(decl), next)),
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Constant),
                 ..
             }) => self
                 .parse_const_decl(i)
                 .map(|(decl, next)| (BlockElem::ConstDecl(decl), next)),
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Type),
                 ..
             }) => self
@@ -1123,7 +1123,7 @@ impl Parser {
         )?;
 
         match next.current() {
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::RightArrow,
                 ..
             }) => {
@@ -1141,7 +1141,7 @@ impl Parser {
                 ))
             }
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Is),
                 ..
             }) => {
@@ -1163,7 +1163,7 @@ impl Parser {
                 ))
             }
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Semicolon,
                 ..
             }) => Ok((
@@ -1191,28 +1191,28 @@ impl Parser {
         i: IndexedIterator<'a, 'b>,
     ) -> ParsingResult<'a, 'b, Declaration> {
         match i.current() {
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Var),
                 ..
             }) => self
                 .parse_var_decl(i)
                 .map(|(decl, next)| (Declaration::Var(decl), next)),
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Constant),
                 ..
             }) => self
                 .parse_const_decl(i)
                 .map(|(decl, next)| (Declaration::Const(decl), next)),
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Type),
                 ..
             }) => self
                 .parse_type_decl(i)
                 .map(|(decl, next)| (Declaration::Type(decl), next)),
 
-            Some(Token {
+            Some(Lexeme {
                 kind: TokenKind::Keyword(Keyword::Routine),
                 ..
             }) => self
@@ -1279,7 +1279,7 @@ impl<T: fmt::Debug> fmt::Display for ParserError<T> {
 
 impl<T: fmt::Debug> core::error::Error for ParserError<T> {}
 
-pub fn parse_program(tokens: &[Token<'_>]) -> ParserResult<Program> {
+pub fn parse_program(tokens: &[Lexeme<'_>]) -> ParserResult<Program> {
     let mut parser = Parser::new();
     let start = parser.skip_unused(IndexedIterator::from(tokens));
     let (decls, tail) = parser.parse_all(Parser::parse_declaration, start)?;

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -520,7 +520,8 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
     }
 }
 
-pub fn parse_program(tokens: Vec<Lexeme<'_>>) -> FinalResult<Program> {
+#[expect(single_use_lifetimes, reason = "Cannot use `'_` in impl Trait")]
+pub fn parse_program<'src>(tokens: impl IntoIterator<Item = Lexeme<'src>>) -> FinalResult<Program> {
     let mut parser = Parser::new(tokens.into_iter());
     let program = parser.parse_program();
     parser.finish(program)

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -62,14 +62,14 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         match literal {
             TokenLiteral::Integer(value) => Literal::Integer {
                 value: value.unwrap_or_else(|e| {
-                    self.recovered(Recoverable::MalformedInteger(e), pos);
+                    self.recover(Recoverable::MalformedInteger(e), pos);
                     0
                 }),
                 repr: lexeme.text.to_owned(),
             },
             TokenLiteral::Real(value) => Literal::Real {
                 value: value.unwrap_or_else(|e| {
-                    self.recovered(Recoverable::MalformedReal(e), pos);
+                    self.recover(Recoverable::MalformedReal(e), pos);
                     Real::NAN
                 }),
                 repr: lexeme.text.to_owned(),

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -1,5 +1,4 @@
 use core::{error, fmt, ops::ControlFlow};
-use std::rc::Rc;
 
 use culpa::throws;
 
@@ -231,33 +230,39 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
     }
 
     #[throws]
-    fn parse_lvalue(&mut self, ident: RawIdentifier) -> Rc<LvalueExpression> {
-        let mut lhs = Rc::new(LvalueExpression::Identifier(ident));
+    fn parse_lvalue(&mut self, ident: RawIdentifier) -> LvalueExpression {
+        let mut current = LvalueExpression::Identifier(ident);
         loop {
             if self.try_eat(Token::Dot) {
                 let member_name = self.eat_identifier()?;
-                lhs = Rc::new(LvalueExpression::Member { lhs, member_name });
+                current = LvalueExpression::Member {
+                    lhs: current.into(),
+                    member_name,
+                };
             } else if self.try_eat(Token::LeftBracket) {
-                let index = self.parse_expr()?;
+                let index = Box::new(self.parse_expr()?);
                 self.eat(Token::RightBracket)?;
-                lhs = Rc::new(LvalueExpression::Index { lhs, index });
+                current = LvalueExpression::Index {
+                    lhs: current.into(),
+                    index,
+                };
             } else {
-                break lhs;
+                break current;
             }
         }
     }
 
     #[throws]
-    fn parse_new(&mut self) -> Rc<Expression> {
+    fn parse_new(&mut self) -> Expression {
         self.eat(Keyword::New)?;
         let array_length = if self.try_eat(Token::LeftBracket) {
             let len = self.parse_expr()?;
             self.eat(Token::RightBracket)?;
-            Some(len)
+            Some(Box::new(len))
         } else {
             None
         };
-        let t = self.parse_type()?;
+        let t = Box::new(self.parse_type()?);
         let fields = if self.try_eat(Keyword::Where) {
             let mut fields = vec![];
             while !self.try_eat(Keyword::End) {
@@ -271,11 +276,11 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         } else {
             None
         };
-        Rc::new(Expression::New {
+        Expression::New {
             t,
             fields,
             array_length,
-        })
+        }
     }
 
     #[throws]
@@ -283,7 +288,7 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         if self.try_eat(op) {
             Some(Expression::UnOp {
                 op,
-                operand: self.parse_atom()?,
+                operand: Box::new(self.parse_atom()?),
             })
         } else {
             None
@@ -291,45 +296,45 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
     }
 
     #[throws]
-    fn parse_atom(&mut self) -> Rc<Expression> {
+    fn parse_atom(&mut self) -> Expression {
         let mut result = if self.try_eat(Token::LeftParenthesis) {
             let res = self.parse_expr()?;
             self.eat(Token::RightParenthesis)?;
             res
         } else if self.try_eat(Keyword::Null) {
-            Rc::new(Expression::Null)
+            Expression::Null
         } else if self.check(Keyword::New) {
             self.parse_new()?
         } else if self.check(TokenKind::Literal) {
-            Rc::new(Expression::Literal(self.eat_literal()?))
+            Expression::Literal(self.eat_literal()?)
         } else if let Some(unop) = self.try_parse_unop(Operator::Not)? {
-            Rc::new(unop)
+            unop
         } else if let Some(unop) = self.try_parse_unop(Operator::Minus)? {
-            Rc::new(unop)
+            unop
         } else {
             let ident = self.eat_identifier()?;
-            Rc::new(if self.check(Token::LeftParenthesis) {
+            if self.check(Token::LeftParenthesis) {
                 Expression::Call {
                     callee: ident,
                     args: self.parse_in_parens_comma_sep(Self::parse_expr)?,
                 }
             } else {
                 Expression::LvalueToRvalue(self.parse_lvalue(ident)?)
-            })
+            }
         };
 
         while self.try_eat(Token::Cast) {
             let ty = self.parse_type()?;
-            result = Rc::new(Expression::Cast {
-                operand: result,
-                target: ty,
-            })
+            result = Expression::Cast {
+                operand: Box::new(result),
+                target: Box::new(ty),
+            }
         }
         result
     }
 
     #[throws]
-    fn parse_binops(&mut self, operators: &[&[Operator]]) -> Rc<Expression> {
+    fn parse_binops(&mut self, operators: &[&[Operator]]) -> Expression {
         let Some((operators, rest)) = operators.split_first() else {
             return self.parse_atom()?;
         };
@@ -337,8 +342,12 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         'level: loop {
             for op in operators.iter().copied() {
                 if self.try_eat(op) {
-                    let rhs = self.parse_binops(rest)?;
-                    lhs = Rc::new(Expression::BinOp { op, lhs, rhs });
+                    let rhs = Box::new(self.parse_binops(rest)?);
+                    lhs = Expression::BinOp {
+                        op,
+                        lhs: Box::new(lhs),
+                        rhs,
+                    };
                     continue 'level;
                 }
             }
@@ -348,7 +357,7 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
     }
 
     #[throws]
-    pub fn parse_expr(&mut self) -> Rc<Expression> {
+    pub fn parse_expr(&mut self) -> Expression {
         self.parse_binops(OPERATORS_PRECEDENCE_TABLE)?
     }
 
@@ -438,10 +447,10 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
             let ident = self.eat_identifier()?;
             let stmt = if self.check(Token::LeftParenthesis) {
                 let args = self.parse_in_parens_comma_sep(Self::parse_expr)?;
-                Statement::Expr(Rc::new(Expression::Call {
+                Statement::Expr(Expression::Call {
                     callee: ident,
                     args,
-                }))
+                })
             } else {
                 let lhs = self.parse_lvalue(ident)?;
                 self.eat(Token::Assignment)?;

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -1,46 +1,30 @@
-use core::{error, fmt, ops::ControlFlow};
+use core::ops::ControlFlow;
 
 use culpa::throws;
 
-use common::{Extent, LoopOrder, Position, RawIdentifier, Real};
+use common::{LoopOrder, RawIdentifier, Real};
 use lexer::{
     BuiltinTypename, Identifier as TokenIdentifier, Keyword, Lexeme, Literal as TokenLiteral, Token,
 };
 
 mod parser;
+mod reporting;
 mod tree;
 mod types;
 
 #[cfg(test)]
 mod tests;
 
-use crate::parser::TokenKind;
+use crate::parser::Error;
 pub use crate::{
-    parser::Parser,
+    parser::{Expected, Parser, TokenKind},
+    reporting::{Fatal, FinalError, FinalResult, ParsingError, Recoverable},
     tree::{
         Block, BlockElem, ConstDecl, Declaration, Expression, Literal, LvalueExpression, Operator,
         Program, RoutineBody, RoutineDecl, Statement, TypeDecl, VarDecl,
     },
     types::{ArrayDescription, FieldDescription, RecordDescription, Type},
 };
-
-#[derive(Debug, Clone)]
-#[must_use]
-pub struct ParsingError {
-    pub what: String,
-    pub position: Position,
-}
-
-impl fmt::Display for ParsingError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { what, position } = self;
-        write!(f, "{what} @ {position}")
-    }
-}
-
-impl error::Error for ParsingError {}
-
-type ParsingResult<T> = Result<T, ParsingError>;
 
 const OPERATORS_PRECEDENCE_TABLE: &[&[Operator]] = &[
     &[Operator::And, Operator::Or, Operator::Xor],
@@ -56,9 +40,6 @@ const OPERATORS_PRECEDENCE_TABLE: &[&[Operator]] = &[
     &[Operator::Mul, Operator::Div, Operator::Mod],
 ];
 
-// For `#[throws]`
-use ParsingError as Error;
-
 impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
     #[throws]
     fn eat_identifier(&mut self) -> RawIdentifier {
@@ -71,40 +52,26 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         }
     }
 
-    fn recover_invalid_literal<T, E>(
-        &mut self,
-        literal: Result<T, E>,
-        default: T,
-        extent: Extent,
-    ) -> T
-    where
-        E: error::Error,
-    {
-        match literal {
-            Ok(literal) => literal,
-            Err(error) => {
-                self.push_error(ParsingError {
-                    position: extent.start,
-                    what: format!("Malformed literal: {error}"),
-                });
-                default
-            }
-        }
-    }
-
     #[throws]
     fn eat_literal(&mut self) -> Literal {
         let lexeme = self.eat_lexeme(TokenKind::Literal)?;
         let Token::Literal(literal) = lexeme.token else {
             unreachable!("We ate `TokenKind::Literal` but got {lexeme:?}")
         };
+        let pos = lexeme.extent.start;
         match literal {
             TokenLiteral::Integer(value) => Literal::Integer {
-                value: self.recover_invalid_literal(value, 0, lexeme.extent),
+                value: value.unwrap_or_else(|e| {
+                    self.recovered(Recoverable::MalformedInteger(e), pos);
+                    0
+                }),
                 repr: lexeme.text.to_owned(),
             },
             TokenLiteral::Real(value) => Literal::Real {
-                value: self.recover_invalid_literal(value, Real::NAN, lexeme.extent),
+                value: value.unwrap_or_else(|e| {
+                    self.recovered(Recoverable::MalformedReal(e), pos);
+                    Real::NAN
+                }),
                 repr: lexeme.text.to_owned(),
             },
             TokenLiteral::Bool(value) => Literal::Bool { value },
@@ -146,7 +113,7 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
     #[throws]
     fn parse_in_parens_comma_sep<T>(
         &mut self,
-        parser: fn(&mut Self) -> ParsingResult<T>,
+        parser: fn(&mut Self) -> Result<T, Error>,
     ) -> Vec<T> {
         self.eat(Token::LeftParenthesis)?;
         let mut result = vec![];
@@ -553,45 +520,8 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
     }
 }
 
-#[derive(Debug)]
-#[must_use]
-pub enum ParserError<T> {
-    Unrecoverable {
-        error: ParsingError,
-    },
-    Recoverable {
-        errors: Vec<ParsingError>,
-        parsed: T,
-    },
-}
-
-pub type ParserResult<T> = Result<T, ParserError<T>>;
-
-impl<T> From<ParsingError> for ParserError<T> {
-    fn from(error: ParsingError) -> Self {
-        Self::Unrecoverable { error }
-    }
-}
-
-impl<T: fmt::Debug> fmt::Display for ParserError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Unrecoverable { error } => write!(f, "unrecoverable error: {error}"),
-            Self::Recoverable { errors, parsed } => {
-                writeln!(f, "Some recoverable errors occurred during parsing:")?;
-                for err in errors {
-                    writeln!(f, "- {err}")?
-                }
-                writeln!(f, "But managed to parse: {parsed:#?}")
-            }
-        }
-    }
-}
-
-impl<T: fmt::Debug> error::Error for ParserError<T> {}
-
-pub fn parse_program(tokens: Vec<Lexeme<'_>>) -> ParserResult<Program> {
+pub fn parse_program(tokens: Vec<Lexeme<'_>>) -> FinalResult<Program> {
     let mut parser = Parser::new(tokens.into_iter());
-    let program = parser.parse_program()?;
+    let program = parser.parse_program();
     parser.finish(program)
 }

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1,0 +1,431 @@
+//! Design largely inspired by `rustc_parse`.
+
+use core::{fmt, mem};
+use std::collections::BTreeSet;
+
+use common::Position;
+use lexer::{BuiltinTypename, Keyword, Lexeme, Operator, Token};
+
+use crate::{ParserError, ParsingError, ParsingResult};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// Like [`lexer::Token`], but flat and without data.
+/// TODO: this can be turned into a bitflag
+///
+/// Idea stolen from rustc.
+pub(crate) enum TokenKind {
+    Var,
+    Type,
+    Routine,
+    Array,
+    Record,
+    Is,
+    End,
+    If,
+    Then,
+    Else,
+    Return,
+    In,
+    While,
+    For,
+    Loop,
+    Reverse,
+    Print,
+    New,
+    Null,
+    Where,
+    Assert,
+    Panic,
+    Constant,
+    Identifier,
+    Literal,
+    Integer,
+    Real,
+    Boolean,
+    LeftBracket,
+    RightBracket,
+    LeftParenthesis,
+    RightParenthesis,
+    /// `=>`
+    RightArrow,
+    /// `::`
+    Cast,
+    /// `:=`
+    Assignment,
+    /// `..`
+    RangeSymbol,
+    Dot,
+    Comma,
+    Semicolon,
+    Colon,
+    Plus,  // Either binary or unary one
+    Minus, // Either binary or unary one
+    Mul,
+    Div,
+    Mod,
+    /// `=`
+    Eq,
+    /// `/=`
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    /// `and`
+    And,
+    /// `or`
+    Or,
+    /// `xor`
+    Xor,
+    /// `not`
+    Not,
+    Invalid,
+    EOF,
+}
+
+impl From<TokenKind> for &'static str {
+    fn from(kind: TokenKind) -> Self {
+        match kind {
+            TokenKind::Var => "`var`",
+            TokenKind::Type => "`type`",
+            TokenKind::Routine => "`routine`",
+            TokenKind::Array => "`array`",
+            TokenKind::Record => "`record`",
+            TokenKind::Is => "`is`",
+            TokenKind::End => "`end`",
+            TokenKind::If => "`if`",
+            TokenKind::Then => "`then`",
+            TokenKind::Else => "`else`",
+            TokenKind::Return => "`return`",
+            TokenKind::In => "`in`",
+            TokenKind::While => "`while`",
+            TokenKind::For => "`for`",
+            TokenKind::Loop => "`loop`",
+            TokenKind::Reverse => "`reverse`",
+            TokenKind::Print => "`print`",
+            TokenKind::New => "`new`",
+            TokenKind::Null => "`null`",
+            TokenKind::Where => "`where`",
+            TokenKind::Assert => "`assert`",
+            TokenKind::Panic => "`panic`",
+            TokenKind::Constant => "`constant`",
+            TokenKind::Identifier => "an identifier",
+            TokenKind::Literal => "a literal",
+            TokenKind::Integer => "`integer`",
+            TokenKind::Real => "`real`",
+            TokenKind::Boolean => "`boolean`",
+            TokenKind::LeftBracket => "`[`",
+            TokenKind::RightBracket => "`]`",
+            TokenKind::LeftParenthesis => "`(`",
+            TokenKind::RightParenthesis => "`)`",
+            TokenKind::RightArrow => "`=>`",
+            TokenKind::Cast => "`::`",
+            TokenKind::Assignment => "`:=`",
+            TokenKind::RangeSymbol => "`..`",
+            TokenKind::Dot => "`.`",
+            TokenKind::Comma => "`,`",
+            TokenKind::Colon => "`:`",
+            TokenKind::Plus => "`+`",
+            TokenKind::Minus => "`-`",
+            TokenKind::Mul => "`*`",
+            TokenKind::Div => "`/`",
+            TokenKind::Mod => "`%`",
+            TokenKind::Eq => "`=`",
+            TokenKind::Ne => "`/=`",
+            TokenKind::Lt => "`<`",
+            TokenKind::Le => "`<=`",
+            TokenKind::Gt => "`>`",
+            TokenKind::Ge => "`>=`",
+            TokenKind::And => "`and`",
+            TokenKind::Or => "`or`",
+            TokenKind::Xor => "`xor`",
+            TokenKind::Not => "`not`",
+            TokenKind::Semicolon => "`;`",
+            TokenKind::Invalid => "an invalid token",
+            TokenKind::EOF => "EOF",
+        }
+    }
+}
+
+impl fmt::Display for TokenKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str((*self).into())
+    }
+}
+
+impl From<Operator> for TokenKind {
+    fn from(op: Operator) -> Self {
+        match op {
+            Operator::Plus => Self::Plus,
+            Operator::Minus => Self::Minus,
+            Operator::Mul => Self::Mul,
+            Operator::Div => Self::Div,
+            Operator::Mod => Self::Mod,
+            Operator::Eq => Self::Eq,
+            Operator::Ne => Self::Ne,
+            Operator::Lt => Self::Lt,
+            Operator::Le => Self::Le,
+            Operator::Gt => Self::Gt,
+            Operator::Ge => Self::Ge,
+            Operator::And => Self::And,
+            Operator::Or => Self::Or,
+            Operator::Xor => Self::Xor,
+            Operator::Not => Self::Not,
+        }
+    }
+}
+
+impl From<Keyword> for TokenKind {
+    fn from(keyword: Keyword) -> Self {
+        match keyword {
+            Keyword::Var => Self::Var,
+            Keyword::Type => Self::Type,
+            Keyword::Routine => Self::Routine,
+            Keyword::Array => Self::Array,
+            Keyword::Record => Self::Record,
+            Keyword::Is => Self::Is,
+            Keyword::End => Self::End,
+            Keyword::If => Self::If,
+            Keyword::Then => Self::Then,
+            Keyword::Else => Self::Else,
+            Keyword::Return => Self::Return,
+            Keyword::In => Self::In,
+            Keyword::While => Self::While,
+            Keyword::For => Self::For,
+            Keyword::Loop => Self::Loop,
+            Keyword::Reverse => Self::Reverse,
+            Keyword::Print => Self::Print,
+            Keyword::New => Self::New,
+            Keyword::Null => Self::Null,
+            Keyword::Where => Self::Where,
+            Keyword::Assert => Self::Assert,
+            Keyword::Panic => Self::Panic,
+            Keyword::Constant => Self::Constant,
+        }
+    }
+}
+
+impl From<BuiltinTypename> for TokenKind {
+    fn from(ty: BuiltinTypename) -> Self {
+        match ty {
+            BuiltinTypename::Integer => Self::Integer,
+            BuiltinTypename::Real => Self::Real,
+            BuiltinTypename::Boolean => Self::Boolean,
+        }
+    }
+}
+
+impl From<&Token<'_>> for TokenKind {
+    fn from(token: &Token<'_>) -> Self {
+        match token {
+            Token::Identifier(_) => Self::Identifier,
+            &Token::Keyword(keyword) => keyword.into(),
+            Token::Literal(_) => Self::Literal,
+            &Token::BuiltinTypename(ty) => ty.into(),
+            &Token::Operator(op) => op.into(),
+            Token::Comment(_) => unreachable!("We skip comments"),
+            Token::Invalid(_) => Self::Invalid,
+            Token::LeftBracket => Self::LeftBracket,
+            Token::RightBracket => Self::RightBracket,
+            Token::LeftParenthesis => Self::LeftParenthesis,
+            Token::RightParenthesis => Self::RightParenthesis,
+            Token::RightArrow => Self::RightArrow,
+            Token::Cast => Self::Cast,
+            Token::Assignment => Self::Assignment,
+            Token::RangeSymbol => Self::RangeSymbol,
+            Token::Dot => Self::Dot,
+            Token::Comma => Self::Comma,
+            Token::Semicolon => Self::Semicolon,
+            Token::Colon => Self::Colon,
+        }
+    }
+}
+
+impl From<Token<'_>> for TokenKind {
+    fn from(token: Token<'_>) -> Self {
+        Self::from(&token)
+    }
+}
+
+// FIXME(GrigorenkoPV): recover on invalid tokens
+fn next_lexeme<'src>(
+    lexer: &mut impl Iterator<Item = Lexeme<'src>>,
+) -> Result<Lexeme<'src>, Position> {
+    let mut eof_pos = Position::begin();
+    for lexeme in lexer {
+        eof_pos = lexeme.extent.end;
+        if let Token::Comment(_) = lexeme.token {
+            continue;
+        }
+        return Ok(lexeme);
+    }
+    Err(eof_pos)
+}
+
+#[derive(Debug)]
+enum State<'src, Lexer> {
+    InProgress { current: Lexeme<'src>, lexer: Lexer },
+    EOF(Position),
+}
+
+impl<'src, I: Iterator<Item = Lexeme<'src>>> From<I> for State<'src, I> {
+    fn from(mut lexer: I) -> Self {
+        match next_lexeme(&mut lexer) {
+            Ok(current) => Self::InProgress { current, lexer },
+            Err(pos) => Self::EOF(pos),
+        }
+    }
+}
+
+impl<'src, I> State<'src, I> {
+    #[must_use]
+    fn current(&self) -> Option<&Lexeme<'src>> {
+        match self {
+            Self::InProgress { current, lexer: _ } => Some(current),
+            Self::EOF(_) => None,
+        }
+    }
+
+    #[must_use]
+    fn current_kind(&self) -> TokenKind {
+        match self.current() {
+            Some(lexeme) => TokenKind::from(&lexeme.token),
+            None => TokenKind::EOF,
+        }
+    }
+
+    #[must_use]
+    fn pos(&self) -> Position {
+        match self {
+            Self::InProgress { current, lexer: _ } => current.extent.start,
+            Self::EOF(pos) => *pos,
+        }
+    }
+
+    #[must_use]
+    fn advance(&mut self) -> Option<Lexeme<'src>>
+    where
+        I: Iterator<Item = Lexeme<'src>>,
+    {
+        let prev = mem::replace(self, Self::EOF(self.pos()));
+        match prev {
+            Self::EOF(_) => None,
+            Self::InProgress { current, lexer } => {
+                *self = lexer.into();
+                Some(current)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Parser<'src, Lexer> {
+    state: State<'src, Lexer>,
+    expected: BTreeSet<TokenKind>,
+    recovered: Vec<ParsingError>,
+}
+
+impl<'src, I: Iterator<Item = Lexeme<'src>>> From<I> for Parser<'src, I> {
+    fn from(lexer: I) -> Self {
+        Self {
+            state: lexer.into(),
+            expected: BTreeSet::new(),
+            recovered: vec![],
+        }
+    }
+}
+
+fn format_expected(out: &mut String, expected: &BTreeSet<TokenKind>) {
+    let or_after = expected.len().checked_sub(2);
+    for (i, &expected) in expected.iter().enumerate() {
+        out.push_str(expected.into());
+        out.push_str(if or_after == Some(i) { " or " } else { ", " });
+    }
+}
+
+impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
+    #[must_use]
+    pub fn new(lexer: I) -> Self {
+        lexer.into()
+    }
+
+    #[must_use]
+    #[track_caller]
+    pub(crate) fn check(&mut self, kind: impl Into<TokenKind>) -> bool {
+        let kind = kind.into();
+        let first_check: bool = self.expected.insert(kind);
+        let is_present = self.state.current_kind() == kind;
+        debug_assert!(
+            !is_present || first_check || kind == TokenKind::EOF,
+            "Duplicate `check()` call for {kind:?} @ {}\n{:?}",
+            self.state.pos(),
+            self.expected
+        );
+        is_present
+    }
+
+    #[must_use]
+    pub(crate) fn eof(&mut self) -> bool {
+        self.check(TokenKind::EOF)
+    }
+
+    fn error(&self) -> ParsingError {
+        debug_assert!(
+            !self.expected.contains(&self.state.current_kind()),
+            "Error message requested, but the next token is expected"
+        );
+
+        let mut what = "Expected ".to_string();
+        format_expected(&mut what, &self.expected);
+        what.push_str("but found ");
+
+        let position = self.state.pos();
+        let found = self.state.current();
+
+        what.push_str(match found {
+            Some(lexeme) => TokenKind::from(&lexeme.token).into(),
+            None => "EOF",
+        });
+
+        ParsingError { what, position }
+    }
+
+    pub(crate) fn try_eat_lexeme(&mut self, kind: impl Into<TokenKind>) -> Option<Lexeme<'src>> {
+        let kind = kind.into();
+        assert_ne!(kind, TokenKind::EOF, "Cannot eat EOF");
+        if self.state.current_kind() == kind {
+            self.expected.clear();
+            self.state.advance()
+        } else {
+            let _: bool = self.expected.insert(kind);
+            None
+        }
+    }
+
+    pub(crate) fn try_eat(&mut self, kind: impl Into<TokenKind>) -> bool {
+        self.try_eat_lexeme(kind.into()).is_some()
+    }
+
+    pub(crate) fn eat_lexeme(&mut self, kind: impl Into<TokenKind>) -> ParsingResult<Lexeme<'src>> {
+        self.try_eat_lexeme(kind.into()).ok_or_else(|| self.error())
+    }
+
+    pub(crate) fn eat(&mut self, kind: impl Into<TokenKind>) -> ParsingResult<()> {
+        self.eat_lexeme(kind).map(drop::<Lexeme<'src>>)
+    }
+
+    pub fn finish<T>(mut self, parsed: T) -> crate::ParserResult<T> {
+        if !self.eof() {
+            Err(self.error())?
+        }
+        let Self { recovered, .. } = self;
+        if recovered.is_empty() {
+            Ok(parsed)
+        } else {
+            Err(ParserError::Recoverable {
+                errors: recovered,
+                parsed,
+            })
+        }
+    }
+}

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -1,19 +1,18 @@
 //! Design largely inspired by `rustc_parse`.
 
-use core::{fmt, mem};
-use std::collections::BTreeSet;
+use core::mem;
 
 use common::Position;
+use culpa::{throw, throws};
 use lexer::{BuiltinTypename, Keyword, Lexeme, Operator, Token};
 
-use crate::{ParserError, ParsingError, ParsingResult};
+use crate::{Fatal, FinalError, FinalResult, ParsingError, Recoverable};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 /// Like [`lexer::Token`], but flat and without data.
-/// TODO: this can be turned into a bitflag
 ///
 /// Idea stolen from rustc.
-pub(crate) enum TokenKind {
+pub enum TokenKind {
     Var,
     Type,
     Routine,
@@ -83,75 +82,11 @@ pub(crate) enum TokenKind {
     EOF,
 }
 
-impl From<TokenKind> for &'static str {
-    fn from(kind: TokenKind) -> Self {
-        match kind {
-            TokenKind::Var => "`var`",
-            TokenKind::Type => "`type`",
-            TokenKind::Routine => "`routine`",
-            TokenKind::Array => "`array`",
-            TokenKind::Record => "`record`",
-            TokenKind::Is => "`is`",
-            TokenKind::End => "`end`",
-            TokenKind::If => "`if`",
-            TokenKind::Then => "`then`",
-            TokenKind::Else => "`else`",
-            TokenKind::Return => "`return`",
-            TokenKind::In => "`in`",
-            TokenKind::While => "`while`",
-            TokenKind::For => "`for`",
-            TokenKind::Loop => "`loop`",
-            TokenKind::Reverse => "`reverse`",
-            TokenKind::Print => "`print`",
-            TokenKind::New => "`new`",
-            TokenKind::Null => "`null`",
-            TokenKind::Where => "`where`",
-            TokenKind::Assert => "`assert`",
-            TokenKind::Panic => "`panic`",
-            TokenKind::Constant => "`constant`",
-            TokenKind::Identifier => "an identifier",
-            TokenKind::Literal => "a literal",
-            TokenKind::Integer => "`integer`",
-            TokenKind::Real => "`real`",
-            TokenKind::Boolean => "`boolean`",
-            TokenKind::LeftBracket => "`[`",
-            TokenKind::RightBracket => "`]`",
-            TokenKind::LeftParenthesis => "`(`",
-            TokenKind::RightParenthesis => "`)`",
-            TokenKind::RightArrow => "`=>`",
-            TokenKind::Cast => "`::`",
-            TokenKind::Assignment => "`:=`",
-            TokenKind::RangeSymbol => "`..`",
-            TokenKind::Dot => "`.`",
-            TokenKind::Comma => "`,`",
-            TokenKind::Colon => "`:`",
-            TokenKind::Plus => "`+`",
-            TokenKind::Minus => "`-`",
-            TokenKind::Mul => "`*`",
-            TokenKind::Div => "`/`",
-            TokenKind::Mod => "`%`",
-            TokenKind::Eq => "`=`",
-            TokenKind::Ne => "`/=`",
-            TokenKind::Lt => "`<`",
-            TokenKind::Le => "`<=`",
-            TokenKind::Gt => "`>`",
-            TokenKind::Ge => "`>=`",
-            TokenKind::And => "`and`",
-            TokenKind::Or => "`or`",
-            TokenKind::Xor => "`xor`",
-            TokenKind::Not => "`not`",
-            TokenKind::Semicolon => "`;`",
-            TokenKind::Unexpected => "an unexpected character",
-            TokenKind::EOF => "EOF",
-        }
-    }
-}
+// TODO: this can be turned into a bitset
+pub type Expected = std::collections::BTreeSet<TokenKind>;
 
-impl fmt::Display for TokenKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str((*self).into())
-    }
-}
+#[expect(clippy::error_impl_error, reason = "for #[throws]")]
+pub(crate) type Error = ParsingError<Fatal>;
 
 impl From<Operator> for TokenKind {
     fn from(op: Operator) -> Self {
@@ -321,25 +256,17 @@ impl<'src, I> State<'src, I> {
 #[derive(Debug)]
 pub struct Parser<'src, Lexer> {
     state: State<'src, Lexer>,
-    expected: BTreeSet<TokenKind>,
-    recovered: Vec<ParsingError>,
+    expected: Expected,
+    recovered: Option<ParsingError<Recoverable>>,
 }
 
 impl<'src, I: Iterator<Item = Lexeme<'src>>> From<I> for Parser<'src, I> {
     fn from(lexer: I) -> Self {
         Self {
             state: lexer.into(),
-            expected: BTreeSet::new(),
-            recovered: vec![],
+            expected: Expected::new(),
+            recovered: None,
         }
-    }
-}
-
-fn format_expected(out: &mut String, expected: &BTreeSet<TokenKind>) {
-    let or_after = expected.len().checked_sub(2);
-    for (i, &expected) in expected.iter().enumerate() {
-        out.push_str(expected.into());
-        out.push_str(if or_after == Some(i) { " or " } else { ", " });
     }
 }
 
@@ -356,7 +283,7 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         let first_check: bool = self.expected.insert(kind);
         let is_present = self.state.current_kind() == kind;
         debug_assert!(
-            !is_present || first_check || kind == TokenKind::EOF,
+            !is_present || first_check,
             "Duplicate `check()` call for {kind:?} @ {}\n{:?}",
             self.state.pos(),
             self.expected
@@ -367,27 +294,6 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
     #[must_use]
     pub(crate) fn eof(&mut self) -> bool {
         self.check(TokenKind::EOF)
-    }
-
-    fn error(&self) -> ParsingError {
-        debug_assert!(
-            !self.expected.contains(&self.state.current_kind()),
-            "Error message requested, but the next token is expected"
-        );
-
-        let mut what = "Expected ".to_string();
-        format_expected(&mut what, &self.expected);
-        what.push_str("but found ");
-
-        let position = self.state.pos();
-        let found = self.state.current();
-
-        what.push_str(match found {
-            Some(lexeme) => TokenKind::from(&lexeme.token).into(),
-            None => "EOF",
-        });
-
-        ParsingError { what, position }
     }
 
     pub(crate) fn try_eat_lexeme(&mut self, kind: impl Into<TokenKind>) -> Option<Lexeme<'src>> {
@@ -406,30 +312,54 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         self.try_eat_lexeme(kind.into()).is_some()
     }
 
-    pub(crate) fn eat_lexeme(&mut self, kind: impl Into<TokenKind>) -> ParsingResult<Lexeme<'src>> {
-        self.try_eat_lexeme(kind.into()).ok_or_else(|| self.error())
-    }
-
-    pub(crate) fn eat(&mut self, kind: impl Into<TokenKind>) -> ParsingResult<()> {
-        self.eat_lexeme(kind).map(drop::<Lexeme<'src>>)
-    }
-
-    pub(crate) fn push_error(&mut self, error: ParsingError) {
-        self.recovered.push(error)
-    }
-
-    pub fn finish<T>(mut self, parsed: T) -> crate::ParserResult<T> {
-        if !self.eof() {
-            Err(self.error())?
+    #[throws]
+    pub(crate) fn eat_lexeme(&mut self, kind: impl Into<TokenKind>) -> Lexeme<'src> {
+        match self.try_eat_lexeme(kind.into()) {
+            Some(l) => l,
+            None => {
+                let found = self.state.current_kind();
+                let expected = self.expected.clone();
+                debug_assert!(
+                    !expected.contains(&found),
+                    "Error message requested, but the next token is expected"
+                );
+                throw!(ParsingError {
+                    position: self.state.pos(),
+                    kind: Fatal::UnexpectedToken { found, expected },
+                    previous: self.recovered.take().map(Box::new),
+                })
+            }
         }
-        let Self { recovered, .. } = self;
-        if recovered.is_empty() {
-            Ok(parsed)
-        } else {
-            Err(ParserError::Recoverable {
-                errors: recovered,
-                parsed,
-            })
+    }
+
+    #[throws]
+    pub(crate) fn eat(&mut self, kind: impl Into<TokenKind>) {
+        let _: Lexeme<'src> = self.eat_lexeme(kind)?;
+    }
+
+    pub(crate) fn recovered(&mut self, error: Recoverable, position: Position) {
+        let previous = self.recovered.take().map(Box::new);
+        self.recovered = Some(ParsingError {
+            position,
+            kind: error,
+            previous,
+        });
+    }
+
+    pub fn finish<T>(mut self, parsed: Result<T, ParsingError<Fatal>>) -> FinalResult<T> {
+        if let Some(lexeme) = self.state.advance() {
+            self.recovered(
+                Recoverable::NotEOF(lexeme.token.into()),
+                lexeme.extent.start,
+            )
+        }
+
+        match parsed {
+            Err(fatal) => Err(FinalError::Failed(fatal)),
+            Ok(parsed) => match self.recovered {
+                None => Ok(parsed),
+                Some(last) => Err(FinalError::ParsedWithError { last, parsed }),
+            },
         }
     }
 }

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -69,7 +69,6 @@ pub enum TokenKind {
     Not,
     Semicolon,
     EOF,
-    Unexpected,
 }
 
 // TODO: this can be turned into a bitset
@@ -149,7 +148,7 @@ impl From<&Token<'_>> for TokenKind {
             &Token::BuiltinTypename(ty) => ty.into(),
             &Token::Operator(op) => op.into(),
             Token::Comment(_) => unreachable!("We skip comments"),
-            Token::Unexpected(_) => Self::Unexpected,
+            Token::Unexpected(_) => unreachable!("We convert unexpected characters into errors"),
             Token::LeftBracket => Self::LeftBracket,
             Token::RightBracket => Self::RightBracket,
             Token::LeftParenthesis => Self::LeftParenthesis,
@@ -172,17 +171,20 @@ impl From<Token<'_>> for TokenKind {
     }
 }
 
-// FIXME(GrigorenkoPV): recover on invalid tokens
 fn next_lexeme<'src>(
     lexer: &mut impl Iterator<Item = Lexeme<'src>>,
+    mut recover: impl FnMut(Recoverable, Position),
 ) -> Result<Lexeme<'src>, Position> {
     let mut eof_pos = Position::begin();
     for lexeme in lexer {
         eof_pos = lexeme.extent.end;
         if let Token::Comment(_) = lexeme.token {
-            continue;
+            // skip comments
+        } else if let Token::Unexpected(c) = lexeme.token {
+            recover(Recoverable::UnexpectedCharacter(c), lexeme.extent.start)
+        } else {
+            return Ok(lexeme);
         }
-        return Ok(lexeme);
     }
     Err(eof_pos)
 }
@@ -193,16 +195,18 @@ enum State<'src, Lexer> {
     EOF(Position),
 }
 
-impl<'src, I: Iterator<Item = Lexeme<'src>>> From<I> for State<'src, I> {
-    fn from(mut lexer: I) -> Self {
-        match next_lexeme(&mut lexer) {
+impl<'src, I> State<'src, I> {
+    #[must_use]
+    fn new(mut lexer: I, recovered: &mut Option<ParsingError<Recoverable>>) -> Self
+    where
+        I: Iterator<Item = Lexeme<'src>>,
+    {
+        match next_lexeme(&mut lexer, |err, pos| add_error(recovered, err, pos)) {
             Ok(current) => Self::InProgress { current, lexer },
             Err(pos) => Self::EOF(pos),
         }
     }
-}
 
-impl<'src, I> State<'src, I> {
     #[must_use]
     fn current(&self) -> Option<&Lexeme<'src>> {
         match self {
@@ -228,7 +232,7 @@ impl<'src, I> State<'src, I> {
     }
 
     #[must_use]
-    fn advance(&mut self) -> Option<Lexeme<'src>>
+    fn advance(&mut self, recovered: &mut Option<ParsingError<Recoverable>>) -> Option<Lexeme<'src>>
     where
         I: Iterator<Item = Lexeme<'src>>,
     {
@@ -236,7 +240,7 @@ impl<'src, I> State<'src, I> {
         match prev {
             Self::EOF(_) => None,
             Self::InProgress { current, lexer } => {
-                *self = lexer.into();
+                *self = Self::new(lexer, recovered);
                 Some(current)
             }
         }
@@ -252,12 +256,27 @@ pub struct Parser<'src, Lexer> {
 
 impl<'src, I: Iterator<Item = Lexeme<'src>>> From<I> for Parser<'src, I> {
     fn from(lexer: I) -> Self {
+        let mut recovered = None;
+        let state = State::new(lexer, &mut recovered);
         Self {
-            state: lexer.into(),
+            state,
             expected: Expected::new(),
-            recovered: None,
+            recovered,
         }
     }
+}
+
+fn add_error(
+    storage: &mut Option<ParsingError<Recoverable>>,
+    kind: Recoverable,
+    position: Position,
+) {
+    let previous = storage.take().map(Box::new);
+    *storage = Some(ParsingError {
+        position,
+        kind,
+        previous,
+    })
 }
 
 impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
@@ -286,12 +305,16 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         self.check(TokenKind::EOF)
     }
 
+    fn advance(&mut self) -> Option<Lexeme<'src>> {
+        self.expected.clear();
+        self.state.advance(&mut self.recovered)
+    }
+
     pub(crate) fn try_eat_lexeme(&mut self, kind: impl Into<TokenKind>) -> Option<Lexeme<'src>> {
         let kind = kind.into();
         assert_ne!(kind, TokenKind::EOF, "Cannot eat EOF");
         if self.state.current_kind() == kind {
-            self.expected.clear();
-            self.state.advance()
+            self.advance()
         } else {
             let _: bool = self.expected.insert(kind);
             None
@@ -327,18 +350,13 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
         let _: Lexeme<'src> = self.eat_lexeme(kind)?;
     }
 
-    pub(crate) fn recovered(&mut self, error: Recoverable, position: Position) {
-        let previous = self.recovered.take().map(Box::new);
-        self.recovered = Some(ParsingError {
-            position,
-            kind: error,
-            previous,
-        });
+    pub(crate) fn recover(&mut self, error: Recoverable, position: Position) {
+        add_error(&mut self.recovered, error, position)
     }
 
     pub fn finish<T>(mut self, parsed: Result<T, ParsingError<Fatal>>) -> FinalResult<T> {
-        if let Some(lexeme) = self.state.advance() {
-            self.recovered(
+        if let Some(lexeme) = self.advance() {
+            self.recover(
                 Recoverable::NotEOF(lexeme.token.into()),
                 lexeme.extent.start,
             )

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -79,7 +79,7 @@ pub(crate) enum TokenKind {
     Xor,
     /// `not`
     Not,
-    Invalid,
+    Unexpected,
     EOF,
 }
 
@@ -141,7 +141,7 @@ impl From<TokenKind> for &'static str {
             TokenKind::Xor => "`xor`",
             TokenKind::Not => "`not`",
             TokenKind::Semicolon => "`;`",
-            TokenKind::Invalid => "an invalid token",
+            TokenKind::Unexpected => "an unexpected character",
             TokenKind::EOF => "EOF",
         }
     }
@@ -224,7 +224,7 @@ impl From<&Token<'_>> for TokenKind {
             &Token::BuiltinTypename(ty) => ty.into(),
             &Token::Operator(op) => op.into(),
             Token::Comment(_) => unreachable!("We skip comments"),
-            Token::Invalid(_) => Self::Invalid,
+            Token::Unexpected(_) => Self::Unexpected,
             Token::LeftBracket => Self::LeftBracket,
             Token::RightBracket => Self::RightBracket,
             Token::LeftParenthesis => Self::LeftParenthesis,
@@ -412,6 +412,10 @@ impl<'src, I: Iterator<Item = Lexeme<'src>>> Parser<'src, I> {
 
     pub(crate) fn eat(&mut self, kind: impl Into<TokenKind>) -> ParsingResult<()> {
         self.eat_lexeme(kind).map(drop::<Lexeme<'src>>)
+    }
+
+    pub(crate) fn push_error(&mut self, error: ParsingError) {
+        self.recovered.push(error)
     }
 
     pub fn finish<T>(mut self, parsed: T) -> crate::ParserResult<T> {

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -13,6 +13,8 @@ use crate::{Fatal, FinalError, FinalResult, ParsingError, Recoverable};
 ///
 /// Idea stolen from rustc.
 pub enum TokenKind {
+    Identifier,
+    Literal,
     Var,
     Type,
     Routine,
@@ -36,8 +38,6 @@ pub enum TokenKind {
     Assert,
     Panic,
     Constant,
-    Identifier,
-    Literal,
     Integer,
     Real,
     Boolean,
@@ -45,41 +45,31 @@ pub enum TokenKind {
     RightBracket,
     LeftParenthesis,
     RightParenthesis,
-    /// `=>`
     RightArrow,
-    /// `::`
     Cast,
-    /// `:=`
     Assignment,
-    /// `..`
     RangeSymbol,
     Dot,
     Comma,
-    Semicolon,
     Colon,
-    Plus,  // Either binary or unary one
-    Minus, // Either binary or unary one
+    Plus,
+    Minus,
     Mul,
     Div,
     Mod,
-    /// `=`
     Eq,
-    /// `/=`
     Ne,
     Lt,
     Le,
     Gt,
     Ge,
-    /// `and`
     And,
-    /// `or`
     Or,
-    /// `xor`
     Xor,
-    /// `not`
     Not,
-    Unexpected,
+    Semicolon,
     EOF,
+    Unexpected,
 }
 
 // TODO: this can be turned into a bitset

--- a/compiler/parser/src/reporting.rs
+++ b/compiler/parser/src/reporting.rs
@@ -11,6 +11,8 @@ use crate::parser::{Expected, TokenKind};
 impl From<TokenKind> for &'static str {
     fn from(kind: TokenKind) -> Self {
         match kind {
+            TokenKind::Identifier => "an identifier",
+            TokenKind::Literal => "a literal",
             TokenKind::Var => "`var`",
             TokenKind::Type => "`type`",
             TokenKind::Routine => "`routine`",
@@ -34,8 +36,6 @@ impl From<TokenKind> for &'static str {
             TokenKind::Assert => "`assert`",
             TokenKind::Panic => "`panic`",
             TokenKind::Constant => "`constant`",
-            TokenKind::Identifier => "an identifier",
-            TokenKind::Literal => "a literal",
             TokenKind::Integer => "`integer`",
             TokenKind::Real => "`real`",
             TokenKind::Boolean => "`boolean`",
@@ -66,8 +66,8 @@ impl From<TokenKind> for &'static str {
             TokenKind::Xor => "`xor`",
             TokenKind::Not => "`not`",
             TokenKind::Semicolon => "`;`",
-            TokenKind::Unexpected => "an unexpected character",
             TokenKind::EOF => "EOF",
+            TokenKind::Unexpected => "an unexpected character",
         }
     }
 }
@@ -93,9 +93,9 @@ impl<K: fmt::Display> fmt::Display for ParsingError<K> {
             position,
             previous,
         } = self;
-        write!(f, "{kind} @ {position}")?;
+        write!(f, "at {position}: {kind}")?;
         if let Some(previous) = previous {
-            write!(f, "\t might be caused by: {previous}")?
+            write!(f, ";\nthis might be caused by an error {previous}")?
         }
         Ok(())
     }
@@ -127,10 +127,10 @@ impl fmt::Display for Recoverable {
                     &TokenKind::EOF,
                     "Complaining about finding EOF instead of EOF?"
                 );
-                write!(f, "Expected EOF, but found {found}")
+                write!(f, "expected EOF, but found {found}")
             }
-            Self::MalformedReal(error) => write!(f, "Malformed real literal: {error}"),
-            Self::MalformedInteger(error) => write!(f, "Malformed integer literal: {error}"),
+            Self::MalformedReal(error) => write!(f, "malformed real literal: {error}"),
+            Self::MalformedInteger(error) => write!(f, "malformed integer literal: {error}"),
         }
     }
 }
@@ -158,7 +158,7 @@ impl fmt::Display for Fatal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnexpectedToken { found, expected } => {
-                write!(f, "Expected ")?;
+                write!(f, "expected ")?;
 
                 let or_after = expected.len().checked_sub(2);
                 for (i, &expected) in expected.iter().enumerate() {
@@ -188,9 +188,12 @@ pub enum FinalError<T> {
 impl<T: fmt::Debug> fmt::Display for FinalError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Failed(fatal) => write!(f, "Failed to parse: {fatal}"),
+            Self::Failed(fatal) => write!(f, "Parsing error {fatal}."),
             Self::ParsedWithError { last, parsed } => {
-                write!(f, "{last}\nHowever, managed to parse:\n{parsed:#?}")
+                write!(
+                    f,
+                    "Parsing error {last}.\nHowever, managed to parse:\n{parsed:#?}"
+                )
             }
         }
     }

--- a/compiler/parser/src/reporting.rs
+++ b/compiler/parser/src/reporting.rs
@@ -67,7 +67,6 @@ impl From<TokenKind> for &'static str {
             TokenKind::Not => "`not`",
             TokenKind::Semicolon => "`;`",
             TokenKind::EOF => "EOF",
-            TokenKind::Unexpected => "an unexpected character",
         }
     }
 }
@@ -116,6 +115,7 @@ pub enum Recoverable {
     NotEOF(TokenKind),
     MalformedReal(ParseFloatError),
     MalformedInteger(ParseIntError),
+    UnexpectedCharacter(char),
 }
 
 impl fmt::Display for Recoverable {
@@ -131,6 +131,7 @@ impl fmt::Display for Recoverable {
             }
             Self::MalformedReal(error) => write!(f, "malformed real literal: {error}"),
             Self::MalformedInteger(error) => write!(f, "malformed integer literal: {error}"),
+            Self::UnexpectedCharacter(c) => write!(f, "unexpected character: {c:?}"),
         }
     }
 }
@@ -138,7 +139,7 @@ impl fmt::Display for Recoverable {
 impl Error for Recoverable {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::NotEOF(_) => None,
+            Self::NotEOF(_) | Self::UnexpectedCharacter(_) => None,
             Self::MalformedReal(e) => Some(e),
             Self::MalformedInteger(e) => Some(e),
         }

--- a/compiler/parser/src/reporting.rs
+++ b/compiler/parser/src/reporting.rs
@@ -1,0 +1,210 @@
+use core::{
+    error::Error,
+    fmt,
+    num::{ParseFloatError, ParseIntError},
+};
+
+use common::Position;
+
+use crate::parser::{Expected, TokenKind};
+
+impl From<TokenKind> for &'static str {
+    fn from(kind: TokenKind) -> Self {
+        match kind {
+            TokenKind::Var => "`var`",
+            TokenKind::Type => "`type`",
+            TokenKind::Routine => "`routine`",
+            TokenKind::Array => "`array`",
+            TokenKind::Record => "`record`",
+            TokenKind::Is => "`is`",
+            TokenKind::End => "`end`",
+            TokenKind::If => "`if`",
+            TokenKind::Then => "`then`",
+            TokenKind::Else => "`else`",
+            TokenKind::Return => "`return`",
+            TokenKind::In => "`in`",
+            TokenKind::While => "`while`",
+            TokenKind::For => "`for`",
+            TokenKind::Loop => "`loop`",
+            TokenKind::Reverse => "`reverse`",
+            TokenKind::Print => "`print`",
+            TokenKind::New => "`new`",
+            TokenKind::Null => "`null`",
+            TokenKind::Where => "`where`",
+            TokenKind::Assert => "`assert`",
+            TokenKind::Panic => "`panic`",
+            TokenKind::Constant => "`constant`",
+            TokenKind::Identifier => "an identifier",
+            TokenKind::Literal => "a literal",
+            TokenKind::Integer => "`integer`",
+            TokenKind::Real => "`real`",
+            TokenKind::Boolean => "`boolean`",
+            TokenKind::LeftBracket => "`[`",
+            TokenKind::RightBracket => "`]`",
+            TokenKind::LeftParenthesis => "`(`",
+            TokenKind::RightParenthesis => "`)`",
+            TokenKind::RightArrow => "`=>`",
+            TokenKind::Cast => "`::`",
+            TokenKind::Assignment => "`:=`",
+            TokenKind::RangeSymbol => "`..`",
+            TokenKind::Dot => "`.`",
+            TokenKind::Comma => "`,`",
+            TokenKind::Colon => "`:`",
+            TokenKind::Plus => "`+`",
+            TokenKind::Minus => "`-`",
+            TokenKind::Mul => "`*`",
+            TokenKind::Div => "`/`",
+            TokenKind::Mod => "`%`",
+            TokenKind::Eq => "`=`",
+            TokenKind::Ne => "`/=`",
+            TokenKind::Lt => "`<`",
+            TokenKind::Le => "`<=`",
+            TokenKind::Gt => "`>`",
+            TokenKind::Ge => "`>=`",
+            TokenKind::And => "`and`",
+            TokenKind::Or => "`or`",
+            TokenKind::Xor => "`xor`",
+            TokenKind::Not => "`not`",
+            TokenKind::Semicolon => "`;`",
+            TokenKind::Unexpected => "an unexpected character",
+            TokenKind::EOF => "EOF",
+        }
+    }
+}
+
+impl fmt::Display for TokenKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str((*self).into())
+    }
+}
+
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct ParsingError<K> {
+    pub position: Position,
+    pub kind: K,
+    pub previous: Option<Box<ParsingError<Recoverable>>>,
+}
+
+impl<K: fmt::Display> fmt::Display for ParsingError<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            kind,
+            position,
+            previous,
+        } = self;
+        write!(f, "{kind} @ {position}")?;
+        if let Some(previous) = previous {
+            write!(f, "\t might be caused by: {previous}")?
+        }
+        Ok(())
+    }
+}
+
+impl<K: Error> Error for ParsingError<K> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self.previous.as_deref() {
+            Some(e) => Some(e),
+            None => self.kind.source(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[must_use]
+pub enum Recoverable {
+    NotEOF(TokenKind),
+    MalformedReal(ParseFloatError),
+    MalformedInteger(ParseIntError),
+}
+
+impl fmt::Display for Recoverable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotEOF(found) => {
+                debug_assert_ne!(
+                    found,
+                    &TokenKind::EOF,
+                    "Complaining about finding EOF instead of EOF?"
+                );
+                write!(f, "Expected EOF, but found {found}")
+            }
+            Self::MalformedReal(error) => write!(f, "Malformed real literal: {error}"),
+            Self::MalformedInteger(error) => write!(f, "Malformed integer literal: {error}"),
+        }
+    }
+}
+
+impl Error for Recoverable {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::NotEOF(_) => None,
+            Self::MalformedReal(e) => Some(e),
+            Self::MalformedInteger(e) => Some(e),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[must_use]
+pub enum Fatal {
+    UnexpectedToken {
+        found: TokenKind,
+        expected: Expected,
+    },
+}
+
+impl fmt::Display for Fatal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedToken { found, expected } => {
+                write!(f, "Expected ")?;
+
+                let or_after = expected.len().checked_sub(2);
+                for (i, &expected) in expected.iter().enumerate() {
+                    write!(
+                        f,
+                        "{expected}{} ",
+                        if or_after == Some(i) { " or" } else { "," }
+                    )?
+                }
+                write!(f, "but found {found}")
+            }
+        }
+    }
+}
+
+impl Error for Fatal {}
+
+#[derive(Debug)]
+pub enum FinalError<T> {
+    ParsedWithError {
+        last: ParsingError<Recoverable>,
+        parsed: T,
+    },
+    Failed(ParsingError<Fatal>),
+}
+
+impl<T: fmt::Debug> fmt::Display for FinalError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Failed(fatal) => write!(f, "Failed to parse: {fatal}"),
+            Self::ParsedWithError { last, parsed } => {
+                write!(f, "{last}\nHowever, managed to parse:\n{parsed:#?}")
+            }
+        }
+    }
+}
+
+impl<T> Error for FinalError<T>
+where
+    T: fmt::Debug,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(match self {
+            Self::ParsedWithError { last, parsed: _ } => last,
+            Self::Failed(e) => e,
+        })
+    }
+}
+pub type FinalResult<T> = Result<T, FinalError<T>>;

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -3,8 +3,7 @@ use lexer::Lexer;
 use crate::{FinalError, Program, parse_program};
 
 fn parse(src: &str) -> Result<String, FinalError<Program>> {
-    let tokens: Vec<_> = Lexer::from(src).collect();
-    parse_program(tokens).map(|program| format!("{program:#?}\n"))
+    parse_program(Lexer::from(src)).map(|program| format!("{program:#?}\n"))
 }
 
 testing::tests! {

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -95,5 +95,6 @@ testing::tests! {
         binary_not => "binary_not"
         invalid => "invalid"
         lexer_invalid => "lexer_invalid"
+        malformed_integer => "malformed_integer"
     ]
 }

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -11,7 +11,7 @@ fn no_eof() {
     let res = parser.parse_expr();
     let res = parser.finish(res);
     testing::expect![[r#"
-        Expected EOF, but found an identifier @ 1:8
+        Parsing error at 1:8: expected EOF, but found an identifier.
         However, managed to parse:
         BinOp {
             op: Plus,

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -1,6 +1,35 @@
 use lexer::Lexer;
 
-use crate::{FinalError, Program, parse_program};
+use crate::{FinalError, Parser, Program, parse_program};
+
+/// Sadly, `parse_program` will never finish successfully without reaching EOF.
+/// But the public `parse_expr` will. So here's a test to check that behavior.
+#[test]
+fn no_eof() {
+    let src = "(1 + 2) a";
+    let mut parser = Parser::new(Lexer::from(src));
+    let res = parser.parse_expr();
+    let res = parser.finish(res);
+    testing::expect![[r#"
+        Expected EOF, but found an identifier @ 1:8
+        However, managed to parse:
+        BinOp {
+            op: Plus,
+            lhs: Literal(
+                Integer {
+                    repr: "1",
+                    value: 1,
+                },
+            ),
+            rhs: Literal(
+                Integer {
+                    repr: "2",
+                    value: 2,
+                },
+            ),
+        }"#]]
+    .assert_eq(&res.expect_err("This is not a valid expression").to_string())
+}
 
 fn parse(src: &str) -> Result<String, FinalError<Program>> {
     parse_program(Lexer::from(src)).map(|program| format!("{program:#?}\n"))

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -1,8 +1,8 @@
 use lexer::Lexer;
 
-use crate::{ParserError, Program, parse_program};
+use crate::{FinalError, Program, parse_program};
 
-fn parse(src: &str) -> Result<String, ParserError<Program>> {
+fn parse(src: &str) -> Result<String, FinalError<Program>> {
     let tokens: Vec<_> = Lexer::from(src).collect();
     parse_program(tokens).map(|program| format!("{program:#?}\n"))
 }

--- a/compiler/parser/src/tests.rs
+++ b/compiler/parser/src/tests.rs
@@ -4,7 +4,7 @@ use crate::{ParserError, Program, parse_program};
 
 fn parse(src: &str) -> Result<String, ParserError<Program>> {
     let tokens: Vec<_> = Lexer::from(src).collect();
-    parse_program(&tokens).map(|program| format!("{program:#?}\n"))
+    parse_program(tokens).map(|program| format!("{program:#?}\n"))
 }
 
 testing::tests! {

--- a/compiler/parser/src/tree.rs
+++ b/compiler/parser/src/tree.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use derive_where::derive_where;
 
 use common::{Integer, LoopOrder, Position, RawIdentifier, Real};
@@ -29,40 +27,40 @@ pub enum Literal {
 pub enum LvalueExpression {
     Identifier(RawIdentifier),
     Member {
-        lhs: Rc<LvalueExpression>,
+        lhs: Box<LvalueExpression>,
         member_name: RawIdentifier,
     },
     Index {
-        lhs: Rc<LvalueExpression>,
-        index: Rc<Expression>,
+        lhs: Box<LvalueExpression>,
+        index: Box<Expression>,
     },
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub enum Expression {
-    LvalueToRvalue(Rc<LvalueExpression>),
+    LvalueToRvalue(LvalueExpression),
     Literal(Literal),
     Call {
         callee: RawIdentifier,
-        args: Vec<Rc<Expression>>,
+        args: Vec<Expression>,
     },
     BinOp {
         op: Operator,
-        lhs: Rc<Expression>,
-        rhs: Rc<Expression>,
+        lhs: Box<Expression>,
+        rhs: Box<Expression>,
     },
     UnOp {
         op: Operator,
-        operand: Rc<Expression>,
+        operand: Box<Expression>,
     },
     Cast {
-        operand: Rc<Expression>,
-        target: Type,
+        operand: Box<Expression>,
+        target: Box<Type>,
     },
     New {
-        t: Type,
-        fields: Option<Vec<(RawIdentifier, Rc<Expression>)>>,
-        array_length: Option<Rc<Expression>>,
+        t: Box<Type>,
+        fields: Option<Vec<(RawIdentifier, Expression)>>,
+        array_length: Option<Box<Expression>>,
     },
     Null,
 }
@@ -71,14 +69,14 @@ pub enum Expression {
 pub struct VarDecl {
     pub name: RawIdentifier,
     pub t: Option<Type>,
-    pub initialiser: Option<Rc<Expression>>,
+    pub initialiser: Option<Expression>,
 }
 
 #[derive(Debug, Hash)]
 pub struct ConstDecl {
     pub name: RawIdentifier,
     pub t: Option<Type>,
-    pub initialiser: Rc<Expression>,
+    pub initialiser: Expression,
 }
 
 #[derive(Debug, Hash)]
@@ -90,7 +88,7 @@ pub struct TypeDecl {
 #[derive(Debug)]
 pub enum RoutineBody {
     Block(Block),
-    Expression(Rc<Expression>),
+    Expression(Expression),
 }
 
 #[derive(Debug)]
@@ -115,38 +113,38 @@ pub struct Block(pub Vec<BlockElem>);
 #[derive(Debug)]
 pub enum Statement {
     Assignment {
-        lhs: Rc<LvalueExpression>,
-        rhs: Rc<Expression>,
+        lhs: LvalueExpression,
+        rhs: Expression,
     },
     While {
-        condition: Rc<Expression>,
+        condition: Expression,
         body: Block,
     },
-    Expr(Rc<Expression>),
+    Expr(Expression),
     If {
-        condition: Rc<Expression>,
+        condition: Expression,
         on_true: Block,
         on_false: Option<Block>,
     },
     For {
         counter: RawIdentifier,
-        from: Rc<Expression>,
-        to: Option<Rc<Expression>>,
+        from: Expression,
+        to: Option<Expression>,
         order: LoopOrder,
         body: Block,
     },
     Print {
-        value: Rc<Expression>,
+        value: Expression,
     },
     Return {
-        value: Rc<Expression>,
+        value: Expression,
     },
     Panic {
         pos: Position,
     },
     Assert {
         pos: Position,
-        value: Rc<Expression>,
+        value: Expression,
     },
 }
 

--- a/compiler/parser/src/types.rs
+++ b/compiler/parser/src/types.rs
@@ -1,5 +1,4 @@
 use std::fmt::Debug;
-use std::rc::Rc;
 
 use common::RawIdentifier;
 
@@ -19,7 +18,7 @@ pub struct RecordDescription {
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ArrayDescription {
     pub t: Box<Type>,
-    pub length: Option<Rc<Expression>>,
+    pub length: Option<Expression>,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]

--- a/compiler/repl/src/main.rs
+++ b/compiler/repl/src/main.rs
@@ -4,15 +4,12 @@ use std::{
 };
 
 use lexer::Lexer;
-use parser::{Expression, IndexedIterator, Parser, ParserResult, TokenIterator as _};
+use parser::{Expression, Parser, ParserResult};
 
 fn parse_expr_from_line(str: &str) -> ParserResult<Rc<Expression>> {
-    let tokens: Vec<_> = Lexer::from(str).collect();
-    let mut parser = Parser::new();
-    let start = IndexedIterator::from(tokens.as_slice());
-    let (result, tail) = parser.parse_expr(start)?;
-    assert_eq!(tail.current(), None, "Unparsed tokens");
-    parser.finish(result)
+    let mut parser = Parser::new(Lexer::from(str));
+    let expr = parser.parse_expr()?;
+    parser.finish(expr)
 }
 
 fn main() -> io::Result<()> {

--- a/compiler/repl/src/main.rs
+++ b/compiler/repl/src/main.rs
@@ -1,11 +1,11 @@
 use std::io::{self, Write};
 
 use lexer::Lexer;
-use parser::{Expression, Parser, ParserResult};
+use parser::{Expression, Parser};
 
-fn parse_expr_from_line(str: &str) -> ParserResult<Expression> {
+fn parse_expr_from_line(str: &str) -> parser::FinalResult<Expression> {
     let mut parser = Parser::new(Lexer::from(str));
-    let expr = parser.parse_expr()?;
+    let expr = parser.parse_expr();
     parser.finish(expr)
 }
 

--- a/compiler/repl/src/main.rs
+++ b/compiler/repl/src/main.rs
@@ -1,12 +1,9 @@
-use std::{
-    io::{self, Write},
-    rc::Rc,
-};
+use std::io::{self, Write};
 
 use lexer::Lexer;
 use parser::{Expression, Parser, ParserResult};
 
-fn parse_expr_from_line(str: &str) -> ParserResult<Rc<Expression>> {
+fn parse_expr_from_line(str: &str) -> ParserResult<Expression> {
     let mut parser = Parser::new(Lexer::from(str));
     let expr = parser.parse_expr()?;
     parser.finish(expr)
@@ -22,7 +19,7 @@ fn main() -> io::Result<()> {
         let _: usize = io::stdin().read_line(&mut buffer)?;
 
         match parse_expr_from_line(&buffer) {
-            Ok(expr) => println!("{:?}", *expr),
+            Ok(expr) => println!("{expr:?}"),
             Err(err) => println!("error: {err}"),
         }
     }

--- a/compiler/testing/src/lib.rs
+++ b/compiler/testing/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "testing")]
 use core::fmt;
 
 pub mod paths;
@@ -27,7 +28,7 @@ pub type TestResult = anyhow::Result<()>;
 
 #[track_caller]
 #[cfg(feature = "testing")]
-pub fn run_test<E: fmt::Debug>(
+pub fn run_test<E: fmt::Display>(
     folder: &str,
     out_extension: &str,
     run: fn(&str) -> Result<String, E>,
@@ -41,15 +42,18 @@ pub fn run_test<E: fmt::Debug>(
     let result = run(&source);
     let expected =
         ::expect_test::expect_file![paths::output_for(folder, test, out_extension, mode)];
-    match mode {
-        Mode::Pass => expected.assert_eq(&result.expect("Test failed but expected to pass")),
+    expected.assert_eq(&match mode {
+        Mode::Pass => match result {
+            Ok(actual) => actual,
+            Err(e) => bail!("Test expected to pass, but failed with the following result:\n{e}"),
+        },
         Mode::Fail => match result {
             Ok(actual) => {
                 bail!("Test expected to fail, but passed with the following result:\n{actual}")
             }
-            Err(e) => expected.assert_debug_eq(&e),
+            Err(e) => format!("{e}\n"),
         },
-    }
+    });
     Ok(())
 }
 

--- a/compiler/testing/src/lib.rs
+++ b/compiler/testing/src/lib.rs
@@ -1,5 +1,7 @@
-#[cfg(feature = "testing")]
 use core::fmt;
+
+#[cfg(feature = "testing")]
+pub use expect_test::{expect, expect_file};
 
 pub mod paths;
 
@@ -40,8 +42,7 @@ pub fn run_test<E: fmt::Display>(
     let source = std::fs::read_to_string(&test_src)
         .with_context(|| format!("Error reading {}", test_src.display()))?;
     let result = run(&source);
-    let expected =
-        ::expect_test::expect_file![paths::output_for(folder, test, out_extension, mode)];
+    let expected = expect_file![paths::output_for(folder, test, out_extension, mode)];
     expected.assert_eq(&match mode {
         Mode::Pass => match result {
             Ok(actual) => actual,

--- a/tests/ast/fail/array_slice_eq.txt
+++ b/tests/ast/fail/array_slice_eq.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Can not apply operator Eq for array [3] integer and array [] integer",
-}
+Can not apply operator Eq for array [3] integer and array [] integer

--- a/tests/ast/fail/bool_arith.txt
+++ b/tests/ast/fail/bool_arith.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Can not apply arithmetic operator Plus for bool and bool",
-}
+Can not apply arithmetic operator Plus for bool and bool

--- a/tests/ast/fail/bool_ord.txt
+++ b/tests/ast/fail/bool_ord.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Can not apply order comparison operator Ge for bool and bool",
-}
+Can not apply order comparison operator Ge for bool and bool

--- a/tests/ast/fail/field_not_record.txt
+++ b/tests/ast/fail/field_not_record.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Type `real` have no fields, but field `length` was requested for it",
-}
+Type `real` have no fields, but field `length` was requested for it

--- a/tests/ast/fail/invalid_array_length.txt
+++ b/tests/ast/fail/invalid_array_length.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Compile-time non negative constant expected but found -1: out of range integral type conversion attempted",
-}
+Compile-time non negative constant expected but found -1: out of range integral type conversion attempted

--- a/tests/ast/fail/new_array_fixed.txt
+++ b/tests/ast/fail/new_array_fixed.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "new[] is only supported for array[] types without length",
-}
+new[] is only supported for array[] types without length

--- a/tests/ast/fail/no_such_field.txt
+++ b/tests/ast/fail/no_such_field.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "No field of name bar in struct with fields [FieldDescription { name: r\"foo\", t: Real }]",
-}
+No field of name bar in struct with fields [FieldDescription { name: r"foo", t: Real }]

--- a/tests/ast/fail/not_scalar_arith.txt
+++ b/tests/ast/fail/not_scalar_arith.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Can not apply arithmetic operator Plus for array [] integer and array [] integer",
-}
+Can not apply arithmetic operator Plus for array [] integer and array [] integer

--- a/tests/ast/fail/not_scalar_ord.txt
+++ b/tests/ast/fail/not_scalar_ord.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Can not apply order comparison operator Lt for array [] integer and array [] integer",
-}
+Can not apply order comparison operator Lt for array [] integer and array [] integer

--- a/tests/ast/fail/real_mod.txt
+++ b/tests/ast/fail/real_mod.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Can not apply modulo operator Mod for real and integer",
-}
+Can not apply modulo operator Mod for real and integer

--- a/tests/ast/fail/routine_redefinition.txt
+++ b/tests/ast/fail/routine_redefinition.txt
@@ -1,3 +1,1 @@
-AnalysisError {
-    what: "Conflicting declarations of routine r\"foo\"",
-}
+Conflicting declarations of routine r"foo"

--- a/tests/lexer/pass/malformed_integer.txt
+++ b/tests/lexer/pass/malformed_integer.txt
@@ -1,0 +1,9 @@
+"routine" @ 1:0-1:7 is KEYWORD(Routine)
+"main" @ 1:8-1:12 is IDENTIFIER(main)
+"(" @ 1:12-1:13 is LEFT PARENTHESIS
+")" @ 1:13-1:14 is RIGHT PARENTHESIS
+"is" @ 1:15-1:17 is KEYWORD(Is)
+"print" @ 2:4-2:9 is KEYWORD(Print)
+"12345678901234567890" @ 2:10-2:30 is INVALID(Malformed integer literal: number too large to fit in target type)
+";" @ 2:30-2:31 is SEMICOLON
+"end" @ 3:0-3:3 is KEYWORD(End)

--- a/tests/parser/fail/binary_not.txt
+++ b/tests/parser/fail/binary_not.txt
@@ -1,6 +1,6 @@
 Unrecoverable {
     error: ParsingError {
-        what: "Token of kind SEMICOLON expected, token \"not\" @ 1:43-1:46 is OPERATOR(Not) found",
+        what: "Expected `[`, `(`, `::`, `.`, `;`, `+`, `-`, `*`, `/`, `%`, `=`, `/=`, `<`, `<=`, `>`, `>=`, `and`, `or` or `xor`, but found `not`",
         position: Position {
             line: 1,
             column: 43,

--- a/tests/parser/fail/binary_not.txt
+++ b/tests/parser/fail/binary_not.txt
@@ -1,1 +1,1 @@
-unrecoverable error: Expected `[`, `(`, `::`, `.`, `;`, `+`, `-`, `*`, `/`, `%`, `=`, `/=`, `<`, `<=`, `>`, `>=`, `and`, `or` or `xor`, but found `not` @ 1:43
+Failed to parse: Expected `[`, `(`, `::`, `.`, `;`, `+`, `-`, `*`, `/`, `%`, `=`, `/=`, `<`, `<=`, `>`, `>=`, `and`, `or` or `xor`, but found `not` @ 1:43

--- a/tests/parser/fail/binary_not.txt
+++ b/tests/parser/fail/binary_not.txt
@@ -1,1 +1,1 @@
-Failed to parse: Expected `[`, `(`, `::`, `.`, `;`, `+`, `-`, `*`, `/`, `%`, `=`, `/=`, `<`, `<=`, `>`, `>=`, `and`, `or` or `xor`, but found `not` @ 1:43
+Parsing error at 1:43: expected `[`, `(`, `::`, `.`, `+`, `-`, `*`, `/`, `%`, `=`, `/=`, `<`, `<=`, `>`, `>=`, `and`, `or`, `xor` or `;`, but found `not`.

--- a/tests/parser/fail/binary_not.txt
+++ b/tests/parser/fail/binary_not.txt
@@ -1,9 +1,1 @@
-Unrecoverable {
-    error: ParsingError {
-        what: "Expected `[`, `(`, `::`, `.`, `;`, `+`, `-`, `*`, `/`, `%`, `=`, `/=`, `<`, `<=`, `>`, `>=`, `and`, `or` or `xor`, but found `not`",
-        position: Position {
-            line: 1,
-            column: 43,
-        },
-    },
-}
+unrecoverable error: Expected `[`, `(`, `::`, `.`, `;`, `+`, `-`, `*`, `/`, `%`, `=`, `/=`, `<`, `<=`, `>`, `>=`, `and`, `or` or `xor`, but found `not` @ 1:43

--- a/tests/parser/fail/invalid.txt
+++ b/tests/parser/fail/invalid.txt
@@ -1,9 +1,1 @@
-Unrecoverable {
-    error: ParsingError {
-        what: "Expected `var`, `type`, `routine`, `constant` or EOF, but found `;`",
-        position: Position {
-            line: 3,
-            column: 3,
-        },
-    },
-}
+unrecoverable error: Expected `var`, `type`, `routine`, `constant` or EOF, but found `;` @ 3:3

--- a/tests/parser/fail/invalid.txt
+++ b/tests/parser/fail/invalid.txt
@@ -1,6 +1,6 @@
 Unrecoverable {
     error: ParsingError {
-        what: "Declaration expected, \";\" @ 3:3-3:4 is SEMICOLON found",
+        what: "Expected `var`, `type`, `routine`, `constant` or EOF, but found `;`",
         position: Position {
             line: 3,
             column: 3,

--- a/tests/parser/fail/invalid.txt
+++ b/tests/parser/fail/invalid.txt
@@ -1,1 +1,1 @@
-Failed to parse: Expected `var`, `type`, `routine`, `constant` or EOF, but found `;` @ 3:3
+Parsing error at 3:3: expected `var`, `type`, `routine`, `constant` or EOF, but found `;`.

--- a/tests/parser/fail/invalid.txt
+++ b/tests/parser/fail/invalid.txt
@@ -1,1 +1,1 @@
-unrecoverable error: Expected `var`, `type`, `routine`, `constant` or EOF, but found `;` @ 3:3
+Failed to parse: Expected `var`, `type`, `routine`, `constant` or EOF, but found `;` @ 3:3

--- a/tests/parser/fail/lexer_invalid.txt
+++ b/tests/parser/fail/lexer_invalid.txt
@@ -1,1 +1,1 @@
-unrecoverable error: Expected an identifier, but found an unexpected character @ 2:6
+Failed to parse: Expected an identifier, but found an unexpected character @ 2:6

--- a/tests/parser/fail/lexer_invalid.txt
+++ b/tests/parser/fail/lexer_invalid.txt
@@ -1,1 +1,2 @@
-Parsing error at 2:6: expected an identifier, but found an unexpected character.
+Parsing error at 2:8: expected an identifier, but found `is`;
+this might be caused by an error at 2:6: unexpected character: '🐈'.

--- a/tests/parser/fail/lexer_invalid.txt
+++ b/tests/parser/fail/lexer_invalid.txt
@@ -1,1 +1,1 @@
-Failed to parse: Expected an identifier, but found an unexpected character @ 2:6
+Parsing error at 2:6: expected an identifier, but found an unexpected character.

--- a/tests/parser/fail/lexer_invalid.txt
+++ b/tests/parser/fail/lexer_invalid.txt
@@ -1,6 +1,6 @@
 Unrecoverable {
     error: ParsingError {
-        what: "Expected an identifier, but found an invalid token",
+        what: "Expected an identifier, but found an unexpected character",
         position: Position {
             line: 2,
             column: 6,

--- a/tests/parser/fail/lexer_invalid.txt
+++ b/tests/parser/fail/lexer_invalid.txt
@@ -1,9 +1,1 @@
-Unrecoverable {
-    error: ParsingError {
-        what: "Expected an identifier, but found an unexpected character",
-        position: Position {
-            line: 2,
-            column: 6,
-        },
-    },
-}
+unrecoverable error: Expected an identifier, but found an unexpected character @ 2:6

--- a/tests/parser/fail/lexer_invalid.txt
+++ b/tests/parser/fail/lexer_invalid.txt
@@ -1,9 +1,9 @@
 Unrecoverable {
     error: ParsingError {
-        what: "Token of kind KEYWORD(End) expected, token \"var\" @ 2:2-2:5 is KEYWORD(Var) found",
+        what: "Expected an identifier, but found an invalid token",
         position: Position {
             line: 2,
-            column: 2,
+            column: 6,
         },
     },
 }

--- a/tests/parser/fail/malformed_integer.txt
+++ b/tests/parser/fail/malformed_integer.txt
@@ -1,0 +1,31 @@
+Malformed integer literal: number too large to fit in target type @ 2:10
+However, managed to parse:
+Program(
+    [
+        Routine(
+            RoutineDecl {
+                name: r"main",
+                arguments: [],
+                return_type: None,
+                body: Some(
+                    Block(
+                        Block(
+                            [
+                                Stmt(
+                                    Print {
+                                        value: Literal(
+                                            Integer {
+                                                repr: "12345678901234567890",
+                                                value: 0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            },
+        ),
+    ],
+)

--- a/tests/parser/fail/malformed_integer.txt
+++ b/tests/parser/fail/malformed_integer.txt
@@ -1,4 +1,4 @@
-Malformed integer literal: number too large to fit in target type @ 2:10
+Parsing error at 2:10: malformed integer literal: number too large to fit in target type.
 However, managed to parse:
 Program(
     [

--- a/tests/src/¡malformed_integer!
+++ b/tests/src/¡malformed_integer!
@@ -1,0 +1,3 @@
+routine main() is
+    print 12345678901234567890;
+end


### PR DESCRIPTION
- Closes #68
- Based on top of #142
- Makes #143 obsolete
- Removes `Rc` from `parser` (see #111)

The design is stolen from `rustc_parse`.

Notable differences:
- better error messages
- accepts a trailing comma in argument lists for routine declarations and call expressions
- recovers from unexpected characters (by skipping them)

TODO:
- test for trailing commas
- tests for parser failures
