### PR TITLE
simplify handling of literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ name = "ast"
 version = "0.0.0"
 dependencies = [
  "common",
- "derive-where",
  "lexer",
  "parser",
  "testing",

--- a/compiler/ast/Cargo.toml
+++ b/compiler/ast/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 common.path = "../common"
 parser.path = "../parser"
-derive-where.workspace = true
 
 [dev-dependencies]
 lexer.path = "../lexer"

--- a/compiler/ast/src/convert.rs
+++ b/compiler/ast/src/convert.rs
@@ -495,12 +495,9 @@ impl Converter {
                         ty: Rc::clone(t),
                     }),
                     Binding {
-                        decl: Decl::Const(ConstDecl { value, t }),
+                        decl: Decl::Const(ConstDecl { value }),
                         ..
-                    } => Ok(Typed {
-                        value: Rc::clone(value), // Constants are immediately propagated
-                        ty: Rc::clone(t),
-                    }),
+                    } => Ok(value.as_literal().into()), // Constants are immediately propagated
 
                     t => Err(AnalysisError {
                         what: format!(
@@ -523,27 +520,7 @@ impl Converter {
             parser::Expression::LvalueToRvalue(lvalue_expression) => {
                 self.convert_lvalue_expr_in_rvalue_context(lvalue_expression)?
             }
-            parser::Expression::IntegerLiteral(integer_literal) => Typed {
-                value: Rc::new(Expression::IntegerLiteral(IntegerLiteral {
-                    repr: integer_literal.repr.clone(),
-                    value: integer_literal.value,
-                })),
-                ty: Type::int(),
-            },
-            parser::Expression::RealLiteral(real_literal) => Typed {
-                value: Rc::new(Expression::RealLiteral(RealLiteral {
-                    repr: real_literal.repr.clone(),
-                    value: real_literal.value,
-                })),
-                ty: Rc::new(Type::Real),
-            },
-            parser::Expression::BoolLiteral(bool_literal) => Typed {
-                value: Rc::new(Expression::BoolLiteral(match bool_literal {
-                    parser::BoolLiteral::True => BoolLiteral::True,
-                    parser::BoolLiteral::False => BoolLiteral::False,
-                })),
-                ty: Type::bool(),
-            },
+            parser::Expression::Literal(literal) => literal.clone().into(),
             parser::Expression::Call { callee, args } => self.convert_call(callee, args)?,
             parser::Expression::BinOp { op, lhs, rhs } => {
                 let lhs = self.convert_expr(lhs)?;
@@ -789,18 +766,16 @@ impl Converter {
                 let t = self.convert_type(t)?;
                 let expr = self.bindings.coerce(expr, &t)?;
                 ConstDecl {
-                    t,
-                    value: expr.try_constexpr_evaluate()?.as_literal(),
+                    value: expr.try_constexpr_evaluate()?,
                 }
             }
             None => ConstDecl {
-                t: expr.ty,
-                value: expr.value.try_constexpr_evaluate()?.as_literal(),
+                value: expr.value.try_constexpr_evaluate()?,
             },
         };
 
         Ok(Binding {
-            decl: decl.clone(),
+            decl,
             name: if is_global {
                 self.bind_global_decl(name, Decl::Const(decl))
             } else {

--- a/compiler/ast/src/lib.rs
+++ b/compiler/ast/src/lib.rs
@@ -13,9 +13,9 @@ pub use crate::{
     convert::convert,
     operators::{BinaryOperator, BoolBinOp, EqBinOp, IntBinOp, RealBinOp, UnaryOperator},
     tree::{
-        Binding, Bindings, Block, BoolLiteral, ConstDecl, Decl, Expression, IntegerLiteral,
-        LocalBinding, LocalDecl, LvalueExpression, Program, RealLiteral, Routine, RoutineBody,
-        RoutineDecl, RoutineSignature, Statement, TypeDecl, VarDecl,
+        Binding, Bindings, Block, ConstDecl, Decl, EvaluatedValue, Expression, Literal,
+        LocalBinding, LocalDecl, LvalueExpression, Program, Routine, RoutineBody, RoutineDecl,
+        RoutineSignature, Statement, TypeDecl, VarDecl,
     },
     types::{ArrayDescription, FieldDescription, RecordDescription, Type},
 };

--- a/compiler/ast/src/tree.rs
+++ b/compiler/ast/src/tree.rs
@@ -1,80 +1,17 @@
 use core::ops::Index;
 use std::rc::Rc;
 
-use derive_where::derive_where;
-
 use common::{
     BindingId, Identifier, Integer, Location, LoopOrder, Position, RawIdentifier, Real, VarLoc,
     integer_to_real, real_to_integer,
 };
+pub use parser::Literal;
 
 use crate::{
     AnalysisError, AnalysisResult, Typed,
     operators::{BinaryOperator, BoolBinOp, EqBinOp, IntBinOp, RealBinOp, UnaryOperator},
     types::{ArrayDescription, Type},
 };
-
-#[derive(Debug)]
-#[derive_where(Hash, Eq, PartialEq)]
-pub struct IntegerLiteral {
-    pub repr: String,
-    #[derive_where(skip(EqHashOrd))]
-    pub value: Integer,
-}
-
-impl From<&IntegerLiteral> for Integer {
-    fn from(value: &IntegerLiteral) -> Self {
-        value.value
-    }
-}
-
-#[derive(Debug)]
-#[derive_where(Hash, Eq, PartialEq)]
-pub struct RealLiteral {
-    pub repr: String,
-    #[derive_where(skip(EqHashOrd))]
-    pub value: Real,
-}
-
-impl From<&RealLiteral> for Real {
-    fn from(value: &RealLiteral) -> Self {
-        value.value
-    }
-}
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-pub enum BoolLiteral {
-    True,
-    False,
-}
-
-impl From<bool> for BoolLiteral {
-    fn from(value: bool) -> Self {
-        #[expect(clippy::match_bool, reason = "prettier this way")]
-        match value {
-            true => Self::True,
-            false => Self::False,
-        }
-    }
-}
-
-impl From<BoolLiteral> for bool {
-    fn from(value: BoolLiteral) -> Self {
-        match value {
-            BoolLiteral::True => true,
-            BoolLiteral::False => false,
-        }
-    }
-}
-
-impl From<BoolLiteral> for Integer {
-    fn from(value: BoolLiteral) -> Self {
-        match value {
-            BoolLiteral::True => 1,
-            BoolLiteral::False => 0,
-        }
-    }
-}
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub enum LvalueExpression {
@@ -92,9 +29,7 @@ pub enum LvalueExpression {
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub enum Expression {
     LvalueToRvalue(Rc<LvalueExpression>),
-    IntegerLiteral(IntegerLiteral),
-    RealLiteral(RealLiteral),
-    BoolLiteral(BoolLiteral),
+    Literal(Literal),
     Call {
         callee: Identifier,
         args: Vec<Rc<Expression>>,
@@ -130,8 +65,21 @@ pub enum Expression {
     IntToReal(Rc<Expression>),
 }
 
-#[derive(Debug, PartialEq)]
-pub(crate) enum EvaluatedValue {
+impl From<Literal> for Typed<Expression> {
+    fn from(literal: Literal) -> Self {
+        Typed {
+            ty: match literal {
+                Literal::Bool { .. } => Type::bool(),
+                Literal::Integer { .. } => Type::int(),
+                Literal::Real { .. } => Type::real(),
+            },
+            value: Rc::new(Expression::Literal(literal)),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum EvaluatedValue {
     Int(Integer),
     Real(Real),
     Bool(bool),
@@ -167,25 +115,17 @@ impl EvaluatedValue {
 }
 
 impl EvaluatedValue {
-    // FIXME(GrigorenkoPV): introduce Expression::Literal
-    pub(crate) fn as_literal(&self) -> Rc<Expression> {
+    pub(crate) fn as_literal(&self) -> Literal {
         match self {
-            EvaluatedValue::Int(val) => Expression::IntegerLiteral(IntegerLiteral {
+            EvaluatedValue::Int(val) => Literal::Integer {
                 repr: val.to_string(),
                 value: *val,
-            })
-            .into(),
-            EvaluatedValue::Real(val) => Expression::RealLiteral(RealLiteral {
+            },
+            EvaluatedValue::Real(val) => Literal::Real {
                 repr: val.to_string(),
                 value: *val,
-            })
-            .into(),
-            EvaluatedValue::Bool(val) => Expression::BoolLiteral(if *val {
-                BoolLiteral::True
-            } else {
-                BoolLiteral::False
-            })
-            .into(),
+            },
+            EvaluatedValue::Bool(val) => Literal::Bool { value: *val },
         }
     }
 
@@ -258,9 +198,11 @@ impl BinOp<EvaluatedValue> for EqBinOp {
 impl Expression {
     pub(crate) fn try_constexpr_evaluate(&self) -> AnalysisResult<EvaluatedValue> {
         Ok(match self {
-            Expression::IntegerLiteral(lit) => EvaluatedValue::Int(lit.value),
-            Expression::RealLiteral(lit) => EvaluatedValue::Real(lit.value),
-            &Expression::BoolLiteral(lit) => EvaluatedValue::Bool(lit.into()),
+            Expression::Literal(lit) => match *lit {
+                Literal::Bool { value } => EvaluatedValue::Bool(value),
+                Literal::Integer { repr: _, value } => EvaluatedValue::Int(value),
+                Literal::Real { repr: _, value } => EvaluatedValue::Real(value),
+            },
 
             Expression::BinOp { op, lhs, rhs } => {
                 let lhs = lhs.try_constexpr_evaluate()?;
@@ -319,11 +261,9 @@ pub struct VarDecl {
     pub relative_location: Location,
 }
 
-/// FIXME(GrigorenkoPV): Typed<Literal>
-#[derive(Debug, Hash, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ConstDecl {
-    pub t: Rc<Type>,
-    pub value: Rc<Expression>,
+    pub value: EvaluatedValue,
 }
 
 #[derive(Debug, Hash, Clone)]
@@ -531,24 +471,22 @@ impl Bindings {
         identifier
     }
 
-    pub fn get_default_initialiser(&self, ty: &Rc<Type>) -> AnalysisResult<Rc<Expression>> {
-        match self.get_effective_type(ty)?.as_ref() {
-            Type::Int => Ok(Expression::IntegerLiteral(IntegerLiteral {
+    pub fn get_default_initialiser(&self, ty: &Rc<Type>) -> AnalysisResult<Expression> {
+        Ok(match self.get_effective_type(ty)?.as_ref() {
+            Type::Int => Expression::Literal(Literal::Integer {
                 repr: "0".to_string(),
                 value: 0,
-            })
-            .into()),
-            Type::Real => Ok(Expression::RealLiteral(RealLiteral {
+            }),
+            Type::Real => Expression::Literal(Literal::Real {
                 repr: "0.0".to_string(),
                 value: 0.0,
-            })
-            .into()),
-            Type::Bool => Ok(Expression::BoolLiteral(BoolLiteral::False).into()),
+            }),
+            Type::Bool => Expression::Literal(Literal::Bool { value: false }),
             Type::Alias(_) => Err(AnalysisError {
                 what: "Effective type cannot be alias".to_string(),
-            }),
-            Type::Record(_) | Type::Array(_) | Type::Null => Ok(Expression::Null.into()),
-        }
+            })?,
+            Type::Record(_) | Type::Array(_) | Type::Null => Expression::Null,
+        })
     }
 
     pub fn rebind(&mut self, ident: &Identifier, new_decl: Decl) {

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use ast::{
-    AnalysisError, AnalysisResult, Binding, Bindings, Block, Decl, Expression, LvalueExpression,
-    Program, Routine, RoutineBody, RoutineDecl, Statement, Type, VarDecl,
+    AnalysisError, AnalysisResult, Binding, Bindings, Block, Decl, Expression, Literal,
+    LvalueExpression, Program, Routine, RoutineBody, RoutineDecl, Statement, Type, VarDecl,
 };
 use common::{Integer, Position, RawIdentifier};
 
@@ -120,19 +120,13 @@ impl<'a> Compiler<'a> {
                     self.bytecode.push(Instruction::LoadAddress);
                 }
             },
-            Expression::IntegerLiteral(integer_literal) => {
-                self.bytecode.push(Instruction::IntConst {
-                    value: integer_literal.value,
-                });
-            }
-            Expression::RealLiteral(real_literal) => {
-                self.bytecode.push(Instruction::RealConst {
-                    value: real_literal.value,
-                });
-            }
-            Expression::BoolLiteral(bool_literal) => {
-                self.bytecode.push(Instruction::IntConst {
-                    value: Integer::from(*bool_literal),
+            Expression::Literal(literal) => {
+                self.bytecode.push(match *literal {
+                    Literal::Bool { value } => Instruction::IntConst {
+                        value: value.into(),
+                    },
+                    Literal::Integer { repr: _, value } => Instruction::IntConst { value },
+                    Literal::Real { repr: _, value } => Instruction::RealConst { value },
                 });
             }
             Expression::Call { callee, args } => {
@@ -279,12 +273,12 @@ impl<'a> Compiler<'a> {
                     relative_location: _,
                 }) => {
                     let initialiser = match initialiser {
-                        Some(initialiser) => Rc::clone(initialiser),
-                        None => self.bindings.get_default_initialiser(t)?,
+                        Some(initialiser) => initialiser.as_ref(),
+                        None => &self.bindings.get_default_initialiser(t)?,
                     };
 
                     // Local variable initialisation is just a `push`
-                    self.compile_expr(&initialiser)?;
+                    self.compile_expr(initialiser)?;
                 }
 
                 ast::LocalDecl::Type(_) | ast::LocalDecl::Const(_) => (),

--- a/compiler/interpreter/src/lib.rs
+++ b/compiler/interpreter/src/lib.rs
@@ -3,9 +3,9 @@ use std::{collections::HashMap, fmt::Debug, io::Write, rc::Rc};
 
 use ast::{
     ArrayDescription, BinaryOperator, Binding, Block, BoolBinOp, Decl, EqBinOp, Expression,
-    FieldDescription, IntBinOp, IntegerLiteral, LocalBinding, LocalDecl, LvalueExpression, Program,
-    RealBinOp, RealLiteral, RecordDescription, Routine, RoutineBody, RoutineDecl, Type, TypeDecl,
-    UnaryOperator, VarDecl,
+    FieldDescription, IntBinOp, Literal, LocalBinding, LocalDecl, LvalueExpression, Program,
+    RealBinOp, RecordDescription, Routine, RoutineBody, RoutineDecl, Type, TypeDecl, UnaryOperator,
+    VarDecl,
 };
 use common::{
     Identifier, Integer, LoopOrder, Position, RawIdentifier, Real, integer_to_real, real_to_integer,
@@ -374,13 +374,11 @@ impl<'a, W: Write> Interpreter<'a, W> {
     fn expression(&mut self, bindings: &mut Bindings<'a>, expression: &'a Expression) -> Value<'a> {
         match expression {
             Expression::Null => Value::Primitive(Primitive::Null),
-            &Expression::IntegerLiteral(IntegerLiteral { repr: _, value }) => {
-                Value::Primitive(Primitive::Integer(value))
-            }
-            &Expression::RealLiteral(RealLiteral { repr: _, value }) => {
-                Value::Primitive(Primitive::Real(value))
-            }
-            &Expression::BoolLiteral(l) => Value::Primitive(Primitive::Bool(l.into())),
+            Expression::Literal(literal) => Value::Primitive(match *literal {
+                Literal::Bool { value } => Primitive::Bool(value),
+                Literal::Integer { repr: _, value } => Primitive::Integer(value),
+                Literal::Real { repr: _, value } => Primitive::Real(value),
+            }),
 
             Expression::LvalueToRvalue(lvalue) => {
                 let addr = self.lvalue(bindings, lvalue)?;

--- a/compiler/lexer/src/lib.rs
+++ b/compiler/lexer/src/lib.rs
@@ -8,8 +8,8 @@ mod tokens;
 mod tests;
 
 pub use crate::tokens::{
-    BoolLiteral, BuiltinTypename, Comment, Identifier, IntegerLiteral, InvalidToken, Keyword,
-    Operator, RealLiteral, Token, TokenKind,
+    BuiltinTypename, Comment, Identifier, InvalidToken, Keyword, Literal, Operator, Token,
+    TokenKind,
 };
 
 trait ImmutableIterator<'a>: Sized + Clone + From<&'a str> {
@@ -172,13 +172,13 @@ fn name_disambiguation(lexeme: &str) -> TokenKind<'_> {
         "or" => TokenKind::Operator(Operator::Or),
         "xor" => TokenKind::Operator(Operator::Xor),
         "not" => TokenKind::Operator(Operator::Not),
-        "true" => TokenKind::BoolLiteral(BoolLiteral { value: true }),
-        "false" => TokenKind::BoolLiteral(BoolLiteral { value: false }),
+        "true" => TokenKind::Literal(Literal::Bool(true)),
+        "false" => TokenKind::Literal(Literal::Bool(false)),
         "integer" => TokenKind::BuiltinTypename(BuiltinTypename::Integer),
         "real" => TokenKind::BuiltinTypename(BuiltinTypename::Real),
         "boolean" => TokenKind::BuiltinTypename(BuiltinTypename::Boolean),
-        "NaN" => TokenKind::RealLiteral(RealLiteral { value: Real::NAN }),
-        "Inf" => TokenKind::RealLiteral(RealLiteral { value: Real::INFINITY }),
+        "NaN" => TokenKind::Literal(Literal::Real(Real::NAN)),
+        "Inf" => TokenKind::Literal(Literal::Real(Real::INFINITY)),
         "assert" => TokenKind::Keyword(Keyword::Assert),
         "panic" => TokenKind::Keyword(Keyword::Panic),
     };
@@ -239,14 +239,14 @@ fn symbolic_token<'a>(start: &IndexIterator<'a>) -> Option<(TokenKind<'a>, Index
 
 fn real_literal_from_representation(s: &str) -> TokenKind<'_> {
     match s.parse() {
-        Ok(value) => TokenKind::RealLiteral(RealLiteral { value }),
+        Ok(value) => TokenKind::Literal(Literal::Real(value)),
         Err(e) => TokenKind::Invalid(InvalidToken::MalformedReal(e)),
     }
 }
 
 fn integer_literal_from_representation(s: &str) -> TokenKind<'_> {
     match s.parse() {
-        Ok(value) => TokenKind::IntegerLiteral(IntegerLiteral { value }),
+        Ok(value) => TokenKind::Literal(Literal::Integer(value)),
         Err(e) => TokenKind::Invalid(InvalidToken::MalformedInteger(e)),
     }
 }
@@ -322,9 +322,7 @@ impl Lexer<'_> {
             | TokenKind::Keyword(_) => true,
 
             TokenKind::Identifier(_)
-            | TokenKind::IntegerLiteral(_)
-            | TokenKind::RealLiteral(_)
-            | TokenKind::BoolLiteral(_)
+            | TokenKind::Literal(_)
             | TokenKind::BuiltinTypename(_)
             | TokenKind::LeftBracket
             | TokenKind::RightParenthesis

--- a/compiler/lexer/src/tokens.rs
+++ b/compiler/lexer/src/tokens.rs
@@ -37,19 +37,11 @@ pub struct Identifier<'a> {
     pub name: &'a str,
 }
 
-#[derive(PartialEq, Eq, Hash, fmt::Debug, Clone, Copy)]
-pub struct IntegerLiteral {
-    pub value: Integer,
-}
-
 #[derive(PartialEq, fmt::Debug, Clone, Copy)]
-pub struct RealLiteral {
-    pub value: Real,
-}
-
-#[derive(PartialEq, Eq, Hash, fmt::Debug, Clone, Copy)]
-pub struct BoolLiteral {
-    pub value: bool,
+pub enum Literal {
+    Real(Real),
+    Integer(Integer),
+    Bool(bool),
 }
 
 #[derive(PartialEq, Eq, Hash, fmt::Debug, Clone, Copy)]
@@ -109,9 +101,7 @@ impl fmt::Display for Comment<'_> {
 pub enum TokenKind<'a> {
     Identifier(Identifier<'a>),
     Keyword(Keyword),
-    IntegerLiteral(IntegerLiteral),
-    RealLiteral(RealLiteral),
-    BoolLiteral(BoolLiteral),
+    Literal(Literal),
     BuiltinTypename(BuiltinTypename),
     Operator(Operator),
     Comment(Comment<'a>),
@@ -139,13 +129,13 @@ impl fmt::Display for TokenKind<'_> {
         match self {
             TokenKind::Identifier(Identifier { name }) => write!(f, "IDENTIFIER({name})"),
             TokenKind::Keyword(keyword) => write!(f, "KEYWORD({keyword:?})"),
-            TokenKind::IntegerLiteral(IntegerLiteral { value }) => {
+            TokenKind::Literal(Literal::Integer(value)) => {
                 write!(f, "INTEGER LITERAL({value})")
             }
-            TokenKind::RealLiteral(RealLiteral { value }) => {
+            TokenKind::Literal(Literal::Real(value)) => {
                 write!(f, "REAL LITERAL({value})")
             }
-            TokenKind::BoolLiteral(BoolLiteral { value }) => {
+            TokenKind::Literal(Literal::Bool(value)) => {
                 write!(f, "BOOLEAN LITERAL({value})")
             }
             TokenKind::BuiltinTypename(builtin_typename) => {

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -3,8 +3,7 @@ use std::rc::Rc;
 
 use common::{Extent, LoopOrder, Position, RawIdentifier, Real};
 use lexer::{
-    BoolLiteral as TokenBoolLiteral, BuiltinTypename, Identifier as TokenIdentifier,
-    IntegerLiteral as TokenIntegerLiteral, InvalidToken, Keyword, RealLiteral as TokenRealLiteral,
+    BuiltinTypename, Identifier as TokenIdentifier, InvalidToken, Keyword, Literal as TokenLiteral,
     Token, TokenKind,
 };
 
@@ -16,9 +15,8 @@ mod tests;
 
 pub use crate::{
     tree::{
-        Block, BlockElem, BoolLiteral, ConstDecl, Declaration, Expression, IntegerLiteral,
-        LvalueExpression, Operator, Program, RealLiteral, RoutineBody, RoutineDecl, Statement,
-        TypeDecl, VarDecl,
+        Block, BlockElem, ConstDecl, Declaration, Expression, Literal, LvalueExpression, Operator,
+        Program, RoutineBody, RoutineDecl, Statement, TypeDecl, VarDecl,
     },
     types::{ArrayDescription, FieldDescription, RecordDescription, Type},
 };
@@ -318,17 +316,17 @@ impl Parser {
         }
     }
 
-    fn parse_real_literal<'a, 'b: 'a>(
+    fn parse_literal<'a, 'b: 'a>(
         &mut self,
         i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, RealLiteral> {
+    ) -> ParsingResult<'a, 'b, Literal> {
         match i.current() {
             Some(&Token {
-                kind: TokenKind::RealLiteral(TokenRealLiteral { value }),
+                kind: TokenKind::Literal(TokenLiteral::Real(value)),
                 lexeme,
                 ..
             }) => Ok((
-                RealLiteral {
+                Literal::Real {
                     repr: lexeme.to_owned(),
                     value,
                 },
@@ -346,7 +344,7 @@ impl Parser {
                 });
 
                 Ok((
-                    RealLiteral {
+                    Literal::Real {
                         repr: lexeme.to_owned(),
                         value: Real::NAN,
                     },
@@ -354,28 +352,12 @@ impl Parser {
                 ))
             }
 
-            Some(token) => Err(ParsingError {
-                what: format!("Real literal expected, {token} found"),
-                position: i.position(),
-            }),
-            None => Err(ParsingError {
-                what: "Real literal expected, EOF found".to_owned(),
-                position: i.position(),
-            }),
-        }
-    }
-
-    fn parse_integer_literal<'a, 'b>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, IntegerLiteral> {
-        match i.current() {
             Some(&Token {
-                kind: TokenKind::IntegerLiteral(TokenIntegerLiteral { value }),
+                kind: TokenKind::Literal(TokenLiteral::Integer(value)),
                 lexeme,
                 ..
             }) => Ok((
-                IntegerLiteral {
+                Literal::Integer {
                     repr: lexeme.to_owned(),
                     value,
                 },
@@ -383,7 +365,7 @@ impl Parser {
             )),
 
             Some(&Token {
-                kind: TokenKind::Invalid(ref t @ InvalidToken::MalformedReal(_)),
+                kind: TokenKind::Invalid(ref t @ InvalidToken::MalformedInteger(_)),
                 extent: Extent { start, .. },
                 lexeme,
             }) => {
@@ -392,7 +374,7 @@ impl Parser {
                     what: t.to_string(),
                 });
                 Ok((
-                    IntegerLiteral {
+                    Literal::Integer {
                         repr: lexeme.to_owned(),
                         value: 0,
                     },
@@ -400,40 +382,17 @@ impl Parser {
                 ))
             }
 
-            Some(token) => Err(ParsingError {
-                what: format!("Integer literal expected, {token} found"),
-                position: i.position(),
-            }),
-            None => Err(ParsingError {
-                what: "Integer literal expected, EOF found".to_owned(),
-                position: i.position(),
-            }),
-        }
-    }
-
-    fn parse_bool_literal<'a, 'b>(
-        &mut self,
-        i: IndexedIterator<'a, 'b>,
-    ) -> ParsingResult<'a, 'b, BoolLiteral> {
-        match i.current() {
             Some(&Token {
-                kind: TokenKind::BoolLiteral(TokenBoolLiteral { value }),
+                kind: TokenKind::Literal(TokenLiteral::Bool(value)),
                 ..
-            }) => Ok((
-                if value {
-                    BoolLiteral::True
-                } else {
-                    BoolLiteral::False
-                },
-                self.next(i),
-            )),
+            }) => Ok((Literal::Bool { value }, self.next(i))),
+
             Some(token) => Err(ParsingError {
-                what: format!("Bool literal expected, {token} found"),
+                what: format!("Literal expected, {token} found"),
                 position: i.position(),
             }),
-
             None => Err(ParsingError {
-                what: "Bool literal expected, EOF found".to_owned(),
+                what: "Literal expected, EOF found".to_owned(),
                 position: i.position(),
             }),
         }
@@ -799,16 +758,8 @@ impl Parser {
                     .map(|((), next)| (Rc::new(Expression::Null), next))
             })
             .or_else(|_| {
-                self.parse_real_literal(i)
-                    .map(|(literal, next)| (Rc::new(Expression::RealLiteral(literal)), next))
-            })
-            .or_else(|_| {
-                self.parse_integer_literal(i)
-                    .map(|(literal, next)| (Rc::new(Expression::IntegerLiteral(literal)), next))
-            })
-            .or_else(|_| {
-                self.parse_bool_literal(i)
-                    .map(|(literal, next)| (Rc::new(Expression::BoolLiteral(literal)), next))
+                self.parse_literal(i)
+                    .map(|(literal, next)| (Rc::new(Expression::Literal(literal)), next))
             })
             .or_else(|_| self.parse_unop(Operator::Not, i))
             .or_else(|_| self.parse_unop(Operator::Minus, i))

--- a/compiler/parser/src/tree.rs
+++ b/compiler/parser/src/tree.rs
@@ -7,26 +7,22 @@ pub use lexer::Operator;
 
 use crate::Type;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[derive_where(Hash, Eq, PartialEq)]
-pub struct IntegerLiteral {
-    pub repr: String,
-    #[derive_where(skip(EqHashOrd))]
-    pub value: Integer,
-}
-
-#[derive(Debug)]
-#[derive_where(Hash, Eq, PartialEq)]
-pub struct RealLiteral {
-    pub repr: String,
-    #[derive_where(skip(EqHashOrd))]
-    pub value: Real,
-}
-
-#[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
-pub enum BoolLiteral {
-    True,
-    False,
+pub enum Literal {
+    Bool {
+        value: bool,
+    },
+    Integer {
+        repr: String,
+        #[derive_where(skip(EqHashOrd))]
+        value: Integer,
+    },
+    Real {
+        repr: String,
+        #[derive_where(skip(EqHashOrd))]
+        value: Real,
+    },
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
@@ -45,9 +41,7 @@ pub enum LvalueExpression {
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub enum Expression {
     LvalueToRvalue(Rc<LvalueExpression>),
-    IntegerLiteral(IntegerLiteral),
-    RealLiteral(RealLiteral),
-    BoolLiteral(BoolLiteral),
+    Literal(Literal),
     Call {
         callee: RawIdentifier,
         args: Vec<Rc<Expression>>,

--- a/tests/ast/pass/arithmetic_operations.txt
+++ b/tests/ast/pass/arithmetic_operations.txt
@@ -20,8 +20,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "7",
                                                                 value: 7,
                                                             },
@@ -41,8 +41,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -62,8 +62,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "5.5",
                                                                 value: 5.5,
                                                             },
@@ -83,8 +83,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "2.0",
                                                                 value: 2.0,
                                                             },
@@ -187,14 +187,14 @@ Program {
                                             op: Int(
                                                 Div,
                                             ),
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "-7",
                                                     value: -7,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -206,14 +206,14 @@ Program {
                                             op: Int(
                                                 Mod,
                                             ),
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "-7",
                                                     value: -7,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -225,14 +225,14 @@ Program {
                                             op: Int(
                                                 Div,
                                             ),
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "7",
                                                     value: 7,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "-3",
                                                     value: -3,
                                                 },
@@ -244,14 +244,14 @@ Program {
                                             op: Int(
                                                 Mod,
                                             ),
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "7",
                                                     value: 7,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "-3",
                                                     value: -3,
                                                 },
@@ -453,8 +453,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "7",
                                                                     value: 7,
                                                                 },
@@ -474,8 +474,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -495,8 +495,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "5.5",
                                                                     value: 5.5,
                                                                 },
@@ -516,8 +516,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "2.0",
                                                                     value: 2.0,
                                                                 },
@@ -620,14 +620,14 @@ Program {
                                                 op: Int(
                                                     Div,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "-7",
                                                         value: -7,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -639,14 +639,14 @@ Program {
                                                 op: Int(
                                                     Mod,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "-7",
                                                         value: -7,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -658,14 +658,14 @@ Program {
                                                 op: Int(
                                                     Div,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "7",
                                                         value: 7,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "-3",
                                                         value: -3,
                                                     },
@@ -677,14 +677,14 @@ Program {
                                                 op: Int(
                                                     Mod,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "7",
                                                         value: 7,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "-3",
                                                         value: -3,
                                                     },
@@ -869,8 +869,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "7",
                                     value: 7,
                                 },
@@ -888,8 +888,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "3",
                                     value: 3,
                                 },
@@ -907,8 +907,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "5.5",
                                     value: 5.5,
                                 },
@@ -926,8 +926,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "2.0",
                                     value: 2.0,
                                 },

--- a/tests/ast/pass/arrays_and_records.txt
+++ b/tests/ast/pass/arrays_and_records.txt
@@ -68,8 +68,8 @@ Program {
                 VarDecl {
                     t: Real,
                     initialiser: Some(
-                        RealLiteral(
-                            RealLiteral {
+                        Literal(
+                            Real {
                                 repr: "0.0000001",
                                 value: 1e-7,
                             },
@@ -410,8 +410,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -423,8 +423,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -441,8 +441,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -454,8 +454,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "3",
                                                                         value: 3,
                                                                     },
@@ -473,8 +473,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -486,8 +486,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -518,8 +518,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -531,8 +531,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "3",
                                                                         value: 3,
                                                                     },
@@ -549,8 +549,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -562,8 +562,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -581,8 +581,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -594,8 +594,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -627,8 +627,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -640,8 +640,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -658,8 +658,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -671,8 +671,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -690,8 +690,8 @@ Program {
                                                         lhs: Identifier(
                                                             t(10),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -703,8 +703,8 @@ Program {
                                                         lhs: Identifier(
                                                             t(10),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -767,8 +767,8 @@ Program {
                                             lhs: Identifier(
                                                 t(13),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -789,8 +789,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -798,8 +798,8 @@ Program {
                                             },
                                             member_name: r"x",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "0.0",
                                                 value: 0.0,
                                             },
@@ -811,8 +811,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -820,8 +820,8 @@ Program {
                                             },
                                             member_name: r"y",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "0.0",
                                                 value: 0.0,
                                             },
@@ -832,8 +832,8 @@ Program {
                                             lhs: Identifier(
                                                 t(13),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -854,8 +854,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -863,8 +863,8 @@ Program {
                                             },
                                             member_name: r"x",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "3.0",
                                                 value: 3.0,
                                             },
@@ -876,8 +876,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -885,8 +885,8 @@ Program {
                                             },
                                             member_name: r"y",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "0.0",
                                                 value: 0.0,
                                             },
@@ -897,8 +897,8 @@ Program {
                                             lhs: Identifier(
                                                 t(13),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -919,8 +919,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -928,8 +928,8 @@ Program {
                                             },
                                             member_name: r"x",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "0.0",
                                                 value: 0.0,
                                             },
@@ -941,8 +941,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -950,8 +950,8 @@ Program {
                                             },
                                             member_name: r"y",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "4.0",
                                                 value: 4.0,
                                             },
@@ -1048,8 +1048,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "0.0000001",
                                     value: 1e-7,
                                 },
@@ -1468,8 +1468,8 @@ Program {
                                                                     lhs: Identifier(
                                                                         t(10),
                                                                     ),
-                                                                    index: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    index: Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
@@ -1481,8 +1481,8 @@ Program {
                                                                     lhs: Identifier(
                                                                         t(10),
                                                                     ),
-                                                                    index: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    index: Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -1499,8 +1499,8 @@ Program {
                                                                     lhs: Identifier(
                                                                         t(10),
                                                                     ),
-                                                                    index: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    index: Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -1512,8 +1512,8 @@ Program {
                                                                     lhs: Identifier(
                                                                         t(10),
                                                                     ),
-                                                                    index: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    index: Literal(
+                                                                        Integer {
                                                                             repr: "3",
                                                                             value: 3,
                                                                         },
@@ -1531,8 +1531,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -1544,8 +1544,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "3",
                                                                         value: 3,
                                                                     },
@@ -1576,8 +1576,8 @@ Program {
                                                                     lhs: Identifier(
                                                                         t(10),
                                                                     ),
-                                                                    index: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    index: Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
@@ -1589,8 +1589,8 @@ Program {
                                                                     lhs: Identifier(
                                                                         t(10),
                                                                     ),
-                                                                    index: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    index: Literal(
+                                                                        Integer {
                                                                             repr: "3",
                                                                             value: 3,
                                                                         },
@@ -1607,8 +1607,8 @@ Program {
                                                                     lhs: Identifier(
                                                                         t(10),
                                                                     ),
-                                                                    index: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    index: Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
@@ -1620,8 +1620,8 @@ Program {
                                                                     lhs: Identifier(
                                                                         t(10),
                                                                     ),
-                                                                    index: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    index: Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -1639,8 +1639,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -1652,8 +1652,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "3",
                                                                         value: 3,
                                                                     },
@@ -1685,8 +1685,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "3",
                                                                         value: 3,
                                                                     },
@@ -1698,8 +1698,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -1716,8 +1716,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "3",
                                                                         value: 3,
                                                                     },
@@ -1729,8 +1729,8 @@ Program {
                                                                 lhs: Identifier(
                                                                     t(10),
                                                                 ),
-                                                                index: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                index: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -1748,8 +1748,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -1761,8 +1761,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(10),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -1825,8 +1825,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -1847,8 +1847,8 @@ Program {
                                                     lhs: Identifier(
                                                         t(13),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -1856,8 +1856,8 @@ Program {
                                                 },
                                                 member_name: r"x",
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -1869,8 +1869,8 @@ Program {
                                                     lhs: Identifier(
                                                         t(13),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -1878,8 +1878,8 @@ Program {
                                                 },
                                                 member_name: r"y",
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -1890,8 +1890,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -1912,8 +1912,8 @@ Program {
                                                     lhs: Identifier(
                                                         t(13),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -1921,8 +1921,8 @@ Program {
                                                 },
                                                 member_name: r"x",
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "3.0",
                                                     value: 3.0,
                                                 },
@@ -1934,8 +1934,8 @@ Program {
                                                     lhs: Identifier(
                                                         t(13),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -1943,8 +1943,8 @@ Program {
                                                 },
                                                 member_name: r"y",
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -1955,8 +1955,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -1977,8 +1977,8 @@ Program {
                                                     lhs: Identifier(
                                                         t(13),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -1986,8 +1986,8 @@ Program {
                                                 },
                                                 member_name: r"x",
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -1999,8 +1999,8 @@ Program {
                                                     lhs: Identifier(
                                                         t(13),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -2008,8 +2008,8 @@ Program {
                                                 },
                                                 member_name: r"y",
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "4.0",
                                                     value: 4.0,
                                                 },

--- a/tests/ast/pass/assert.txt
+++ b/tests/ast/pass/assert.txt
@@ -16,8 +16,10 @@ Program {
                                     If {
                                         condition: UnOp {
                                             op: BoolNeg,
-                                            operand: BoolLiteral(
-                                                True,
+                                            operand: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                         },
                                         on_true: Block {
@@ -37,8 +39,8 @@ Program {
                                         condition: UnOp {
                                             op: BoolNeg,
                                             operand: IntToBool(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -69,21 +71,21 @@ Program {
                                                     op: Int(
                                                         Add,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
                                                     ),
                                                 },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },
@@ -130,8 +132,10 @@ Program {
                                         If {
                                             condition: UnOp {
                                                 op: BoolNeg,
-                                                operand: BoolLiteral(
-                                                    True,
+                                                operand: Literal(
+                                                    Bool {
+                                                        value: true,
+                                                    },
                                                 ),
                                             },
                                             on_true: Block {
@@ -151,8 +155,8 @@ Program {
                                             condition: UnOp {
                                                 op: BoolNeg,
                                                 operand: IntToBool(
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -183,21 +187,21 @@ Program {
                                                         op: Int(
                                                             Add,
                                                         ),
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lhs: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
                                                         ),
                                                     },
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },

--- a/tests/ast/pass/comparison_operators.txt
+++ b/tests/ast/pass/comparison_operators.txt
@@ -20,8 +20,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "5",
                                                                 value: 5,
                                                             },
@@ -41,8 +41,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -62,8 +62,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "2.5",
                                                                 value: 2.5,
                                                             },
@@ -83,8 +83,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "5.0",
                                                                 value: 5.0,
                                                             },
@@ -306,11 +306,15 @@ Program {
                                             op: Eq(
                                                 Eq,
                                             ),
-                                            lhs: BoolLiteral(
-                                                True,
+                                            lhs: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
-                                            rhs: BoolLiteral(
-                                                False,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         },
                                     },
@@ -319,11 +323,15 @@ Program {
                                             op: Eq(
                                                 Ne,
                                             ),
-                                            lhs: BoolLiteral(
-                                                True,
+                                            lhs: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
-                                            rhs: BoolLiteral(
-                                                False,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         },
                                     },
@@ -358,8 +366,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "5",
                                                                     value: 5,
                                                                 },
@@ -379,8 +387,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -400,8 +408,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "2.5",
                                                                     value: 2.5,
                                                                 },
@@ -421,8 +429,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "5.0",
                                                                     value: 5.0,
                                                                 },
@@ -644,11 +652,15 @@ Program {
                                                 op: Eq(
                                                     Eq,
                                                 ),
-                                                lhs: BoolLiteral(
-                                                    True,
+                                                lhs: Literal(
+                                                    Bool {
+                                                        value: true,
+                                                    },
                                                 ),
-                                                rhs: BoolLiteral(
-                                                    False,
+                                                rhs: Literal(
+                                                    Bool {
+                                                        value: false,
+                                                    },
                                                 ),
                                             },
                                         },
@@ -657,11 +669,15 @@ Program {
                                                 op: Eq(
                                                     Ne,
                                                 ),
-                                                lhs: BoolLiteral(
-                                                    True,
+                                                lhs: Literal(
+                                                    Bool {
+                                                        value: true,
+                                                    },
                                                 ),
-                                                rhs: BoolLiteral(
-                                                    False,
+                                                rhs: Literal(
+                                                    Bool {
+                                                        value: false,
+                                                    },
                                                 ),
                                             },
                                         },
@@ -679,8 +695,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "5",
                                     value: 5,
                                 },
@@ -698,8 +714,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "3",
                                     value: 3,
                                 },
@@ -717,8 +733,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "2.5",
                                     value: 2.5,
                                 },
@@ -736,8 +752,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "5.0",
                                     value: 5.0,
                                 },

--- a/tests/ast/pass/complex_expressions.txt
+++ b/tests/ast/pass/complex_expressions.txt
@@ -39,8 +39,8 @@ Program {
                                                     n(1),
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -75,8 +75,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -96,8 +96,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -117,8 +117,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "4",
                                                                 value: 4,
                                                             },
@@ -136,8 +136,8 @@ Program {
                                             op: Int(
                                                 Add,
                                             ),
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -146,14 +146,14 @@ Program {
                                                 op: Int(
                                                     Mul,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
@@ -170,21 +170,21 @@ Program {
                                                 op: Int(
                                                     Add,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
@@ -200,14 +200,14 @@ Program {
                                                 op: Int(
                                                     Add,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -217,14 +217,14 @@ Program {
                                                 op: Int(
                                                     Add,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
@@ -241,14 +241,14 @@ Program {
                                                 op: Int(
                                                     Lt,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -258,14 +258,14 @@ Program {
                                                 op: Int(
                                                     Lt,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
@@ -345,8 +345,8 @@ Program {
                                             lhs: Call {
                                                 callee: add_one(0),
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },
@@ -356,8 +356,8 @@ Program {
                                             rhs: Call {
                                                 callee: add_one(0),
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -373,8 +373,8 @@ Program {
                                                 Call {
                                                     callee: add_one(0),
                                                     args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -528,8 +528,8 @@ Program {
                                                         n(1),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -576,8 +576,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -597,8 +597,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -618,8 +618,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "4",
                                                                     value: 4,
                                                                 },
@@ -637,8 +637,8 @@ Program {
                                                 op: Int(
                                                     Add,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -647,14 +647,14 @@ Program {
                                                     op: Int(
                                                         Mul,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "4",
                                                             value: 4,
                                                         },
@@ -671,21 +671,21 @@ Program {
                                                     op: Int(
                                                         Add,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
                                                     ),
                                                 },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
@@ -701,14 +701,14 @@ Program {
                                                     op: Int(
                                                         Add,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -718,14 +718,14 @@ Program {
                                                     op: Int(
                                                         Add,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "4",
                                                             value: 4,
                                                         },
@@ -742,14 +742,14 @@ Program {
                                                     op: Int(
                                                         Lt,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -759,14 +759,14 @@ Program {
                                                     op: Int(
                                                         Lt,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "4",
                                                             value: 4,
                                                         },
@@ -846,8 +846,8 @@ Program {
                                                 lhs: Call {
                                                     callee: add_one(0),
                                                     args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "5",
                                                                 value: 5,
                                                             },
@@ -857,8 +857,8 @@ Program {
                                                 rhs: Call {
                                                     callee: add_one(0),
                                                     args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -874,8 +874,8 @@ Program {
                                                     Call {
                                                         callee: add_one(0),
                                                         args: [
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -993,8 +993,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "2",
                                     value: 2,
                                 },
@@ -1012,8 +1012,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "3",
                                     value: 3,
                                 },
@@ -1031,8 +1031,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "4",
                                     value: 4,
                                 },

--- a/tests/ast/pass/conditionals.txt
+++ b/tests/ast/pass/conditionals.txt
@@ -39,8 +39,8 @@ Program {
                                                     value(1),
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -56,8 +56,8 @@ Program {
                                                         op: Real(
                                                             Sub,
                                                         ),
-                                                        lhs: RealLiteral(
-                                                            RealLiteral {
+                                                        lhs: Literal(
+                                                            Real {
                                                                 repr: "0.0",
                                                                 value: 0.0,
                                                             },
@@ -109,8 +109,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "4",
                                                                 value: 4,
                                                             },
@@ -137,15 +137,15 @@ Program {
                                                         a(3),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -160,8 +160,8 @@ Program {
                                                             VarDecl {
                                                                 t: Int,
                                                                 initialiser: Some(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
@@ -175,8 +175,8 @@ Program {
                                                     },
                                                 ),
                                                 Print {
-                                                    value: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    value: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -196,8 +196,8 @@ Program {
                                             Block {
                                                 stmts: [
                                                     Print {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -258,8 +258,8 @@ Program {
                                                         value(1),
                                                     ),
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.0",
                                                         value: 0.0,
                                                     },
@@ -275,8 +275,8 @@ Program {
                                                             op: Real(
                                                                 Sub,
                                                             ),
-                                                            lhs: RealLiteral(
-                                                                RealLiteral {
+                                                            lhs: Literal(
+                                                                Real {
                                                                     repr: "0.0",
                                                                     value: 0.0,
                                                                 },
@@ -340,8 +340,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "4",
                                                                     value: 4,
                                                                 },
@@ -368,15 +368,15 @@ Program {
                                                             a(3),
                                                         ),
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
                                                     ),
                                                 },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },
@@ -391,8 +391,8 @@ Program {
                                                                 VarDecl {
                                                                     t: Int,
                                                                     initialiser: Some(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
@@ -406,8 +406,8 @@ Program {
                                                         },
                                                     ),
                                                     Print {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -427,8 +427,8 @@ Program {
                                                 Block {
                                                     stmts: [
                                                         Print {
-                                                            value: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            value: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -453,8 +453,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "4",
                                     value: 4,
                                 },
@@ -472,8 +472,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },

--- a/tests/ast/pass/constant.txt
+++ b/tests/ast/pass/constant.txt
@@ -4,12 +4,8 @@ Program {
             name: LENGTH(0),
             decl: Const(
                 ConstDecl {
-                    t: Int,
-                    value: IntegerLiteral(
-                        IntegerLiteral {
-                            repr: "100",
-                            value: 100,
-                        },
+                    value: Int(
+                        100,
                     ),
                 },
             ),
@@ -18,12 +14,8 @@ Program {
             name: DOUBLE_LENGTH(1),
             decl: Const(
                 ConstDecl {
-                    t: Int,
-                    value: IntegerLiteral(
-                        IntegerLiteral {
-                            repr: "200",
-                            value: 200,
-                        },
+                    value: Int(
+                        200,
                     ),
                 },
             ),
@@ -100,8 +92,8 @@ Program {
                                                 lhs: Identifier(
                                                     arr(4),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -160,14 +152,14 @@ Program {
                                                     op: Int(
                                                         Mul,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "100",
                                                             value: 100,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -186,14 +178,14 @@ Program {
                                                     op: Int(
                                                         Sub,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "200",
                                                             value: 200,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "100",
                                                             value: 100,
                                                         },
@@ -265,8 +257,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(8),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -279,12 +271,8 @@ Program {
                                             name: LENGTH(9),
                                             decl: Const(
                                                 ConstDecl {
-                                                    t: Int,
-                                                    value: IntegerLiteral(
-                                                        IntegerLiteral {
-                                                            repr: "300",
-                                                            value: 300,
-                                                        },
+                                                    value: Int(
+                                                        300,
                                                     ),
                                                 },
                                             ),
@@ -295,14 +283,14 @@ Program {
                                             op: Int(
                                                 Gt,
                                             ),
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "300",
                                                     value: 300,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "200",
                                                     value: 200,
                                                 },
@@ -311,8 +299,8 @@ Program {
                                         on_true: Block {
                                             stmts: [
                                                 Print {
-                                                    value: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    value: Literal(
+                                                        Integer {
                                                             repr: "300",
                                                             value: 300,
                                                         },
@@ -323,20 +311,16 @@ Program {
                                                         name: LENGTH(10),
                                                         decl: Const(
                                                             ConstDecl {
-                                                                t: Int,
-                                                                value: IntegerLiteral(
-                                                                    IntegerLiteral {
-                                                                        repr: "400",
-                                                                        value: 400,
-                                                                    },
+                                                                value: Int(
+                                                                    400,
                                                                 ),
                                                             },
                                                         ),
                                                     },
                                                 ),
                                                 Print {
-                                                    value: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    value: Literal(
+                                                        Integer {
                                                             repr: "400",
                                                             value: 400,
                                                         },
@@ -348,8 +332,8 @@ Program {
                                         on_false: None,
                                     },
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "300",
                                                 value: 300,
                                             },
@@ -370,12 +354,8 @@ Program {
                 name: LENGTH(0),
                 decl: Const(
                     ConstDecl {
-                        t: Int,
-                        value: IntegerLiteral(
-                            IntegerLiteral {
-                                repr: "100",
-                                value: 100,
-                            },
+                        value: Int(
+                            100,
                         ),
                     },
                 ),
@@ -384,12 +364,8 @@ Program {
                 name: DOUBLE_LENGTH(1),
                 decl: Const(
                     ConstDecl {
-                        t: Int,
-                        value: IntegerLiteral(
-                            IntegerLiteral {
-                                repr: "200",
-                                value: 200,
-                            },
+                        value: Int(
+                            200,
                         ),
                     },
                 ),
@@ -466,8 +442,8 @@ Program {
                                                     lhs: Identifier(
                                                         arr(4),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -545,14 +521,14 @@ Program {
                                                         op: Int(
                                                             Mul,
                                                         ),
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lhs: Literal(
+                                                            Integer {
                                                                 repr: "100",
                                                                 value: 100,
                                                             },
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -571,14 +547,14 @@ Program {
                                                         op: Int(
                                                             Sub,
                                                         ),
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lhs: Literal(
+                                                            Integer {
                                                                 repr: "200",
                                                                 value: 200,
                                                             },
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "100",
                                                                 value: 100,
                                                             },
@@ -664,8 +640,8 @@ Program {
                                                     lhs: Identifier(
                                                         t(8),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -678,12 +654,8 @@ Program {
                                                 name: LENGTH(9),
                                                 decl: Const(
                                                     ConstDecl {
-                                                        t: Int,
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
-                                                                repr: "300",
-                                                                value: 300,
-                                                            },
+                                                        value: Int(
+                                                            300,
                                                         ),
                                                     },
                                                 ),
@@ -694,14 +666,14 @@ Program {
                                                 op: Int(
                                                     Gt,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "300",
                                                         value: 300,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "200",
                                                         value: 200,
                                                     },
@@ -710,8 +682,8 @@ Program {
                                             on_true: Block {
                                                 stmts: [
                                                     Print {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "300",
                                                                 value: 300,
                                                             },
@@ -722,20 +694,16 @@ Program {
                                                             name: LENGTH(10),
                                                             decl: Const(
                                                                 ConstDecl {
-                                                                    t: Int,
-                                                                    value: IntegerLiteral(
-                                                                        IntegerLiteral {
-                                                                            repr: "400",
-                                                                            value: 400,
-                                                                        },
+                                                                    value: Int(
+                                                                        400,
                                                                     ),
                                                                 },
                                                             ),
                                                         },
                                                     ),
                                                     Print {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "400",
                                                                 value: 400,
                                                             },
@@ -747,8 +715,8 @@ Program {
                                             on_false: None,
                                         },
                                         Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
+                                            value: Literal(
+                                                Integer {
                                                     repr: "300",
                                                     value: 300,
                                                 },
@@ -787,12 +755,8 @@ Program {
                 name: LENGTH(9),
                 decl: Const(
                     ConstDecl {
-                        t: Int,
-                        value: IntegerLiteral(
-                            IntegerLiteral {
-                                repr: "300",
-                                value: 300,
-                            },
+                        value: Int(
+                            300,
                         ),
                     },
                 ),
@@ -801,12 +765,8 @@ Program {
                 name: LENGTH(10),
                 decl: Const(
                     ConstDecl {
-                        t: Int,
-                        value: IntegerLiteral(
-                            IntegerLiteral {
-                                repr: "400",
-                                value: 400,
-                            },
+                        value: Int(
+                            400,
                         ),
                     },
                 ),

--- a/tests/ast/pass/deep_conditionals.txt
+++ b/tests/ast/pass/deep_conditionals.txt
@@ -20,8 +20,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -41,8 +41,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -62,8 +62,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -83,8 +83,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -104,8 +104,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -125,8 +125,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -146,8 +146,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -170,8 +170,8 @@ Program {
                                                     a(1),
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -180,8 +180,8 @@ Program {
                                         on_true: Block {
                                             stmts: [
                                                 Print {
-                                                    value: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    value: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -197,8 +197,8 @@ Program {
                                                                 b(2),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -207,8 +207,8 @@ Program {
                                                     on_true: Block {
                                                         stmts: [
                                                             Print {
-                                                                value: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                value: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -224,8 +224,8 @@ Program {
                                                                             c(3),
                                                                         ),
                                                                     ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    rhs: Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
@@ -234,8 +234,8 @@ Program {
                                                                 on_true: Block {
                                                                     stmts: [
                                                                         Print {
-                                                                            value: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            value: Literal(
+                                                                                Integer {
                                                                                     repr: "3",
                                                                                     value: 3,
                                                                                 },
@@ -257,8 +257,8 @@ Program {
                                                                                             d(4),
                                                                                         ),
                                                                                     ),
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    rhs: Literal(
+                                                                                        Integer {
                                                                                             repr: "1",
                                                                                             value: 1,
                                                                                         },
@@ -267,8 +267,8 @@ Program {
                                                                                 on_true: Block {
                                                                                     stmts: [
                                                                                         Print {
-                                                                                            value: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            value: Literal(
+                                                                                                Integer {
                                                                                                     repr: "0",
                                                                                                     value: 0,
                                                                                                 },
@@ -300,8 +300,8 @@ Program {
                                                                                 e(5),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
@@ -310,8 +310,8 @@ Program {
                                                                     on_true: Block {
                                                                         stmts: [
                                                                             Print {
-                                                                                value: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                value: Literal(
+                                                                                    Integer {
                                                                                         repr: "0",
                                                                                         value: 0,
                                                                                     },
@@ -333,8 +333,8 @@ Program {
                                                                                                 f(6),
                                                                                             ),
                                                                                         ),
-                                                                                        rhs: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        rhs: Literal(
+                                                                                            Integer {
                                                                                                 repr: "1",
                                                                                                 value: 1,
                                                                                             },
@@ -343,8 +343,8 @@ Program {
                                                                                     on_true: Block {
                                                                                         stmts: [
                                                                                             Print {
-                                                                                                value: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                value: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "0",
                                                                                                         value: 0,
                                                                                                     },
@@ -375,8 +375,8 @@ Program {
                                                                 d(4),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -385,8 +385,8 @@ Program {
                                                     on_true: Block {
                                                         stmts: [
                                                             Print {
-                                                                value: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                value: Literal(
+                                                                    Integer {
                                                                         repr: "4",
                                                                         value: 4,
                                                                     },
@@ -402,8 +402,8 @@ Program {
                                                                             e(5),
                                                                         ),
                                                                     ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    rhs: Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
@@ -412,8 +412,8 @@ Program {
                                                                 on_true: Block {
                                                                     stmts: [
                                                                         Print {
-                                                                            value: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            value: Literal(
+                                                                                Integer {
                                                                                     repr: "5",
                                                                                     value: 5,
                                                                                 },
@@ -429,8 +429,8 @@ Program {
                                                                                         f(6),
                                                                                     ),
                                                                                 ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                rhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "1",
                                                                                         value: 1,
                                                                                     },
@@ -439,8 +439,8 @@ Program {
                                                                             on_true: Block {
                                                                                 stmts: [
                                                                                     Print {
-                                                                                        value: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        value: Literal(
+                                                                                            Integer {
                                                                                                 repr: "6",
                                                                                                 value: 6,
                                                                                             },
@@ -456,8 +456,8 @@ Program {
                                                                                                     g(7),
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "1",
                                                                                                     value: 1,
                                                                                                 },
@@ -466,8 +466,8 @@ Program {
                                                                                         on_true: Block {
                                                                                             stmts: [
                                                                                                 Print {
-                                                                                                    value: IntegerLiteral(
-                                                                                                        IntegerLiteral {
+                                                                                                    value: Literal(
+                                                                                                        Integer {
                                                                                                             repr: "7",
                                                                                                             value: 7,
                                                                                                         },
@@ -480,8 +480,8 @@ Program {
                                                                                             Block {
                                                                                                 stmts: [
                                                                                                     Print {
-                                                                                                        value: IntegerLiteral(
-                                                                                                            IntegerLiteral {
+                                                                                                        value: Literal(
+                                                                                                            Integer {
                                                                                                                 repr: "0",
                                                                                                                 value: 0,
                                                                                                             },
@@ -499,8 +499,8 @@ Program {
                                                                                 Block {
                                                                                     stmts: [
                                                                                         Print {
-                                                                                            value: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            value: Literal(
+                                                                                                Integer {
                                                                                                     repr: "0",
                                                                                                     value: 0,
                                                                                                 },
@@ -518,8 +518,8 @@ Program {
                                                                     Block {
                                                                         stmts: [
                                                                             Print {
-                                                                                value: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                value: Literal(
+                                                                                    Integer {
                                                                                         repr: "0",
                                                                                         value: 0,
                                                                                     },
@@ -546,8 +546,8 @@ Program {
                                                                                 b(2),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
@@ -556,8 +556,8 @@ Program {
                                                                     on_true: Block {
                                                                         stmts: [
                                                                             Print {
-                                                                                value: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                value: Literal(
+                                                                                    Integer {
                                                                                         repr: "0",
                                                                                         value: 0,
                                                                                     },
@@ -579,8 +579,8 @@ Program {
                                                                                                 c(3),
                                                                                             ),
                                                                                         ),
-                                                                                        rhs: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        rhs: Literal(
+                                                                                            Integer {
                                                                                                 repr: "1",
                                                                                                 value: 1,
                                                                                             },
@@ -589,8 +589,8 @@ Program {
                                                                                     on_true: Block {
                                                                                         stmts: [
                                                                                             Print {
-                                                                                                value: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                value: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "0",
                                                                                                         value: 0,
                                                                                                     },
@@ -627,8 +627,8 @@ Program {
                                                                     e(5),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -637,8 +637,8 @@ Program {
                                                         on_true: Block {
                                                             stmts: [
                                                                 Print {
-                                                                    value: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    value: Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
@@ -660,8 +660,8 @@ Program {
                                                                                     g(7),
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -670,8 +670,8 @@ Program {
                                                                         on_true: Block {
                                                                             stmts: [
                                                                                 Print {
-                                                                                    value: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    value: Literal(
+                                                                                        Integer {
                                                                                             repr: "0",
                                                                                             value: 0,
                                                                                         },
@@ -723,8 +723,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -744,8 +744,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -765,8 +765,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -786,8 +786,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -807,8 +807,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -828,8 +828,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -849,8 +849,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -873,8 +873,8 @@ Program {
                                                         a(1),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -883,8 +883,8 @@ Program {
                                             on_true: Block {
                                                 stmts: [
                                                     Print {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -900,8 +900,8 @@ Program {
                                                                     b(2),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -910,8 +910,8 @@ Program {
                                                         on_true: Block {
                                                             stmts: [
                                                                 Print {
-                                                                    value: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    value: Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -927,8 +927,8 @@ Program {
                                                                                 c(3),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
@@ -937,8 +937,8 @@ Program {
                                                                     on_true: Block {
                                                                         stmts: [
                                                                             Print {
-                                                                                value: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                value: Literal(
+                                                                                    Integer {
                                                                                         repr: "3",
                                                                                         value: 3,
                                                                                     },
@@ -960,8 +960,8 @@ Program {
                                                                                                 d(4),
                                                                                             ),
                                                                                         ),
-                                                                                        rhs: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        rhs: Literal(
+                                                                                            Integer {
                                                                                                 repr: "1",
                                                                                                 value: 1,
                                                                                             },
@@ -970,8 +970,8 @@ Program {
                                                                                     on_true: Block {
                                                                                         stmts: [
                                                                                             Print {
-                                                                                                value: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                value: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "0",
                                                                                                         value: 0,
                                                                                                     },
@@ -1003,8 +1003,8 @@ Program {
                                                                                     e(5),
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -1013,8 +1013,8 @@ Program {
                                                                         on_true: Block {
                                                                             stmts: [
                                                                                 Print {
-                                                                                    value: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    value: Literal(
+                                                                                        Integer {
                                                                                             repr: "0",
                                                                                             value: 0,
                                                                                         },
@@ -1036,8 +1036,8 @@ Program {
                                                                                                     f(6),
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "1",
                                                                                                     value: 1,
                                                                                                 },
@@ -1046,8 +1046,8 @@ Program {
                                                                                         on_true: Block {
                                                                                             stmts: [
                                                                                                 Print {
-                                                                                                    value: IntegerLiteral(
-                                                                                                        IntegerLiteral {
+                                                                                                    value: Literal(
+                                                                                                        Integer {
                                                                                                             repr: "0",
                                                                                                             value: 0,
                                                                                                         },
@@ -1078,8 +1078,8 @@ Program {
                                                                     d(4),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -1088,8 +1088,8 @@ Program {
                                                         on_true: Block {
                                                             stmts: [
                                                                 Print {
-                                                                    value: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    value: Literal(
+                                                                        Integer {
                                                                             repr: "4",
                                                                             value: 4,
                                                                         },
@@ -1105,8 +1105,8 @@ Program {
                                                                                 e(5),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
@@ -1115,8 +1115,8 @@ Program {
                                                                     on_true: Block {
                                                                         stmts: [
                                                                             Print {
-                                                                                value: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                value: Literal(
+                                                                                    Integer {
                                                                                         repr: "5",
                                                                                         value: 5,
                                                                                     },
@@ -1132,8 +1132,8 @@ Program {
                                                                                             f(6),
                                                                                         ),
                                                                                     ),
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    rhs: Literal(
+                                                                                        Integer {
                                                                                             repr: "1",
                                                                                             value: 1,
                                                                                         },
@@ -1142,8 +1142,8 @@ Program {
                                                                                 on_true: Block {
                                                                                     stmts: [
                                                                                         Print {
-                                                                                            value: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            value: Literal(
+                                                                                                Integer {
                                                                                                     repr: "6",
                                                                                                     value: 6,
                                                                                                 },
@@ -1159,8 +1159,8 @@ Program {
                                                                                                         g(7),
                                                                                                     ),
                                                                                                 ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                rhs: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "1",
                                                                                                         value: 1,
                                                                                                     },
@@ -1169,8 +1169,8 @@ Program {
                                                                                             on_true: Block {
                                                                                                 stmts: [
                                                                                                     Print {
-                                                                                                        value: IntegerLiteral(
-                                                                                                            IntegerLiteral {
+                                                                                                        value: Literal(
+                                                                                                            Integer {
                                                                                                                 repr: "7",
                                                                                                                 value: 7,
                                                                                                             },
@@ -1183,8 +1183,8 @@ Program {
                                                                                                 Block {
                                                                                                     stmts: [
                                                                                                         Print {
-                                                                                                            value: IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            value: Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "0",
                                                                                                                     value: 0,
                                                                                                                 },
@@ -1202,8 +1202,8 @@ Program {
                                                                                     Block {
                                                                                         stmts: [
                                                                                             Print {
-                                                                                                value: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                value: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "0",
                                                                                                         value: 0,
                                                                                                     },
@@ -1221,8 +1221,8 @@ Program {
                                                                         Block {
                                                                             stmts: [
                                                                                 Print {
-                                                                                    value: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    value: Literal(
+                                                                                        Integer {
                                                                                             repr: "0",
                                                                                             value: 0,
                                                                                         },
@@ -1249,8 +1249,8 @@ Program {
                                                                                     b(2),
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -1259,8 +1259,8 @@ Program {
                                                                         on_true: Block {
                                                                             stmts: [
                                                                                 Print {
-                                                                                    value: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    value: Literal(
+                                                                                        Integer {
                                                                                             repr: "0",
                                                                                             value: 0,
                                                                                         },
@@ -1282,8 +1282,8 @@ Program {
                                                                                                     c(3),
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "1",
                                                                                                     value: 1,
                                                                                                 },
@@ -1292,8 +1292,8 @@ Program {
                                                                                         on_true: Block {
                                                                                             stmts: [
                                                                                                 Print {
-                                                                                                    value: IntegerLiteral(
-                                                                                                        IntegerLiteral {
+                                                                                                    value: Literal(
+                                                                                                        Integer {
                                                                                                             repr: "0",
                                                                                                             value: 0,
                                                                                                         },
@@ -1330,8 +1330,8 @@ Program {
                                                                         e(5),
                                                                     ),
                                                                 ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                rhs: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -1340,8 +1340,8 @@ Program {
                                                             on_true: Block {
                                                                 stmts: [
                                                                     Print {
-                                                                        value: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        value: Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
@@ -1363,8 +1363,8 @@ Program {
                                                                                         g(7),
                                                                                     ),
                                                                                 ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                rhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "1",
                                                                                         value: 1,
                                                                                     },
@@ -1373,8 +1373,8 @@ Program {
                                                                             on_true: Block {
                                                                                 stmts: [
                                                                                     Print {
-                                                                                        value: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        value: Literal(
+                                                                                            Integer {
                                                                                                 repr: "0",
                                                                                                 value: 0,
                                                                                             },
@@ -1409,8 +1409,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },
@@ -1428,8 +1428,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },
@@ -1447,8 +1447,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },
@@ -1466,8 +1466,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },
@@ -1485,8 +1485,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },
@@ -1504,8 +1504,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },
@@ -1523,8 +1523,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },

--- a/tests/ast/pass/default_init.txt
+++ b/tests/ast/pass/default_init.txt
@@ -99,8 +99,8 @@ Program {
                                                         i(4),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },
@@ -146,8 +146,8 @@ Program {
                                                         r(5),
                                                     ),
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.0",
                                                         value: 0.0,
                                                     },
@@ -193,8 +193,10 @@ Program {
                                                         b(6),
                                                     ),
                                                 ),
-                                                rhs: BoolLiteral(
-                                                    False,
+                                                rhs: Literal(
+                                                    Bool {
+                                                        value: false,
+                                                    },
                                                 ),
                                             },
                                         },
@@ -336,8 +338,8 @@ Program {
                                                     ),
                                                 ),
                                                 rhs: Cast {
-                                                    operand: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    operand: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -606,8 +608,8 @@ Program {
                                                             i(4),
                                                         ),
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -653,8 +655,8 @@ Program {
                                                             r(5),
                                                         ),
                                                     ),
-                                                    rhs: RealLiteral(
-                                                        RealLiteral {
+                                                    rhs: Literal(
+                                                        Real {
                                                             repr: "0.0",
                                                             value: 0.0,
                                                         },
@@ -700,8 +702,10 @@ Program {
                                                             b(6),
                                                         ),
                                                     ),
-                                                    rhs: BoolLiteral(
-                                                        False,
+                                                    rhs: Literal(
+                                                        Bool {
+                                                            value: false,
+                                                        },
                                                     ),
                                                 },
                                             },
@@ -843,8 +847,8 @@ Program {
                                                         ),
                                                     ),
                                                     rhs: Cast {
-                                                        operand: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        operand: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },

--- a/tests/ast/pass/for_loops.txt
+++ b/tests/ast/pass/for_loops.txt
@@ -179,8 +179,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -216,8 +216,8 @@ Program {
                                                                 result(6),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -298,8 +298,8 @@ Program {
                                 stmts: [
                                     For {
                                         counter: i(10),
-                                        lower_bound: IntegerLiteral(
-                                            IntegerLiteral {
+                                        lower_bound: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -314,8 +314,8 @@ Program {
                                             stmts: [
                                                 For {
                                                     counter: j(11),
-                                                    lower_bound: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lower_bound: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -347,8 +347,8 @@ Program {
                                                                                         j(11),
                                                                                     ),
                                                                                 ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                rhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "1",
                                                                                         value: 1,
                                                                                     },
@@ -423,8 +423,8 @@ Program {
                                                                                                 j(11),
                                                                                             ),
                                                                                         ),
-                                                                                        rhs: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        rhs: Literal(
+                                                                                            Integer {
                                                                                                 repr: "1",
                                                                                                 value: 1,
                                                                                             },
@@ -447,8 +447,8 @@ Program {
                                                                                             j(11),
                                                                                         ),
                                                                                     ),
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    rhs: Literal(
+                                                                                        Integer {
                                                                                             repr: "1",
                                                                                             value: 1,
                                                                                         },
@@ -518,8 +518,8 @@ Program {
                                                 n(14),
                                             ),
                                         ),
-                                        upper_bound: IntegerLiteral(
-                                            IntegerLiteral {
+                                        upper_bound: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -577,8 +577,8 @@ Program {
                                 stmts: [
                                     For {
                                         counter: i(18),
-                                        lower_bound: IntegerLiteral(
-                                            IntegerLiteral {
+                                        lower_bound: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -661,15 +661,15 @@ Program {
                                             lhs: Identifier(
                                                 arr(20),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "3",
                                                 value: 3,
                                             },
@@ -680,15 +680,15 @@ Program {
                                             lhs: Identifier(
                                                 arr(20),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "5",
                                                 value: 5,
                                             },
@@ -699,15 +699,15 @@ Program {
                                             lhs: Identifier(
                                                 arr(20),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -718,15 +718,15 @@ Program {
                                             lhs: Identifier(
                                                 arr(20),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "2",
                                                 value: 2,
                                             },
@@ -737,15 +737,15 @@ Program {
                                             lhs: Identifier(
                                                 arr(20),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "4",
                                                 value: 4,
                                             },
@@ -767,8 +767,8 @@ Program {
                                         Call {
                                             callee: count(16),
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -780,8 +780,8 @@ Program {
                                         Call {
                                             callee: countdown(13),
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },
@@ -846,8 +846,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -883,8 +883,8 @@ Program {
                                                                     result(6),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -965,8 +965,8 @@ Program {
                                     stmts: [
                                         For {
                                             counter: i(10),
-                                            lower_bound: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lower_bound: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -981,8 +981,8 @@ Program {
                                                 stmts: [
                                                     For {
                                                         counter: j(11),
-                                                        lower_bound: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lower_bound: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -1014,8 +1014,8 @@ Program {
                                                                                             j(11),
                                                                                         ),
                                                                                     ),
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    rhs: Literal(
+                                                                                        Integer {
                                                                                             repr: "1",
                                                                                             value: 1,
                                                                                         },
@@ -1090,8 +1090,8 @@ Program {
                                                                                                     j(11),
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "1",
                                                                                                     value: 1,
                                                                                                 },
@@ -1114,8 +1114,8 @@ Program {
                                                                                                 j(11),
                                                                                             ),
                                                                                         ),
-                                                                                        rhs: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        rhs: Literal(
+                                                                                            Integer {
                                                                                                 repr: "1",
                                                                                                 value: 1,
                                                                                             },
@@ -1288,8 +1288,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -1427,8 +1427,8 @@ Program {
                                                     n(14),
                                                 ),
                                             ),
-                                            upper_bound: IntegerLiteral(
-                                                IntegerLiteral {
+                                            upper_bound: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -1510,8 +1510,8 @@ Program {
                                     stmts: [
                                         For {
                                             counter: i(18),
-                                            lower_bound: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lower_bound: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -1618,15 +1618,15 @@ Program {
                                                 lhs: Identifier(
                                                     arr(20),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -1637,15 +1637,15 @@ Program {
                                                 lhs: Identifier(
                                                     arr(20),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },
@@ -1656,15 +1656,15 @@ Program {
                                                 lhs: Identifier(
                                                     arr(20),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -1675,15 +1675,15 @@ Program {
                                                 lhs: Identifier(
                                                     arr(20),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -1694,15 +1694,15 @@ Program {
                                                 lhs: Identifier(
                                                     arr(20),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
@@ -1724,8 +1724,8 @@ Program {
                                             Call {
                                                 callee: count(16),
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -1737,8 +1737,8 @@ Program {
                                             Call {
                                                 callee: countdown(13),
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },

--- a/tests/ast/pass/function_parameters.txt
+++ b/tests/ast/pass/function_parameters.txt
@@ -85,14 +85,14 @@ Program {
                                         Call {
                                             callee: a_plus_b(0),
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },
@@ -220,14 +220,14 @@ Program {
                                             Call {
                                                 callee: a_plus_b(0),
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
                                                     ),
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },

--- a/tests/ast/pass/function_return.txt
+++ b/tests/ast/pass/function_return.txt
@@ -68,8 +68,8 @@ Program {
                                         value: Call {
                                             callee: echo(0),
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "42",
                                                         value: 42,
                                                     },
@@ -168,8 +168,8 @@ Program {
                                             value: Call {
                                                 callee: echo(0),
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "42",
                                                             value: 42,
                                                         },

--- a/tests/ast/pass/identifiers.txt
+++ b/tests/ast/pass/identifiers.txt
@@ -20,8 +20,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -41,8 +41,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -62,8 +62,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -83,8 +83,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -104,8 +104,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "4",
                                                                 value: 4,
                                                             },
@@ -125,8 +125,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "5",
                                                                 value: 5,
                                                             },
@@ -146,8 +146,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "6",
                                                                 value: 6,
                                                             },
@@ -167,8 +167,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "7",
                                                                 value: 7,
                                                             },
@@ -188,8 +188,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "8",
                                                                 value: 8,
                                                             },
@@ -209,8 +209,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "9",
                                                                 value: 9,
                                                             },
@@ -323,8 +323,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -344,8 +344,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -365,8 +365,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -386,8 +386,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -407,8 +407,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "4",
                                                                     value: 4,
                                                                 },
@@ -428,8 +428,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "5",
                                                                     value: 5,
                                                                 },
@@ -449,8 +449,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "6",
                                                                     value: 6,
                                                                 },
@@ -470,8 +470,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "7",
                                                                     value: 7,
                                                                 },
@@ -491,8 +491,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "8",
                                                                     value: 8,
                                                                 },
@@ -512,8 +512,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "9",
                                                                     value: 9,
                                                                 },
@@ -609,8 +609,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },
@@ -628,8 +628,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "2",
                                     value: 2,
                                 },
@@ -647,8 +647,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "3",
                                     value: 3,
                                 },
@@ -666,8 +666,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -685,8 +685,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "4",
                                     value: 4,
                                 },
@@ -704,8 +704,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "5",
                                     value: 5,
                                 },
@@ -723,8 +723,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "6",
                                     value: 6,
                                 },
@@ -742,8 +742,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "7",
                                     value: 7,
                                 },
@@ -761,8 +761,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "8",
                                     value: 8,
                                 },
@@ -780,8 +780,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "9",
                                     value: 9,
                                 },

--- a/tests/ast/pass/invalid_new_array_length.txt
+++ b/tests/ast/pass/invalid_new_array_length.txt
@@ -29,8 +29,8 @@ Program {
                                                             elements: Real,
                                                             length: UnOp {
                                                                 op: IntNeg,
-                                                                operand: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                operand: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -85,8 +85,8 @@ Program {
                                                                 elements: Real,
                                                                 length: UnOp {
                                                                     op: IntNeg,
-                                                                    operand: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    operand: Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
@@ -124,8 +124,8 @@ Program {
                                 elements: Real,
                                 length: UnOp {
                                     op: IntNeg,
-                                    operand: IntegerLiteral(
-                                        IntegerLiteral {
+                                    operand: Literal(
+                                        Integer {
                                             repr: "1",
                                             value: 1,
                                         },

--- a/tests/ast/pass/lazy_operators.txt
+++ b/tests/ast/pass/lazy_operators.txt
@@ -20,8 +20,10 @@ Program {
                                                 VarDecl {
                                                     t: Bool,
                                                     initialiser: Some(
-                                                        BoolLiteral(
-                                                            False,
+                                                        Literal(
+                                                            Bool {
+                                                                value: false,
+                                                            },
                                                         ),
                                                     ),
                                                     relative_location: Local(
@@ -73,8 +75,10 @@ Program {
                                                 VarDecl {
                                                     t: Bool,
                                                     initialiser: Some(
-                                                        BoolLiteral(
-                                                            True,
+                                                        Literal(
+                                                            Bool {
+                                                                value: true,
+                                                            },
                                                         ),
                                                     ),
                                                     relative_location: Local(
@@ -120,8 +124,8 @@ Program {
                             Block {
                                 stmts: [
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -143,8 +147,8 @@ Program {
                                         },
                                     },
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -166,8 +170,8 @@ Program {
                                         },
                                     },
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "2",
                                                 value: 2,
                                             },
@@ -189,8 +193,8 @@ Program {
                                         },
                                     },
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "3",
                                                 value: 3,
                                             },
@@ -212,8 +216,8 @@ Program {
                                         },
                                     },
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "4",
                                                 value: 4,
                                             },
@@ -235,8 +239,8 @@ Program {
                                         },
                                     },
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "5",
                                                 value: 5,
                                             },
@@ -288,8 +292,10 @@ Program {
                                                     VarDecl {
                                                         t: Bool,
                                                         initialiser: Some(
-                                                            BoolLiteral(
-                                                                False,
+                                                            Literal(
+                                                                Bool {
+                                                                    value: false,
+                                                                },
                                                             ),
                                                         ),
                                                         relative_location: Local(
@@ -327,8 +333,10 @@ Program {
                     VarDecl {
                         t: Bool,
                         initialiser: Some(
-                            BoolLiteral(
-                                False,
+                            Literal(
+                                Bool {
+                                    value: false,
+                                },
                             ),
                         ),
                         relative_location: Local(
@@ -357,8 +365,10 @@ Program {
                                                     VarDecl {
                                                         t: Bool,
                                                         initialiser: Some(
-                                                            BoolLiteral(
-                                                                True,
+                                                            Literal(
+                                                                Bool {
+                                                                    value: true,
+                                                                },
                                                             ),
                                                         ),
                                                         relative_location: Local(
@@ -396,8 +406,10 @@ Program {
                     VarDecl {
                         t: Bool,
                         initialiser: Some(
-                            BoolLiteral(
-                                True,
+                            Literal(
+                                Bool {
+                                    value: true,
+                                },
                             ),
                         ),
                         relative_location: Local(
@@ -420,8 +432,8 @@ Program {
                                 Block {
                                     stmts: [
                                         Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
+                                            value: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -443,8 +455,8 @@ Program {
                                             },
                                         },
                                         Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
+                                            value: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -466,8 +478,8 @@ Program {
                                             },
                                         },
                                         Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
+                                            value: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -489,8 +501,8 @@ Program {
                                             },
                                         },
                                         Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
+                                            value: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -512,8 +524,8 @@ Program {
                                             },
                                         },
                                         Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
+                                            value: Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
@@ -535,8 +547,8 @@ Program {
                                             },
                                         },
                                         Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
+                                            value: Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },

--- a/tests/ast/pass/length.txt
+++ b/tests/ast/pass/length.txt
@@ -175,8 +175,8 @@ Program {
                                                                     (
                                                                         r"length",
                                                                         IntToReal(
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "10",
                                                                                     value: 10,
                                                                                 },
@@ -428,8 +428,8 @@ Program {
                                                                         (
                                                                             r"length",
                                                                             IntToReal(
-                                                                                IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                Literal(
+                                                                                    Integer {
                                                                                         repr: "10",
                                                                                         value: 10,
                                                                                     },
@@ -520,8 +520,8 @@ Program {
                                         (
                                             r"length",
                                             IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "10",
                                                         value: 10,
                                                     },

--- a/tests/ast/pass/local_type.txt
+++ b/tests/ast/pass/local_type.txt
@@ -69,8 +69,8 @@ Program {
                                                     (
                                                         r"x",
                                                         IntToReal(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -80,8 +80,8 @@ Program {
                                                     (
                                                         r"y",
                                                         IntToReal(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -172,8 +172,8 @@ Program {
                                                         (
                                                             r"x",
                                                             IntToReal(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -183,8 +183,8 @@ Program {
                                                         (
                                                             r"y",
                                                             IntToReal(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },

--- a/tests/ast/pass/logical_operators.txt
+++ b/tests/ast/pass/logical_operators.txt
@@ -20,8 +20,10 @@ Program {
                                                 VarDecl {
                                                     t: Bool,
                                                     initialiser: Some(
-                                                        BoolLiteral(
-                                                            True,
+                                                        Literal(
+                                                            Bool {
+                                                                value: true,
+                                                            },
                                                         ),
                                                     ),
                                                     relative_location: Local(
@@ -38,8 +40,10 @@ Program {
                                                 VarDecl {
                                                     t: Bool,
                                                     initialiser: Some(
-                                                        BoolLiteral(
-                                                            False,
+                                                        Literal(
+                                                            Bool {
+                                                                value: false,
+                                                            },
                                                         ),
                                                     ),
                                                     relative_location: Local(
@@ -56,8 +60,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "5",
                                                                 value: 5,
                                                             },
@@ -77,8 +81,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -118,8 +122,10 @@ Program {
                                                     a(1),
                                                 ),
                                             ),
-                                            rhs: BoolLiteral(
-                                                True,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                         },
                                     },
@@ -145,8 +151,10 @@ Program {
                                             op: Bool(
                                                 Or,
                                             ),
-                                            lhs: BoolLiteral(
-                                                False,
+                                            lhs: Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                             rhs: LvalueToRvalue(
                                                 Identifier(
@@ -230,8 +238,10 @@ Program {
                                                     VarDecl {
                                                         t: Bool,
                                                         initialiser: Some(
-                                                            BoolLiteral(
-                                                                True,
+                                                            Literal(
+                                                                Bool {
+                                                                    value: true,
+                                                                },
                                                             ),
                                                         ),
                                                         relative_location: Local(
@@ -248,8 +258,10 @@ Program {
                                                     VarDecl {
                                                         t: Bool,
                                                         initialiser: Some(
-                                                            BoolLiteral(
-                                                                False,
+                                                            Literal(
+                                                                Bool {
+                                                                    value: false,
+                                                                },
                                                             ),
                                                         ),
                                                         relative_location: Local(
@@ -266,8 +278,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "5",
                                                                     value: 5,
                                                                 },
@@ -287,8 +299,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -328,8 +340,10 @@ Program {
                                                         a(1),
                                                     ),
                                                 ),
-                                                rhs: BoolLiteral(
-                                                    True,
+                                                rhs: Literal(
+                                                    Bool {
+                                                        value: true,
+                                                    },
                                                 ),
                                             },
                                         },
@@ -355,8 +369,10 @@ Program {
                                                 op: Bool(
                                                     Or,
                                                 ),
-                                                lhs: BoolLiteral(
-                                                    False,
+                                                lhs: Literal(
+                                                    Bool {
+                                                        value: false,
+                                                    },
                                                 ),
                                                 rhs: LvalueToRvalue(
                                                     Identifier(
@@ -423,8 +439,10 @@ Program {
                     VarDecl {
                         t: Bool,
                         initialiser: Some(
-                            BoolLiteral(
-                                True,
+                            Literal(
+                                Bool {
+                                    value: true,
+                                },
                             ),
                         ),
                         relative_location: Local(
@@ -439,8 +457,10 @@ Program {
                     VarDecl {
                         t: Bool,
                         initialiser: Some(
-                            BoolLiteral(
-                                False,
+                            Literal(
+                                Bool {
+                                    value: false,
+                                },
                             ),
                         ),
                         relative_location: Local(
@@ -455,8 +475,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "5",
                                     value: 5,
                                 },
@@ -474,8 +494,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },

--- a/tests/ast/pass/nested_control.txt
+++ b/tests/ast/pass/nested_control.txt
@@ -20,8 +20,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -44,8 +44,8 @@ Program {
                                                     i(1),
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -60,8 +60,8 @@ Program {
                                                             VarDecl {
                                                                 t: Int,
                                                                 initialiser: Some(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
@@ -84,8 +84,8 @@ Program {
                                                                 j(2),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -100,8 +100,8 @@ Program {
                                                                         VarDecl {
                                                                             t: Int,
                                                                             initialiser: Some(
-                                                                                IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                Literal(
+                                                                                    Integer {
                                                                                         repr: "0",
                                                                                         value: 0,
                                                                                     },
@@ -124,8 +124,8 @@ Program {
                                                                             k(3),
                                                                         ),
                                                                     ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    rhs: Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -140,8 +140,8 @@ Program {
                                                                                     VarDecl {
                                                                                         t: Int,
                                                                                         initialiser: Some(
-                                                                                            IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            Literal(
+                                                                                                Integer {
                                                                                                     repr: "0",
                                                                                                     value: 0,
                                                                                                 },
@@ -164,8 +164,8 @@ Program {
                                                                                         w(4),
                                                                                     ),
                                                                                 ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                rhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "2",
                                                                                         value: 2,
                                                                                     },
@@ -180,8 +180,8 @@ Program {
                                                                                                 VarDecl {
                                                                                                     t: Int,
                                                                                                     initialiser: Some(
-                                                                                                        IntegerLiteral(
-                                                                                                            IntegerLiteral {
+                                                                                                        Literal(
+                                                                                                            Integer {
                                                                                                                 repr: "0",
                                                                                                                 value: 0,
                                                                                                             },
@@ -204,8 +204,8 @@ Program {
                                                                                                     v(5),
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "2",
                                                                                                     value: 2,
                                                                                                 },
@@ -261,8 +261,8 @@ Program {
                                                                                                                 v(5),
                                                                                                             ),
                                                                                                         ),
-                                                                                                        rhs: IntegerLiteral(
-                                                                                                            IntegerLiteral {
+                                                                                                        rhs: Literal(
+                                                                                                            Integer {
                                                                                                                 repr: "1",
                                                                                                                 value: 1,
                                                                                                             },
@@ -286,8 +286,8 @@ Program {
                                                                                                     w(4),
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "1",
                                                                                                     value: 1,
                                                                                                 },
@@ -311,8 +311,8 @@ Program {
                                                                                         k(3),
                                                                                     ),
                                                                                 ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                rhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "1",
                                                                                         value: 1,
                                                                                     },
@@ -336,8 +336,8 @@ Program {
                                                                             j(2),
                                                                         ),
                                                                     ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    rhs: Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
@@ -361,8 +361,8 @@ Program {
                                                                 i(1),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -404,8 +404,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -428,8 +428,8 @@ Program {
                                                         i(1),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -444,8 +444,8 @@ Program {
                                                                 VarDecl {
                                                                     t: Int,
                                                                     initialiser: Some(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
@@ -468,8 +468,8 @@ Program {
                                                                     j(2),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -484,8 +484,8 @@ Program {
                                                                             VarDecl {
                                                                                 t: Int,
                                                                                 initialiser: Some(
-                                                                                    IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    Literal(
+                                                                                        Integer {
                                                                                             repr: "0",
                                                                                             value: 0,
                                                                                         },
@@ -508,8 +508,8 @@ Program {
                                                                                 k(3),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "2",
                                                                                 value: 2,
                                                                             },
@@ -524,8 +524,8 @@ Program {
                                                                                         VarDecl {
                                                                                             t: Int,
                                                                                             initialiser: Some(
-                                                                                                IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                Literal(
+                                                                                                    Integer {
                                                                                                         repr: "0",
                                                                                                         value: 0,
                                                                                                     },
@@ -548,8 +548,8 @@ Program {
                                                                                             w(4),
                                                                                         ),
                                                                                     ),
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    rhs: Literal(
+                                                                                        Integer {
                                                                                             repr: "2",
                                                                                             value: 2,
                                                                                         },
@@ -564,8 +564,8 @@ Program {
                                                                                                     VarDecl {
                                                                                                         t: Int,
                                                                                                         initialiser: Some(
-                                                                                                            IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "0",
                                                                                                                     value: 0,
                                                                                                                 },
@@ -588,8 +588,8 @@ Program {
                                                                                                         v(5),
                                                                                                     ),
                                                                                                 ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                rhs: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "2",
                                                                                                         value: 2,
                                                                                                     },
@@ -645,8 +645,8 @@ Program {
                                                                                                                     v(5),
                                                                                                                 ),
                                                                                                             ),
-                                                                                                            rhs: IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            rhs: Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "1",
                                                                                                                     value: 1,
                                                                                                                 },
@@ -670,8 +670,8 @@ Program {
                                                                                                         w(4),
                                                                                                     ),
                                                                                                 ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                rhs: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "1",
                                                                                                         value: 1,
                                                                                                     },
@@ -695,8 +695,8 @@ Program {
                                                                                             k(3),
                                                                                         ),
                                                                                     ),
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    rhs: Literal(
+                                                                                        Integer {
                                                                                             repr: "1",
                                                                                             value: 1,
                                                                                         },
@@ -720,8 +720,8 @@ Program {
                                                                                 j(2),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
@@ -745,8 +745,8 @@ Program {
                                                                     i(1),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -771,8 +771,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -790,8 +790,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -809,8 +809,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -828,8 +828,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -847,8 +847,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },

--- a/tests/ast/pass/new_array.txt
+++ b/tests/ast/pass/new_array.txt
@@ -97,8 +97,8 @@ Program {
                                                         n(3),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },
@@ -128,8 +128,8 @@ Program {
                                                     n(3),
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -138,8 +138,8 @@ Program {
                                         on_true: Block {
                                             stmts: [
                                                 Return {
-                                                    value: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    value: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -173,8 +173,8 @@ Program {
                                                                                 n(3),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
@@ -219,8 +219,8 @@ Program {
                                                     length: Call {
                                                         callee: factorial(2),
                                                         args: [
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "5",
                                                                     value: 5,
                                                                 },
@@ -237,8 +237,8 @@ Program {
                                             args: [
                                                 NewArray {
                                                     elements: Int,
-                                                    length: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    length: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -372,8 +372,8 @@ Program {
                                                             n(3),
                                                         ),
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -403,8 +403,8 @@ Program {
                                                         n(3),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },
@@ -413,8 +413,8 @@ Program {
                                             on_true: Block {
                                                 stmts: [
                                                     Return {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -448,8 +448,8 @@ Program {
                                                                                     n(3),
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -506,8 +506,8 @@ Program {
                                                         length: Call {
                                                             callee: factorial(2),
                                                             args: [
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "5",
                                                                         value: 5,
                                                                     },
@@ -524,8 +524,8 @@ Program {
                                                 args: [
                                                     NewArray {
                                                         elements: Int,
-                                                        length: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        length: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },

--- a/tests/ast/pass/oob_big.txt
+++ b/tests/ast/pass/oob_big.txt
@@ -52,8 +52,8 @@ Program {
                                                 lhs: Identifier(
                                                     a(1),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "10",
                                                         value: 10,
                                                     },
@@ -124,8 +124,8 @@ Program {
                                                     lhs: Identifier(
                                                         a(1),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "10",
                                                             value: 10,
                                                         },

--- a/tests/ast/pass/oob_neg.txt
+++ b/tests/ast/pass/oob_neg.txt
@@ -54,8 +54,8 @@ Program {
                                                 ),
                                                 index: UnOp {
                                                     op: IntNeg,
-                                                    operand: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    operand: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -129,8 +129,8 @@ Program {
                                                     ),
                                                     index: UnOp {
                                                         op: IntNeg,
-                                                        operand: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        operand: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },

--- a/tests/ast/pass/oob_zero.txt
+++ b/tests/ast/pass/oob_zero.txt
@@ -52,8 +52,8 @@ Program {
                                                 lhs: Identifier(
                                                     a(1),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },
@@ -124,8 +124,8 @@ Program {
                                                     lhs: Identifier(
                                                         a(1),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },

--- a/tests/ast/pass/operator_precedence.txt
+++ b/tests/ast/pass/operator_precedence.txt
@@ -11,8 +11,8 @@ Program {
                         },
                         args_bindings: [],
                         body: Expression(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "3",
                                     value: 3,
                                 },
@@ -33,8 +33,8 @@ Program {
                         },
                         args_bindings: [],
                         body: Expression(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "4",
                                     value: 4,
                                 },
@@ -55,8 +55,8 @@ Program {
                         },
                         args_bindings: [],
                         body: Expression(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "5",
                                     value: 5,
                                 },
@@ -88,14 +88,14 @@ Program {
                                                 op: Int(
                                                     Lt,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -105,14 +105,14 @@ Program {
                                                 op: Int(
                                                     Gt,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -129,25 +129,29 @@ Program {
                                                 op: Bool(
                                                     And,
                                                 ),
-                                                lhs: BoolLiteral(
-                                                    True,
+                                                lhs: Literal(
+                                                    Bool {
+                                                        value: true,
+                                                    },
                                                 ),
-                                                rhs: BoolLiteral(
-                                                    False,
+                                                rhs: Literal(
+                                                    Bool {
+                                                        value: false,
+                                                    },
                                                 ),
                                             },
                                             rhs: BinOp {
                                                 op: Eq(
                                                     Eq,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -188,21 +192,21 @@ Program {
                                                 op: Int(
                                                     Mod,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "17",
                                                         value: 17,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -246,14 +250,14 @@ Program {
                                                     op: Int(
                                                         Gt,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -263,14 +267,14 @@ Program {
                                                     op: Int(
                                                         Lt,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "4",
                                                             value: 4,
                                                         },
@@ -280,8 +284,8 @@ Program {
                                             rhs: UnOp {
                                                 op: BoolNeg,
                                                 operand: IntToBool(
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -299,21 +303,21 @@ Program {
                                                 op: Int(
                                                     Div,
                                                 ),
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "100",
                                                         value: 100,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },
@@ -342,8 +346,8 @@ Program {
                             },
                             args_bindings: [],
                             body: Expression(
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "3",
                                         value: 3,
                                     },
@@ -364,8 +368,8 @@ Program {
                             },
                             args_bindings: [],
                             body: Expression(
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "4",
                                         value: 4,
                                     },
@@ -386,8 +390,8 @@ Program {
                             },
                             args_bindings: [],
                             body: Expression(
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "5",
                                         value: 5,
                                     },
@@ -419,14 +423,14 @@ Program {
                                                     op: Int(
                                                         Lt,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -436,14 +440,14 @@ Program {
                                                     op: Int(
                                                         Gt,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "4",
                                                             value: 4,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -460,25 +464,29 @@ Program {
                                                     op: Bool(
                                                         And,
                                                     ),
-                                                    lhs: BoolLiteral(
-                                                        True,
+                                                    lhs: Literal(
+                                                        Bool {
+                                                            value: true,
+                                                        },
                                                     ),
-                                                    rhs: BoolLiteral(
-                                                        False,
+                                                    rhs: Literal(
+                                                        Bool {
+                                                            value: false,
+                                                        },
                                                     ),
                                                 },
                                                 rhs: BinOp {
                                                     op: Eq(
                                                         Eq,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -519,21 +527,21 @@ Program {
                                                     op: Int(
                                                         Mod,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "17",
                                                             value: 17,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },
                                                     ),
                                                 },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -577,14 +585,14 @@ Program {
                                                         op: Int(
                                                             Gt,
                                                         ),
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lhs: Literal(
+                                                            Integer {
                                                                 repr: "5",
                                                                 value: 5,
                                                             },
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -594,14 +602,14 @@ Program {
                                                         op: Int(
                                                             Lt,
                                                         ),
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lhs: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "4",
                                                                 value: 4,
                                                             },
@@ -611,8 +619,8 @@ Program {
                                                 rhs: UnOp {
                                                     op: BoolNeg,
                                                     operand: IntToBool(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -630,21 +638,21 @@ Program {
                                                     op: Int(
                                                         Div,
                                                     ),
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "100",
                                                             value: 100,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
                                                     ),
                                                 },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },

--- a/tests/ast/pass/panic.txt
+++ b/tests/ast/pass/panic.txt
@@ -14,16 +14,18 @@ Program {
                             Block {
                                 stmts: [
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
                                         ),
                                     },
                                     If {
-                                        condition: BoolLiteral(
-                                            True,
+                                        condition: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                         on_true: Block {
                                             stmts: [
@@ -40,8 +42,8 @@ Program {
                                             Block {
                                                 stmts: [
                                                     Print {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -77,16 +79,18 @@ Program {
                                 Block {
                                     stmts: [
                                         Print {
-                                            value: IntegerLiteral(
-                                                IntegerLiteral {
+                                            value: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
                                             ),
                                         },
                                         If {
-                                            condition: BoolLiteral(
-                                                True,
+                                            condition: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                             on_true: Block {
                                                 stmts: [
@@ -103,8 +107,8 @@ Program {
                                                 Block {
                                                     stmts: [
                                                         Print {
-                                                            value: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            value: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },

--- a/tests/ast/pass/parse_minus.txt
+++ b/tests/ast/pass/parse_minus.txt
@@ -6,8 +6,8 @@ Program {
                 VarDecl {
                     t: Int,
                     initialiser: Some(
-                        IntegerLiteral(
-                            IntegerLiteral {
+                        Literal(
+                            Integer {
                                 repr: "-1",
                                 value: -1,
                             },
@@ -29,14 +29,14 @@ Program {
                             op: Int(
                                 Sub,
                             ),
-                            lhs: IntegerLiteral(
-                                IntegerLiteral {
+                            lhs: Literal(
+                                Integer {
                                     repr: "-1",
                                     value: -1,
                                 },
                             ),
-                            rhs: IntegerLiteral(
-                                IntegerLiteral {
+                            rhs: Literal(
+                                Integer {
                                     repr: "-2",
                                     value: -2,
                                 },
@@ -59,14 +59,14 @@ Program {
                             op: Int(
                                 Sub,
                             ),
-                            lhs: IntegerLiteral(
-                                IntegerLiteral {
+                            lhs: Literal(
+                                Integer {
                                     repr: "-1",
                                     value: -1,
                                 },
                             ),
-                            rhs: IntegerLiteral(
-                                IntegerLiteral {
+                            rhs: Literal(
+                                Integer {
                                     repr: "-2",
                                     value: -2,
                                 },
@@ -89,8 +89,8 @@ Program {
                             op: Int(
                                 Add,
                             ),
-                            lhs: IntegerLiteral(
-                                IntegerLiteral {
+                            lhs: Literal(
+                                Integer {
                                     repr: "-5",
                                     value: -5,
                                 },
@@ -99,14 +99,14 @@ Program {
                                 op: Int(
                                     Add,
                                 ),
-                                lhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                lhs: Literal(
+                                    Integer {
                                         repr: "-7",
                                         value: -7,
                                     },
                                 ),
-                                rhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                rhs: Literal(
+                                    Integer {
                                         repr: "-8",
                                         value: -8,
                                     },
@@ -128,8 +128,8 @@ Program {
                     initialiser: Some(
                         UnOp {
                             op: IntNeg,
-                            operand: IntegerLiteral(
-                                IntegerLiteral {
+                            operand: Literal(
+                                Integer {
                                     repr: "-7",
                                     value: -7,
                                 },
@@ -171,8 +171,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "-1",
                                     value: -1,
                                 },
@@ -194,14 +194,14 @@ Program {
                                 op: Int(
                                     Sub,
                                 ),
-                                lhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                lhs: Literal(
+                                    Integer {
                                         repr: "-1",
                                         value: -1,
                                     },
                                 ),
-                                rhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                rhs: Literal(
+                                    Integer {
                                         repr: "-2",
                                         value: -2,
                                     },
@@ -224,14 +224,14 @@ Program {
                                 op: Int(
                                     Sub,
                                 ),
-                                lhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                lhs: Literal(
+                                    Integer {
                                         repr: "-1",
                                         value: -1,
                                     },
                                 ),
-                                rhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                rhs: Literal(
+                                    Integer {
                                         repr: "-2",
                                         value: -2,
                                     },
@@ -254,8 +254,8 @@ Program {
                                 op: Int(
                                     Add,
                                 ),
-                                lhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                lhs: Literal(
+                                    Integer {
                                         repr: "-5",
                                         value: -5,
                                     },
@@ -264,14 +264,14 @@ Program {
                                     op: Int(
                                         Add,
                                     ),
-                                    lhs: IntegerLiteral(
-                                        IntegerLiteral {
+                                    lhs: Literal(
+                                        Integer {
                                             repr: "-7",
                                             value: -7,
                                         },
                                     ),
-                                    rhs: IntegerLiteral(
-                                        IntegerLiteral {
+                                    rhs: Literal(
+                                        Integer {
                                             repr: "-8",
                                             value: -8,
                                         },
@@ -293,8 +293,8 @@ Program {
                         initialiser: Some(
                             UnOp {
                                 op: IntNeg,
-                                operand: IntegerLiteral(
-                                    IntegerLiteral {
+                                operand: Literal(
+                                    Integer {
                                         repr: "-7",
                                         value: -7,
                                     },

--- a/tests/ast/pass/print.txt
+++ b/tests/ast/pass/print.txt
@@ -173,8 +173,8 @@ Program {
                                                                 [
                                                                     (
                                                                         r"id",
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
@@ -186,8 +186,8 @@ Program {
                                                                             elements: Alias(
                                                                                 recursive(2),
                                                                             ),
-                                                                            length: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            length: Literal(
+                                                                                Integer {
                                                                                     repr: "3",
                                                                                     value: 3,
                                                                                 },
@@ -249,8 +249,8 @@ Program {
                                                                 [
                                                                     (
                                                                         r"id",
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
@@ -270,8 +270,8 @@ Program {
                                                                             elements: Alias(
                                                                                 recursive(2),
                                                                             ),
-                                                                            length: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            length: Literal(
+                                                                                Integer {
                                                                                     repr: "3",
                                                                                     value: 3,
                                                                                 },
@@ -317,8 +317,8 @@ Program {
                                                 ),
                                                 member_name: r"links",
                                             },
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -338,8 +338,8 @@ Program {
                                                 ),
                                                 member_name: r"links",
                                             },
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -542,8 +542,8 @@ Program {
                                                                     [
                                                                         (
                                                                             r"id",
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "0",
                                                                                     value: 0,
                                                                                 },
@@ -555,8 +555,8 @@ Program {
                                                                                 elements: Alias(
                                                                                     recursive(2),
                                                                                 ),
-                                                                                length: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                length: Literal(
+                                                                                    Integer {
                                                                                         repr: "3",
                                                                                         value: 3,
                                                                                     },
@@ -618,8 +618,8 @@ Program {
                                                                     [
                                                                         (
                                                                             r"id",
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "0",
                                                                                     value: 0,
                                                                                 },
@@ -639,8 +639,8 @@ Program {
                                                                                 elements: Alias(
                                                                                     recursive(2),
                                                                                 ),
-                                                                                length: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                length: Literal(
+                                                                                    Integer {
                                                                                         repr: "3",
                                                                                         value: 3,
                                                                                     },
@@ -686,8 +686,8 @@ Program {
                                                     ),
                                                     member_name: r"links",
                                                 },
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -707,8 +707,8 @@ Program {
                                                     ),
                                                     member_name: r"links",
                                                 },
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -751,8 +751,8 @@ Program {
                                     [
                                         (
                                             r"id",
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -764,8 +764,8 @@ Program {
                                                 elements: Alias(
                                                     recursive(2),
                                                 ),
-                                                length: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                length: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -798,8 +798,8 @@ Program {
                                     [
                                         (
                                             r"id",
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -819,8 +819,8 @@ Program {
                                                 elements: Alias(
                                                     recursive(2),
                                                 ),
-                                                length: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                length: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },

--- a/tests/ast/pass/raytracer.txt
+++ b/tests/ast/pass/raytracer.txt
@@ -6,8 +6,8 @@ Program {
                 VarDecl {
                     t: Real,
                     initialiser: Some(
-                        RealLiteral(
-                            RealLiteral {
+                        Literal(
+                            Real {
                                 repr: "0.0001",
                                 value: 0.0001,
                             },
@@ -428,8 +428,8 @@ Program {
                                             Sub,
                                         ),
                                         lhs: IntToReal(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -536,8 +536,8 @@ Program {
                                                     ),
                                                 ),
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.5",
                                                     value: 0.5,
                                                 },
@@ -558,8 +558,8 @@ Program {
                                                                 res(18),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -625,8 +625,8 @@ Program {
                                                     s(20),
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -635,8 +635,8 @@ Program {
                                         on_true: Block {
                                             stmts: [
                                                 Return {
-                                                    value: RealLiteral(
-                                                        RealLiteral {
+                                                    value: Literal(
+                                                        Real {
                                                             repr: "NaN",
                                                             value: NaN,
                                                         },
@@ -654,8 +654,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "1.0",
                                                                 value: 1.0,
                                                             },
@@ -678,8 +678,8 @@ Program {
                                                     s(20),
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "1.0",
                                                     value: 1.0,
                                                 },
@@ -701,8 +701,8 @@ Program {
                                                             ),
                                                         ),
                                                         rhs: IntToReal(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -717,14 +717,14 @@ Program {
                                     },
                                     For {
                                         counter: i(22),
-                                        lower_bound: IntegerLiteral(
-                                            IntegerLiteral {
+                                        lower_bound: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
                                         ),
-                                        upper_bound: IntegerLiteral(
-                                            IntegerLiteral {
+                                        upper_bound: Literal(
+                                            Integer {
                                                 repr: "100",
                                                 value: 100,
                                             },
@@ -786,8 +786,8 @@ Program {
                                                             },
                                                         },
                                                         rhs: IntToReal(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -1634,8 +1634,8 @@ Program {
                                             Div,
                                         ),
                                         lhs: IntToReal(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -1942,8 +1942,8 @@ Program {
                                                             val(54),
                                                         ),
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -1958,8 +1958,8 @@ Program {
                                                             val(54),
                                                         ),
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "256",
                                                             value: 256,
                                                         },
@@ -2374,20 +2374,20 @@ Program {
                         Call {
                             callee: colour_of(59),
                             args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "255",
                                         value: 255,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
@@ -2412,20 +2412,20 @@ Program {
                         Call {
                             callee: colour_of(59),
                             args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "255",
                                         value: 255,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
@@ -2450,20 +2450,20 @@ Program {
                         Call {
                             callee: colour_of(59),
                             args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "255",
                                         value: 255,
                                     },
@@ -2488,20 +2488,20 @@ Program {
                         Call {
                             callee: colour_of(59),
                             args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "0",
                                         value: 0,
                                     },
@@ -2526,20 +2526,20 @@ Program {
                         Call {
                             callee: colour_of(59),
                             args: [
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "255",
                                         value: 255,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "255",
                                         value: 255,
                                     },
                                 ),
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "255",
                                         value: 255,
                                     },
@@ -2711,8 +2711,8 @@ Program {
                                                 ),
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -2844,8 +2844,8 @@ Program {
                                                         ),
                                                     ),
                                                 },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -2996,8 +2996,8 @@ Program {
                                     ),
                                     For {
                                         counter: x(84),
-                                        lower_bound: IntegerLiteral(
-                                            IntegerLiteral {
+                                        lower_bound: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -3014,8 +3014,8 @@ Program {
                                                     member_name: r"width",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -3026,8 +3026,8 @@ Program {
                                             stmts: [
                                                 For {
                                                     counter: y(85),
-                                                    lower_bound: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lower_bound: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -3044,8 +3044,8 @@ Program {
                                                                 member_name: r"height",
                                                             },
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -3171,15 +3171,15 @@ Program {
                                                     member_name: r"height",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
                                             ),
                                         },
-                                        upper_bound: IntegerLiteral(
-                                            IntegerLiteral {
+                                        upper_bound: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -3189,8 +3189,8 @@ Program {
                                             stmts: [
                                                 For {
                                                     counter: x(89),
-                                                    lower_bound: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lower_bound: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -3207,8 +3207,8 @@ Program {
                                                                 member_name: r"width",
                                                             },
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -3453,8 +3453,8 @@ Program {
                                     [
                                         (
                                             r"kind",
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -3521,8 +3521,8 @@ Program {
                                     [
                                         (
                                             r"kind",
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -3647,8 +3647,8 @@ Program {
                                                                 Mul,
                                                             ),
                                                             lhs: IntToReal(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -3820,8 +3820,8 @@ Program {
                                                                         Mul,
                                                                     ),
                                                                     lhs: IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "4",
                                                                                 value: 4,
                                                                             },
@@ -3858,8 +3858,8 @@ Program {
                                                     discriminant(103),
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -3868,8 +3868,8 @@ Program {
                                         on_true: Block {
                                             stmts: [
                                                 Return {
-                                                    value: RealLiteral(
-                                                        RealLiteral {
+                                                    value: Literal(
+                                                        Real {
                                                             repr: "NaN",
                                                             value: NaN,
                                                         },
@@ -3919,8 +3919,8 @@ Program {
                                                                     Mul,
                                                                 ),
                                                                 lhs: IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -3980,8 +3980,8 @@ Program {
                                                                     Mul,
                                                                 ),
                                                                 lhs: IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -4023,8 +4023,8 @@ Program {
                                                 ],
                                             },
                                             rhs: IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },
@@ -4077,8 +4077,8 @@ Program {
                                                                 ],
                                                             },
                                                             rhs: IntToReal(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "0",
                                                                         value: 0,
                                                                     },
@@ -4111,8 +4111,8 @@ Program {
                                                             Block {
                                                                 stmts: [
                                                                     Return {
-                                                                        value: RealLiteral(
-                                                                            RealLiteral {
+                                                                        value: Literal(
+                                                                            Real {
                                                                                 repr: "NaN",
                                                                                 value: NaN,
                                                                             },
@@ -4213,8 +4213,8 @@ Program {
                                                     ],
                                                 },
                                                 IntToReal(
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -4225,8 +4225,8 @@ Program {
                                         on_true: Block {
                                             stmts: [
                                                 Return {
-                                                    value: RealLiteral(
-                                                        RealLiteral {
+                                                    value: Literal(
+                                                        Real {
                                                             repr: "NaN",
                                                             value: NaN,
                                                         },
@@ -4344,8 +4344,8 @@ Program {
                                             Block {
                                                 stmts: [
                                                     Return {
-                                                        value: RealLiteral(
-                                                            RealLiteral {
+                                                        value: Literal(
+                                                            Real {
                                                                 repr: "NaN",
                                                                 value: NaN,
                                                             },
@@ -4428,8 +4428,8 @@ Program {
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -4475,8 +4475,8 @@ Program {
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -4510,8 +4510,8 @@ Program {
                                         on_false: None,
                                     },
                                     Return {
-                                        value: RealLiteral(
-                                            RealLiteral {
+                                        value: Literal(
+                                            Real {
                                                 repr: "NaN",
                                                 value: NaN,
                                             },
@@ -4734,8 +4734,8 @@ Program {
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -4781,8 +4781,8 @@ Program {
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -4892,8 +4892,8 @@ Program {
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -4932,8 +4932,8 @@ Program {
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -5030,8 +5030,8 @@ Program {
                                     [
                                         (
                                             r"t",
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -5412,8 +5412,8 @@ Program {
                                                     t: Real,
                                                     initialiser: Some(
                                                         IntToReal(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -5484,24 +5484,24 @@ Program {
                                                             callee: vector_of(28),
                                                             args: [
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
                                                                     ),
                                                                 ),
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
                                                                     ),
                                                                 ),
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "-2",
                                                                             value: -2,
                                                                         },
@@ -5530,24 +5530,24 @@ Program {
                                                             callee: vector_of(28),
                                                             args: [
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
                                                                     ),
                                                                 ),
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
                                                                     ),
                                                                 ),
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
@@ -5576,24 +5576,24 @@ Program {
                                                             callee: vector_of(28),
                                                             args: [
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
                                                                     ),
                                                                 ),
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
                                                                     ),
                                                                 ),
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
@@ -5634,8 +5634,8 @@ Program {
                                                                         ),
                                                                     },
                                                                     rhs: IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "2",
                                                                                 value: 2,
                                                                             },
@@ -5655,8 +5655,8 @@ Program {
                                                                         ),
                                                                     },
                                                                     rhs: IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "2",
                                                                                 value: 2,
                                                                             },
@@ -5664,8 +5664,8 @@ Program {
                                                                     ),
                                                                 },
                                                                 IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
@@ -5683,8 +5683,8 @@ Program {
                                     ),
                                     For {
                                         counter: x(144),
-                                        lower_bound: IntegerLiteral(
-                                            IntegerLiteral {
+                                        lower_bound: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -5701,8 +5701,8 @@ Program {
                                                     member_name: r"width",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -5713,8 +5713,8 @@ Program {
                                             stmts: [
                                                 For {
                                                     counter: y(145),
-                                                    lower_bound: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lower_bound: Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -5731,8 +5731,8 @@ Program {
                                                                 member_name: r"height",
                                                             },
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -5789,8 +5789,8 @@ Program {
                                                                                                                 op: Real(
                                                                                                                     Mul,
                                                                                                                 ),
-                                                                                                                lhs: RealLiteral(
-                                                                                                                    RealLiteral {
+                                                                                                                lhs: Literal(
+                                                                                                                    Real {
                                                                                                                         repr: "1.0",
                                                                                                                         value: 1.0,
                                                                                                                     },
@@ -5842,8 +5842,8 @@ Program {
                                                                                                                 op: Real(
                                                                                                                     Mul,
                                                                                                                 ),
-                                                                                                                lhs: RealLiteral(
-                                                                                                                    RealLiteral {
+                                                                                                                lhs: Literal(
+                                                                                                                    Real {
                                                                                                                         repr: "1.0",
                                                                                                                         value: 1.0,
                                                                                                                     },
@@ -6007,8 +6007,8 @@ Program {
                                                                                                         callee: vector_mul(37),
                                                                                                         args: [
                                                                                                             IntToReal(
-                                                                                                                IntegerLiteral(
-                                                                                                                    IntegerLiteral {
+                                                                                                                Literal(
+                                                                                                                    Integer {
                                                                                                                         repr: "-1",
                                                                                                                         value: -1,
                                                                                                                     },
@@ -6045,8 +6045,8 @@ Program {
                                                                                     ),
                                                                                 ),
                                                                                 rhs: IntToReal(
-                                                                                    IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    Literal(
+                                                                                        Integer {
                                                                                             repr: "0",
                                                                                             value: 0,
                                                                                         },
@@ -6060,8 +6060,8 @@ Program {
                                                                                             colour_ratio(149),
                                                                                         ),
                                                                                         rhs: IntToReal(
-                                                                                            IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            Literal(
+                                                                                                Integer {
                                                                                                     repr: "1",
                                                                                                     value: 1,
                                                                                                 },
@@ -6224,21 +6224,21 @@ Program {
                                                                         Call {
                                                                             callee: vector_of(28),
                                                                             args: [
-                                                                                RealLiteral(
-                                                                                    RealLiteral {
+                                                                                Literal(
+                                                                                    Real {
                                                                                         repr: "0.5",
                                                                                         value: 0.5,
                                                                                     },
                                                                                 ),
-                                                                                RealLiteral(
-                                                                                    RealLiteral {
+                                                                                Literal(
+                                                                                    Real {
                                                                                         repr: "0.5",
                                                                                         value: 0.5,
                                                                                     },
                                                                                 ),
                                                                                 IntToReal(
-                                                                                    IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    Literal(
+                                                                                        Integer {
                                                                                             repr: "3",
                                                                                             value: 3,
                                                                                         },
@@ -6250,8 +6250,8 @@ Program {
                                                                     (
                                                                         r"radius",
                                                                         IntToReal(
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -6297,21 +6297,21 @@ Program {
                                                                         Call {
                                                                             callee: vector_of(28),
                                                                             args: [
-                                                                                RealLiteral(
-                                                                                    RealLiteral {
+                                                                                Literal(
+                                                                                    Real {
                                                                                         repr: "-0.8",
                                                                                         value: -0.8,
                                                                                     },
                                                                                 ),
-                                                                                RealLiteral(
-                                                                                    RealLiteral {
+                                                                                Literal(
+                                                                                    Real {
                                                                                         repr: "-0.5",
                                                                                         value: -0.5,
                                                                                     },
                                                                                 ),
                                                                                 IntToReal(
-                                                                                    IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    Literal(
+                                                                                        Integer {
                                                                                             repr: "4",
                                                                                             value: 4,
                                                                                         },
@@ -6323,8 +6323,8 @@ Program {
                                                                     (
                                                                         r"radius",
                                                                         IntToReal(
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "2",
                                                                                     value: 2,
                                                                                 },
@@ -6371,22 +6371,22 @@ Program {
                                                                             callee: vector_of(28),
                                                                             args: [
                                                                                 IntToReal(
-                                                                                    IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    Literal(
+                                                                                        Integer {
                                                                                             repr: "0",
                                                                                             value: 0,
                                                                                         },
                                                                                     ),
                                                                                 ),
-                                                                                RealLiteral(
-                                                                                    RealLiteral {
+                                                                                Literal(
+                                                                                    Real {
                                                                                         repr: "-1.5",
                                                                                         value: -1.5,
                                                                                     },
                                                                                 ),
                                                                                 IntToReal(
-                                                                                    IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    Literal(
+                                                                                        Integer {
                                                                                             repr: "5",
                                                                                             value: 5,
                                                                                         },
@@ -6400,22 +6400,22 @@ Program {
                                                                         Call {
                                                                             callee: vector_of(28),
                                                                             args: [
-                                                                                RealLiteral(
-                                                                                    RealLiteral {
+                                                                                Literal(
+                                                                                    Real {
                                                                                         repr: "0.2",
                                                                                         value: 0.2,
                                                                                     },
                                                                                 ),
                                                                                 IntToReal(
-                                                                                    IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    Literal(
+                                                                                        Integer {
                                                                                             repr: "1",
                                                                                             value: 1,
                                                                                         },
                                                                                     ),
                                                                                 ),
-                                                                                RealLiteral(
-                                                                                    RealLiteral {
+                                                                                Literal(
+                                                                                    Real {
                                                                                         repr: "-0.1",
                                                                                         value: -0.1,
                                                                                     },
@@ -6484,8 +6484,8 @@ Program {
                                             lhs: Identifier(
                                                 scene(155),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -6507,8 +6507,8 @@ Program {
                                             lhs: Identifier(
                                                 scene(155),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -6530,8 +6530,8 @@ Program {
                                             lhs: Identifier(
                                                 scene(155),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -6555,14 +6555,14 @@ Program {
                                                 Call {
                                                     callee: trace_rays(133),
                                                     args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "36",
                                                                 value: 36,
                                                             },
                                                         ),
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "64",
                                                                 value: 64,
                                                             },
@@ -6594,8 +6594,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "0.0001",
                                     value: 0.0001,
                                 },
@@ -7136,8 +7136,8 @@ Program {
                                                 Sub,
                                             ),
                                             lhs: IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -7244,8 +7244,8 @@ Program {
                                                         ),
                                                     ),
                                                 },
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.5",
                                                         value: 0.5,
                                                     },
@@ -7266,8 +7266,8 @@ Program {
                                                                     res(18),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -7365,8 +7365,8 @@ Program {
                                                         s(20),
                                                     ),
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.0",
                                                         value: 0.0,
                                                     },
@@ -7375,8 +7375,8 @@ Program {
                                             on_true: Block {
                                                 stmts: [
                                                     Return {
-                                                        value: RealLiteral(
-                                                            RealLiteral {
+                                                        value: Literal(
+                                                            Real {
                                                                 repr: "NaN",
                                                                 value: NaN,
                                                             },
@@ -7394,8 +7394,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "1.0",
                                                                     value: 1.0,
                                                                 },
@@ -7418,8 +7418,8 @@ Program {
                                                         s(20),
                                                     ),
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "1.0",
                                                         value: 1.0,
                                                     },
@@ -7441,8 +7441,8 @@ Program {
                                                                 ),
                                                             ),
                                                             rhs: IntToReal(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -7457,14 +7457,14 @@ Program {
                                         },
                                         For {
                                             counter: i(22),
-                                            lower_bound: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lower_bound: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
                                             ),
-                                            upper_bound: IntegerLiteral(
-                                                IntegerLiteral {
+                                            upper_bound: Literal(
+                                                Integer {
                                                     repr: "100",
                                                     value: 100,
                                                 },
@@ -7526,8 +7526,8 @@ Program {
                                                                 },
                                                             },
                                                             rhs: IntToReal(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -7632,8 +7632,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "1.0",
                                     value: 1.0,
                                 },
@@ -8609,8 +8609,8 @@ Program {
                                                 Div,
                                             ),
                                             lhs: IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -8971,8 +8971,8 @@ Program {
                                                                 val(54),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -8987,8 +8987,8 @@ Program {
                                                                 val(54),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "256",
                                                                 value: 256,
                                                             },
@@ -9491,20 +9491,20 @@ Program {
                             Call {
                                 callee: colour_of(59),
                                 args: [
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "255",
                                             value: 255,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
@@ -9529,20 +9529,20 @@ Program {
                             Call {
                                 callee: colour_of(59),
                                 args: [
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "255",
                                             value: 255,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
@@ -9567,20 +9567,20 @@ Program {
                             Call {
                                 callee: colour_of(59),
                                 args: [
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "255",
                                             value: 255,
                                         },
@@ -9605,20 +9605,20 @@ Program {
                             Call {
                                 callee: colour_of(59),
                                 args: [
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "0",
                                             value: 0,
                                         },
@@ -9643,20 +9643,20 @@ Program {
                             Call {
                                 callee: colour_of(59),
                                 args: [
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "255",
                                             value: 255,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "255",
                                             value: 255,
                                         },
                                     ),
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "255",
                                             value: 255,
                                         },
@@ -9866,8 +9866,8 @@ Program {
                                                     ),
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -9999,8 +9999,8 @@ Program {
                                                             ),
                                                         ),
                                                     },
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -10203,8 +10203,8 @@ Program {
                                         ),
                                         For {
                                             counter: x(84),
-                                            lower_bound: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lower_bound: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -10221,8 +10221,8 @@ Program {
                                                         member_name: r"width",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -10233,8 +10233,8 @@ Program {
                                                 stmts: [
                                                     For {
                                                         counter: y(85),
-                                                        lower_bound: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lower_bound: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -10251,8 +10251,8 @@ Program {
                                                                     member_name: r"height",
                                                                 },
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -10503,15 +10503,15 @@ Program {
                                                         member_name: r"height",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
                                             },
-                                            upper_bound: IntegerLiteral(
-                                                IntegerLiteral {
+                                            upper_bound: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -10521,8 +10521,8 @@ Program {
                                                 stmts: [
                                                     For {
                                                         counter: x(89),
-                                                        lower_bound: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lower_bound: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -10539,8 +10539,8 @@ Program {
                                                                     member_name: r"width",
                                                                 },
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -10837,8 +10837,8 @@ Program {
                                         [
                                             (
                                                 r"kind",
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -10919,8 +10919,8 @@ Program {
                                         [
                                             (
                                                 r"kind",
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -11045,8 +11045,8 @@ Program {
                                                                     Mul,
                                                                 ),
                                                                 lhs: IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -11218,8 +11218,8 @@ Program {
                                                                             Mul,
                                                                         ),
                                                                         lhs: IntToReal(
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "4",
                                                                                     value: 4,
                                                                                 },
@@ -11256,8 +11256,8 @@ Program {
                                                         discriminant(103),
                                                     ),
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.0",
                                                         value: 0.0,
                                                     },
@@ -11266,8 +11266,8 @@ Program {
                                             on_true: Block {
                                                 stmts: [
                                                     Return {
-                                                        value: RealLiteral(
-                                                            RealLiteral {
+                                                        value: Literal(
+                                                            Real {
                                                                 repr: "NaN",
                                                                 value: NaN,
                                                             },
@@ -11317,8 +11317,8 @@ Program {
                                                                         Mul,
                                                                     ),
                                                                     lhs: IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "2",
                                                                                 value: 2,
                                                                             },
@@ -11378,8 +11378,8 @@ Program {
                                                                         Mul,
                                                                     ),
                                                                     lhs: IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "2",
                                                                                 value: 2,
                                                                             },
@@ -11421,8 +11421,8 @@ Program {
                                                     ],
                                                 },
                                                 rhs: IntToReal(
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -11475,8 +11475,8 @@ Program {
                                                                     ],
                                                                 },
                                                                 rhs: IntToReal(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
@@ -11509,8 +11509,8 @@ Program {
                                                                 Block {
                                                                     stmts: [
                                                                         Return {
-                                                                            value: RealLiteral(
-                                                                                RealLiteral {
+                                                                            value: Literal(
+                                                                                Real {
                                                                                     repr: "NaN",
                                                                                     value: NaN,
                                                                                 },
@@ -11607,8 +11607,8 @@ Program {
                                     Mul,
                                 ),
                                 lhs: IntToReal(
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "2",
                                             value: 2,
                                         },
@@ -11776,8 +11776,8 @@ Program {
                                             Mul,
                                         ),
                                         lhs: IntToReal(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
@@ -11841,8 +11841,8 @@ Program {
                                         Mul,
                                     ),
                                     lhs: IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "2",
                                                 value: 2,
                                             },
@@ -11900,8 +11900,8 @@ Program {
                                         Mul,
                                     ),
                                     lhs: IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "2",
                                                 value: 2,
                                             },
@@ -11998,8 +11998,8 @@ Program {
                                                         ],
                                                     },
                                                     IntToReal(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -12010,8 +12010,8 @@ Program {
                                             on_true: Block {
                                                 stmts: [
                                                     Return {
-                                                        value: RealLiteral(
-                                                            RealLiteral {
+                                                        value: Literal(
+                                                            Real {
                                                                 repr: "NaN",
                                                                 value: NaN,
                                                             },
@@ -12129,8 +12129,8 @@ Program {
                                                 Block {
                                                     stmts: [
                                                         Return {
-                                                            value: RealLiteral(
-                                                                RealLiteral {
+                                                            value: Literal(
+                                                                Real {
                                                                     repr: "NaN",
                                                                     value: NaN,
                                                                 },
@@ -12314,8 +12314,8 @@ Program {
                                                         member_name: r"kind",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -12361,8 +12361,8 @@ Program {
                                                         member_name: r"kind",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -12396,8 +12396,8 @@ Program {
                                             on_false: None,
                                         },
                                         Return {
-                                            value: RealLiteral(
-                                                RealLiteral {
+                                            value: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -12704,8 +12704,8 @@ Program {
                                                         member_name: r"kind",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -12751,8 +12751,8 @@ Program {
                                                         member_name: r"kind",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -12890,8 +12890,8 @@ Program {
                                                         member_name: r"kind",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -12930,8 +12930,8 @@ Program {
                                                         member_name: r"kind",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -13056,8 +13056,8 @@ Program {
                                         [
                                             (
                                                 r"t",
-                                                RealLiteral(
-                                                    RealLiteral {
+                                                Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
@@ -13532,8 +13532,8 @@ Program {
                                                         t: Real,
                                                         initialiser: Some(
                                                             IntToReal(
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -13604,24 +13604,24 @@ Program {
                                                                 callee: vector_of(28),
                                                                 args: [
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
                                                                         ),
                                                                     ),
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
                                                                         ),
                                                                     ),
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "-2",
                                                                                 value: -2,
                                                                             },
@@ -13650,24 +13650,24 @@ Program {
                                                                 callee: vector_of(28),
                                                                 args: [
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
                                                                         ),
                                                                     ),
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
                                                                         ),
                                                                     ),
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
@@ -13696,24 +13696,24 @@ Program {
                                                                 callee: vector_of(28),
                                                                 args: [
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
                                                                         ),
                                                                     ),
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
                                                                         ),
                                                                     ),
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
@@ -13754,8 +13754,8 @@ Program {
                                                                             ),
                                                                         },
                                                                         rhs: IntToReal(
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "2",
                                                                                     value: 2,
                                                                                 },
@@ -13775,8 +13775,8 @@ Program {
                                                                             ),
                                                                         },
                                                                         rhs: IntToReal(
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "2",
                                                                                     value: 2,
                                                                                 },
@@ -13784,8 +13784,8 @@ Program {
                                                                         ),
                                                                     },
                                                                     IntToReal(
-                                                                        IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        Literal(
+                                                                            Integer {
                                                                                 repr: "0",
                                                                                 value: 0,
                                                                             },
@@ -13803,8 +13803,8 @@ Program {
                                         ),
                                         For {
                                             counter: x(144),
-                                            lower_bound: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lower_bound: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -13821,8 +13821,8 @@ Program {
                                                         member_name: r"width",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -13833,8 +13833,8 @@ Program {
                                                 stmts: [
                                                     For {
                                                         counter: y(145),
-                                                        lower_bound: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lower_bound: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -13851,8 +13851,8 @@ Program {
                                                                     member_name: r"height",
                                                                 },
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -13909,8 +13909,8 @@ Program {
                                                                                                                     op: Real(
                                                                                                                         Mul,
                                                                                                                     ),
-                                                                                                                    lhs: RealLiteral(
-                                                                                                                        RealLiteral {
+                                                                                                                    lhs: Literal(
+                                                                                                                        Real {
                                                                                                                             repr: "1.0",
                                                                                                                             value: 1.0,
                                                                                                                         },
@@ -13962,8 +13962,8 @@ Program {
                                                                                                                     op: Real(
                                                                                                                         Mul,
                                                                                                                     ),
-                                                                                                                    lhs: RealLiteral(
-                                                                                                                        RealLiteral {
+                                                                                                                    lhs: Literal(
+                                                                                                                        Real {
                                                                                                                             repr: "1.0",
                                                                                                                             value: 1.0,
                                                                                                                         },
@@ -14127,8 +14127,8 @@ Program {
                                                                                                             callee: vector_mul(37),
                                                                                                             args: [
                                                                                                                 IntToReal(
-                                                                                                                    IntegerLiteral(
-                                                                                                                        IntegerLiteral {
+                                                                                                                    Literal(
+                                                                                                                        Integer {
                                                                                                                             repr: "-1",
                                                                                                                             value: -1,
                                                                                                                         },
@@ -14165,8 +14165,8 @@ Program {
                                                                                         ),
                                                                                     ),
                                                                                     rhs: IntToReal(
-                                                                                        IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        Literal(
+                                                                                            Integer {
                                                                                                 repr: "0",
                                                                                                 value: 0,
                                                                                             },
@@ -14180,8 +14180,8 @@ Program {
                                                                                                 colour_ratio(149),
                                                                                             ),
                                                                                             rhs: IntToReal(
-                                                                                                IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                Literal(
+                                                                                                    Integer {
                                                                                                         repr: "1",
                                                                                                         value: 1,
                                                                                                     },
@@ -14396,8 +14396,8 @@ Program {
                         t: Real,
                         initialiser: Some(
                             IntToReal(
-                                IntegerLiteral(
-                                    IntegerLiteral {
+                                Literal(
+                                    Integer {
                                         repr: "2",
                                         value: 2,
                                     },
@@ -14464,24 +14464,24 @@ Program {
                                 callee: vector_of(28),
                                 args: [
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
                                         ),
                                     ),
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
                                         ),
                                     ),
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "-2",
                                                 value: -2,
                                             },
@@ -14508,24 +14508,24 @@ Program {
                                 callee: vector_of(28),
                                 args: [
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
                                         ),
                                     ),
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
                                         ),
                                     ),
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -14552,24 +14552,24 @@ Program {
                                 callee: vector_of(28),
                                 args: [
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
                                         ),
                                     ),
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
                                         ),
                                     ),
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -14608,8 +14608,8 @@ Program {
                                             ),
                                         },
                                         rhs: IntToReal(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -14629,8 +14629,8 @@ Program {
                                             ),
                                         },
                                         rhs: IntToReal(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -14638,8 +14638,8 @@ Program {
                                         ),
                                     },
                                     IntToReal(
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -14725,8 +14725,8 @@ Program {
                                                             op: Real(
                                                                 Mul,
                                                             ),
-                                                            lhs: RealLiteral(
-                                                                RealLiteral {
+                                                            lhs: Literal(
+                                                                Real {
                                                                     repr: "1.0",
                                                                     value: 1.0,
                                                                 },
@@ -14778,8 +14778,8 @@ Program {
                                                             op: Real(
                                                                 Mul,
                                                             ),
-                                                            lhs: RealLiteral(
-                                                                RealLiteral {
+                                                            lhs: Literal(
+                                                                Real {
                                                                     repr: "1.0",
                                                                     value: 1.0,
                                                                 },
@@ -14918,8 +14918,8 @@ Program {
                                         callee: vector_mul(37),
                                         args: [
                                             IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "-1",
                                                         value: -1,
                                                     },
@@ -15023,21 +15023,21 @@ Program {
                                                                             Call {
                                                                                 callee: vector_of(28),
                                                                                 args: [
-                                                                                    RealLiteral(
-                                                                                        RealLiteral {
+                                                                                    Literal(
+                                                                                        Real {
                                                                                             repr: "0.5",
                                                                                             value: 0.5,
                                                                                         },
                                                                                     ),
-                                                                                    RealLiteral(
-                                                                                        RealLiteral {
+                                                                                    Literal(
+                                                                                        Real {
                                                                                             repr: "0.5",
                                                                                             value: 0.5,
                                                                                         },
                                                                                     ),
                                                                                     IntToReal(
-                                                                                        IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        Literal(
+                                                                                            Integer {
                                                                                                 repr: "3",
                                                                                                 value: 3,
                                                                                             },
@@ -15049,8 +15049,8 @@ Program {
                                                                         (
                                                                             r"radius",
                                                                             IntToReal(
-                                                                                IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                Literal(
+                                                                                    Integer {
                                                                                         repr: "1",
                                                                                         value: 1,
                                                                                     },
@@ -15096,21 +15096,21 @@ Program {
                                                                             Call {
                                                                                 callee: vector_of(28),
                                                                                 args: [
-                                                                                    RealLiteral(
-                                                                                        RealLiteral {
+                                                                                    Literal(
+                                                                                        Real {
                                                                                             repr: "-0.8",
                                                                                             value: -0.8,
                                                                                         },
                                                                                     ),
-                                                                                    RealLiteral(
-                                                                                        RealLiteral {
+                                                                                    Literal(
+                                                                                        Real {
                                                                                             repr: "-0.5",
                                                                                             value: -0.5,
                                                                                         },
                                                                                     ),
                                                                                     IntToReal(
-                                                                                        IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        Literal(
+                                                                                            Integer {
                                                                                                 repr: "4",
                                                                                                 value: 4,
                                                                                             },
@@ -15122,8 +15122,8 @@ Program {
                                                                         (
                                                                             r"radius",
                                                                             IntToReal(
-                                                                                IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                Literal(
+                                                                                    Integer {
                                                                                         repr: "2",
                                                                                         value: 2,
                                                                                     },
@@ -15170,22 +15170,22 @@ Program {
                                                                                 callee: vector_of(28),
                                                                                 args: [
                                                                                     IntToReal(
-                                                                                        IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        Literal(
+                                                                                            Integer {
                                                                                                 repr: "0",
                                                                                                 value: 0,
                                                                                             },
                                                                                         ),
                                                                                     ),
-                                                                                    RealLiteral(
-                                                                                        RealLiteral {
+                                                                                    Literal(
+                                                                                        Real {
                                                                                             repr: "-1.5",
                                                                                             value: -1.5,
                                                                                         },
                                                                                     ),
                                                                                     IntToReal(
-                                                                                        IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        Literal(
+                                                                                            Integer {
                                                                                                 repr: "5",
                                                                                                 value: 5,
                                                                                             },
@@ -15199,22 +15199,22 @@ Program {
                                                                             Call {
                                                                                 callee: vector_of(28),
                                                                                 args: [
-                                                                                    RealLiteral(
-                                                                                        RealLiteral {
+                                                                                    Literal(
+                                                                                        Real {
                                                                                             repr: "0.2",
                                                                                             value: 0.2,
                                                                                         },
                                                                                     ),
                                                                                     IntToReal(
-                                                                                        IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        Literal(
+                                                                                            Integer {
                                                                                                 repr: "1",
                                                                                                 value: 1,
                                                                                             },
                                                                                         ),
                                                                                     ),
-                                                                                    RealLiteral(
-                                                                                        RealLiteral {
+                                                                                    Literal(
+                                                                                        Real {
                                                                                             repr: "-0.1",
                                                                                             value: -0.1,
                                                                                         },
@@ -15283,8 +15283,8 @@ Program {
                                                 lhs: Identifier(
                                                     scene(155),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -15306,8 +15306,8 @@ Program {
                                                 lhs: Identifier(
                                                     scene(155),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -15329,8 +15329,8 @@ Program {
                                                 lhs: Identifier(
                                                     scene(155),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -15354,14 +15354,14 @@ Program {
                                                     Call {
                                                         callee: trace_rays(133),
                                                         args: [
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "36",
                                                                     value: 36,
                                                                 },
                                                             ),
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "64",
                                                                     value: 64,
                                                                 },
@@ -15403,21 +15403,21 @@ Program {
                                             Call {
                                                 callee: vector_of(28),
                                                 args: [
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "0.5",
                                                             value: 0.5,
                                                         },
                                                     ),
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "0.5",
                                                             value: 0.5,
                                                         },
                                                     ),
                                                     IntToReal(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -15429,8 +15429,8 @@ Program {
                                         (
                                             r"radius",
                                             IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -15474,21 +15474,21 @@ Program {
                                             Call {
                                                 callee: vector_of(28),
                                                 args: [
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "-0.8",
                                                             value: -0.8,
                                                         },
                                                     ),
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "-0.5",
                                                             value: -0.5,
                                                         },
                                                     ),
                                                     IntToReal(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "4",
                                                                 value: 4,
                                                             },
@@ -15500,8 +15500,8 @@ Program {
                                         (
                                             r"radius",
                                             IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -15546,22 +15546,22 @@ Program {
                                                 callee: vector_of(28),
                                                 args: [
                                                     IntToReal(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
                                                         ),
                                                     ),
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "-1.5",
                                                             value: -1.5,
                                                         },
                                                     ),
                                                     IntToReal(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "5",
                                                                 value: 5,
                                                             },
@@ -15575,22 +15575,22 @@ Program {
                                             Call {
                                                 callee: vector_of(28),
                                                 args: [
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "0.2",
                                                             value: 0.2,
                                                         },
                                                     ),
                                                     IntToReal(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
                                                         ),
                                                     ),
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "-0.1",
                                                             value: -0.1,
                                                         },

--- a/tests/ast/pass/real_comparisons.txt
+++ b/tests/ast/pass/real_comparisons.txt
@@ -18,14 +18,14 @@ Program {
                                             op: Eq(
                                                 Eq,
                                             ),
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -37,14 +37,14 @@ Program {
                                             op: Eq(
                                                 Ne,
                                             ),
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -56,14 +56,14 @@ Program {
                                             op: Real(
                                                 Lt,
                                             ),
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -75,14 +75,14 @@ Program {
                                             op: Real(
                                                 Le,
                                             ),
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -94,14 +94,14 @@ Program {
                                             op: Real(
                                                 Gt,
                                             ),
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -113,14 +113,14 @@ Program {
                                             op: Real(
                                                 Ge,
                                             ),
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -142,21 +142,21 @@ Program {
                                                                 op: Real(
                                                                     Add,
                                                                 ),
-                                                                lhs: RealLiteral(
-                                                                    RealLiteral {
+                                                                lhs: Literal(
+                                                                    Real {
                                                                         repr: "0.1",
                                                                         value: 0.1,
                                                                     },
                                                                 ),
-                                                                rhs: RealLiteral(
-                                                                    RealLiteral {
+                                                                rhs: Literal(
+                                                                    Real {
                                                                         repr: "0.1",
                                                                         value: 0.1,
                                                                     },
                                                                 ),
                                                             },
-                                                            rhs: RealLiteral(
-                                                                RealLiteral {
+                                                            rhs: Literal(
+                                                                Real {
                                                                     repr: "0.1",
                                                                     value: 0.1,
                                                                 },
@@ -187,8 +187,8 @@ Program {
                                                     a(1),
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.3",
                                                     value: 0.3,
                                                 },
@@ -206,14 +206,14 @@ Program {
                                                             op: Real(
                                                                 Add,
                                                             ),
-                                                            lhs: RealLiteral(
-                                                                RealLiteral {
+                                                            lhs: Literal(
+                                                                Real {
                                                                     repr: "0.1",
                                                                     value: 0.1,
                                                                 },
                                                             ),
-                                                            rhs: RealLiteral(
-                                                                RealLiteral {
+                                                            rhs: Literal(
+                                                                Real {
                                                                     repr: "0.2",
                                                                     value: 0.2,
                                                                 },
@@ -244,8 +244,8 @@ Program {
                                                     b(2),
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.3",
                                                     value: 0.3,
                                                 },
@@ -281,14 +281,14 @@ Program {
                                                 op: Eq(
                                                     Eq,
                                                 ),
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
+                                                lhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
@@ -300,14 +300,14 @@ Program {
                                                 op: Eq(
                                                     Ne,
                                                 ),
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
+                                                lhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
@@ -319,14 +319,14 @@ Program {
                                                 op: Real(
                                                     Lt,
                                                 ),
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
+                                                lhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
@@ -338,14 +338,14 @@ Program {
                                                 op: Real(
                                                     Le,
                                                 ),
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
+                                                lhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
@@ -357,14 +357,14 @@ Program {
                                                 op: Real(
                                                     Gt,
                                                 ),
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
+                                                lhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
@@ -376,14 +376,14 @@ Program {
                                                 op: Real(
                                                     Ge,
                                                 ),
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
+                                                lhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
@@ -405,21 +405,21 @@ Program {
                                                                     op: Real(
                                                                         Add,
                                                                     ),
-                                                                    lhs: RealLiteral(
-                                                                        RealLiteral {
+                                                                    lhs: Literal(
+                                                                        Real {
                                                                             repr: "0.1",
                                                                             value: 0.1,
                                                                         },
                                                                     ),
-                                                                    rhs: RealLiteral(
-                                                                        RealLiteral {
+                                                                    rhs: Literal(
+                                                                        Real {
                                                                             repr: "0.1",
                                                                             value: 0.1,
                                                                         },
                                                                     ),
                                                                 },
-                                                                rhs: RealLiteral(
-                                                                    RealLiteral {
+                                                                rhs: Literal(
+                                                                    Real {
                                                                         repr: "0.1",
                                                                         value: 0.1,
                                                                     },
@@ -450,8 +450,8 @@ Program {
                                                         a(1),
                                                     ),
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.3",
                                                         value: 0.3,
                                                     },
@@ -469,14 +469,14 @@ Program {
                                                                 op: Real(
                                                                     Add,
                                                                 ),
-                                                                lhs: RealLiteral(
-                                                                    RealLiteral {
+                                                                lhs: Literal(
+                                                                    Real {
                                                                         repr: "0.1",
                                                                         value: 0.1,
                                                                     },
                                                                 ),
-                                                                rhs: RealLiteral(
-                                                                    RealLiteral {
+                                                                rhs: Literal(
+                                                                    Real {
                                                                         repr: "0.2",
                                                                         value: 0.2,
                                                                     },
@@ -507,8 +507,8 @@ Program {
                                                         b(2),
                                                     ),
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.3",
                                                         value: 0.3,
                                                     },
@@ -537,21 +537,21 @@ Program {
                                     op: Real(
                                         Add,
                                     ),
-                                    lhs: RealLiteral(
-                                        RealLiteral {
+                                    lhs: Literal(
+                                        Real {
                                             repr: "0.1",
                                             value: 0.1,
                                         },
                                     ),
-                                    rhs: RealLiteral(
-                                        RealLiteral {
+                                    rhs: Literal(
+                                        Real {
                                             repr: "0.1",
                                             value: 0.1,
                                         },
                                     ),
                                 },
-                                rhs: RealLiteral(
-                                    RealLiteral {
+                                rhs: Literal(
+                                    Real {
                                         repr: "0.1",
                                         value: 0.1,
                                     },
@@ -574,14 +574,14 @@ Program {
                                 op: Real(
                                     Add,
                                 ),
-                                lhs: RealLiteral(
-                                    RealLiteral {
+                                lhs: Literal(
+                                    Real {
                                         repr: "0.1",
                                         value: 0.1,
                                     },
                                 ),
-                                rhs: RealLiteral(
-                                    RealLiteral {
+                                rhs: Literal(
+                                    Real {
                                         repr: "0.2",
                                         value: 0.2,
                                     },

--- a/tests/ast/pass/real_literals.txt
+++ b/tests/ast/pass/real_literals.txt
@@ -20,8 +20,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "0.0",
                                                                 value: 0.0,
                                                             },
@@ -48,8 +48,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "3.14",
                                                                 value: 3.14,
                                                             },
@@ -76,8 +76,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "1.5",
                                                                 value: 1.5,
                                                             },
@@ -104,8 +104,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "0.5",
                                                                 value: 0.5,
                                                             },
@@ -132,8 +132,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "10.25",
                                                                 value: 10.25,
                                                             },
@@ -160,8 +160,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "0.001",
                                                                 value: 0.001,
                                                             },
@@ -188,8 +188,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "999.999999999999",
                                                                 value: 999.999999999999,
                                                             },
@@ -216,8 +216,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "0.12345678901234",
                                                                 value: 0.12345678901234,
                                                             },
@@ -244,8 +244,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "2.71828182845904",
                                                                 value: 2.71828182845904,
                                                             },
@@ -272,8 +272,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "1.11111111111111",
                                                                 value: 1.11111111111111,
                                                             },
@@ -300,8 +300,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "0.00000000000001",
                                                                 value: 1e-14,
                                                             },
@@ -328,8 +328,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "12345.6789012345",
                                                                 value: 12345.6789012345,
                                                             },
@@ -356,8 +356,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "NaN",
                                                                 value: NaN,
                                                             },
@@ -384,8 +384,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: ".5",
                                                                 value: 0.5,
                                                             },
@@ -412,8 +412,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "-.5",
                                                                 value: -0.5,
                                                             },
@@ -440,8 +440,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "+.5",
                                                                 value: 0.5,
                                                             },
@@ -470,8 +470,8 @@ Program {
                                                     initialiser: Some(
                                                         UnOp {
                                                             op: RealNeg,
-                                                            operand: RealLiteral(
-                                                                RealLiteral {
+                                                            operand: Literal(
+                                                                Real {
                                                                     repr: "NaN",
                                                                     value: NaN,
                                                                 },
@@ -499,8 +499,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "Inf",
                                                                 value: inf,
                                                             },
@@ -529,8 +529,8 @@ Program {
                                                     initialiser: Some(
                                                         UnOp {
                                                             op: RealNeg,
-                                                            operand: RealLiteral(
-                                                                RealLiteral {
+                                                            operand: Literal(
+                                                                Real {
                                                                     repr: "Inf",
                                                                     value: inf,
                                                                 },
@@ -582,8 +582,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "0.0",
                                                                     value: 0.0,
                                                                 },
@@ -610,8 +610,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "3.14",
                                                                     value: 3.14,
                                                                 },
@@ -638,8 +638,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "1.5",
                                                                     value: 1.5,
                                                                 },
@@ -666,8 +666,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "0.5",
                                                                     value: 0.5,
                                                                 },
@@ -694,8 +694,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "10.25",
                                                                     value: 10.25,
                                                                 },
@@ -722,8 +722,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "0.001",
                                                                     value: 0.001,
                                                                 },
@@ -750,8 +750,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "999.999999999999",
                                                                     value: 999.999999999999,
                                                                 },
@@ -778,8 +778,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "0.12345678901234",
                                                                     value: 0.12345678901234,
                                                                 },
@@ -806,8 +806,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "2.71828182845904",
                                                                     value: 2.71828182845904,
                                                                 },
@@ -834,8 +834,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "1.11111111111111",
                                                                     value: 1.11111111111111,
                                                                 },
@@ -862,8 +862,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "0.00000000000001",
                                                                     value: 1e-14,
                                                                 },
@@ -890,8 +890,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "12345.6789012345",
                                                                     value: 12345.6789012345,
                                                                 },
@@ -918,8 +918,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "NaN",
                                                                     value: NaN,
                                                                 },
@@ -946,8 +946,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: ".5",
                                                                     value: 0.5,
                                                                 },
@@ -974,8 +974,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "-.5",
                                                                     value: -0.5,
                                                                 },
@@ -1002,8 +1002,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "+.5",
                                                                     value: 0.5,
                                                                 },
@@ -1032,8 +1032,8 @@ Program {
                                                         initialiser: Some(
                                                             UnOp {
                                                                 op: RealNeg,
-                                                                operand: RealLiteral(
-                                                                    RealLiteral {
+                                                                operand: Literal(
+                                                                    Real {
                                                                         repr: "NaN",
                                                                         value: NaN,
                                                                     },
@@ -1061,8 +1061,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "Inf",
                                                                     value: inf,
                                                                 },
@@ -1091,8 +1091,8 @@ Program {
                                                         initialiser: Some(
                                                             UnOp {
                                                                 op: RealNeg,
-                                                                operand: RealLiteral(
-                                                                    RealLiteral {
+                                                                operand: Literal(
+                                                                    Real {
                                                                         repr: "Inf",
                                                                         value: inf,
                                                                     },
@@ -1127,8 +1127,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "0.0",
                                     value: 0.0,
                                 },
@@ -1146,8 +1146,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "3.14",
                                     value: 3.14,
                                 },
@@ -1165,8 +1165,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "1.5",
                                     value: 1.5,
                                 },
@@ -1184,8 +1184,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "0.5",
                                     value: 0.5,
                                 },
@@ -1203,8 +1203,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "10.25",
                                     value: 10.25,
                                 },
@@ -1222,8 +1222,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "0.001",
                                     value: 0.001,
                                 },
@@ -1241,8 +1241,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "999.999999999999",
                                     value: 999.999999999999,
                                 },
@@ -1260,8 +1260,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "0.12345678901234",
                                     value: 0.12345678901234,
                                 },
@@ -1279,8 +1279,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "2.71828182845904",
                                     value: 2.71828182845904,
                                 },
@@ -1298,8 +1298,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "1.11111111111111",
                                     value: 1.11111111111111,
                                 },
@@ -1317,8 +1317,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "0.00000000000001",
                                     value: 1e-14,
                                 },
@@ -1336,8 +1336,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "12345.6789012345",
                                     value: 12345.6789012345,
                                 },
@@ -1355,8 +1355,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "NaN",
                                     value: NaN,
                                 },
@@ -1374,8 +1374,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: ".5",
                                     value: 0.5,
                                 },
@@ -1393,8 +1393,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "-.5",
                                     value: -0.5,
                                 },
@@ -1412,8 +1412,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "+.5",
                                     value: 0.5,
                                 },
@@ -1433,8 +1433,8 @@ Program {
                         initialiser: Some(
                             UnOp {
                                 op: RealNeg,
-                                operand: RealLiteral(
-                                    RealLiteral {
+                                operand: Literal(
+                                    Real {
                                         repr: "NaN",
                                         value: NaN,
                                     },
@@ -1453,8 +1453,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "Inf",
                                     value: inf,
                                 },
@@ -1474,8 +1474,8 @@ Program {
                         initialiser: Some(
                             UnOp {
                                 op: RealNeg,
-                                operand: RealLiteral(
-                                    RealLiteral {
+                                operand: Literal(
+                                    Real {
                                         repr: "Inf",
                                         value: inf,
                                     },

--- a/tests/ast/pass/records.txt
+++ b/tests/ast/pass/records.txt
@@ -348,8 +348,8 @@ Program {
                                             ),
                                         },
                                         rhs: IntToReal(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -382,8 +382,8 @@ Program {
                                             ),
                                         },
                                         rhs: IntToReal(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -422,14 +422,14 @@ Program {
                                                         Call {
                                                             callee: point_of(3),
                                                             args: [
-                                                                RealLiteral(
-                                                                    RealLiteral {
+                                                                Literal(
+                                                                    Real {
                                                                         repr: "0.0",
                                                                         value: 0.0,
                                                                     },
                                                                 ),
-                                                                RealLiteral(
-                                                                    RealLiteral {
+                                                                Literal(
+                                                                    Real {
                                                                         repr: "0.0",
                                                                         value: 0.0,
                                                                     },
@@ -456,14 +456,14 @@ Program {
                                                         Call {
                                                             callee: point_of(3),
                                                             args: [
-                                                                RealLiteral(
-                                                                    RealLiteral {
+                                                                Literal(
+                                                                    Real {
                                                                         repr: "3.0",
                                                                         value: 3.0,
                                                                     },
                                                                 ),
-                                                                RealLiteral(
-                                                                    RealLiteral {
+                                                                Literal(
+                                                                    Real {
                                                                         repr: "4.0",
                                                                         value: 4.0,
                                                                     },
@@ -966,8 +966,8 @@ Program {
                                                 ),
                                             },
                                             rhs: IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -1000,8 +1000,8 @@ Program {
                                                 ),
                                             },
                                             rhs: IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -1040,14 +1040,14 @@ Program {
                                                             Call {
                                                                 callee: point_of(3),
                                                                 args: [
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "0.0",
                                                                             value: 0.0,
                                                                         },
                                                                     ),
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "0.0",
                                                                             value: 0.0,
                                                                         },
@@ -1074,14 +1074,14 @@ Program {
                                                             Call {
                                                                 callee: point_of(3),
                                                                 args: [
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "3.0",
                                                                             value: 3.0,
                                                                         },
                                                                     ),
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "4.0",
                                                                             value: 4.0,
                                                                         },
@@ -1164,14 +1164,14 @@ Program {
                             Call {
                                 callee: point_of(3),
                                 args: [
-                                    RealLiteral(
-                                        RealLiteral {
+                                    Literal(
+                                        Real {
                                             repr: "0.0",
                                             value: 0.0,
                                         },
                                     ),
-                                    RealLiteral(
-                                        RealLiteral {
+                                    Literal(
+                                        Real {
                                             repr: "0.0",
                                             value: 0.0,
                                         },
@@ -1196,14 +1196,14 @@ Program {
                             Call {
                                 callee: point_of(3),
                                 args: [
-                                    RealLiteral(
-                                        RealLiteral {
+                                    Literal(
+                                        Real {
                                             repr: "3.0",
                                             value: 3.0,
                                         },
                                     ),
-                                    RealLiteral(
-                                        RealLiteral {
+                                    Literal(
+                                        Real {
                                             repr: "4.0",
                                             value: 4.0,
                                         },

--- a/tests/ast/pass/recursive_function.txt
+++ b/tests/ast/pass/recursive_function.txt
@@ -39,8 +39,8 @@ Program {
                                                     n(1),
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -49,8 +49,8 @@ Program {
                                         on_true: Block {
                                             stmts: [
                                                 Return {
-                                                    value: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    value: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -79,8 +79,8 @@ Program {
                                                                                 n(1),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
@@ -100,8 +100,8 @@ Program {
                                                                                 n(1),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "2",
                                                                                 value: 2,
                                                                             },
@@ -141,8 +141,8 @@ Program {
                                         value: Call {
                                             callee: fibonacci(0),
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "10",
                                                         value: 10,
                                                     },
@@ -200,8 +200,8 @@ Program {
                                                         n(1),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -210,8 +210,8 @@ Program {
                                             on_true: Block {
                                                 stmts: [
                                                     Return {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -240,8 +240,8 @@ Program {
                                                                                     n(1),
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -261,8 +261,8 @@ Program {
                                                                                     n(1),
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "2",
                                                                                     value: 2,
                                                                                 },
@@ -314,8 +314,8 @@ Program {
                                             value: Call {
                                                 callee: fibonacci(0),
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "10",
                                                             value: 10,
                                                         },

--- a/tests/ast/pass/recursive_types.txt
+++ b/tests/ast/pass/recursive_types.txt
@@ -228,8 +228,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -271,8 +271,8 @@ Program {
                                                                 result(9),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -473,8 +473,8 @@ Program {
                                                         Call {
                                                             callee: singleton(3),
                                                             args: [
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -766,8 +766,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -809,8 +809,8 @@ Program {
                                                                     result(9),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -869,8 +869,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -1077,8 +1077,8 @@ Program {
                                                             Call {
                                                                 callee: singleton(3),
                                                                 args: [
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
@@ -1124,8 +1124,8 @@ Program {
                             Call {
                                 callee: singleton(3),
                                 args: [
-                                    IntegerLiteral(
-                                        IntegerLiteral {
+                                    Literal(
+                                        Integer {
                                             repr: "1",
                                             value: 1,
                                         },

--- a/tests/ast/pass/references.txt
+++ b/tests/ast/pass/references.txt
@@ -65,8 +65,8 @@ Program {
                                     lhs: Identifier(
                                         t(1),
                                     ),
-                                    index: IntegerLiteral(
-                                        IntegerLiteral {
+                                    index: Literal(
+                                        Integer {
                                             repr: "1",
                                             value: 1,
                                         },
@@ -129,8 +129,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(4),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -393,8 +393,8 @@ Program {
                                                             elements: Alias(
                                                                 object(0),
                                                             ),
-                                                            length: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            length: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -413,8 +413,8 @@ Program {
                                             lhs: Identifier(
                                                 t(8),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -431,8 +431,8 @@ Program {
                                             lhs: Identifier(
                                                 t(8),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -456,8 +456,8 @@ Program {
                                                         lhs: Identifier(
                                                             t(8),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -496,8 +496,8 @@ Program {
                                                         lhs: Identifier(
                                                             t(8),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -846,15 +846,15 @@ Program {
                                             lhs: Identifier(
                                                 a(12),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "10",
                                                 value: 10,
                                             },
@@ -865,15 +865,15 @@ Program {
                                             lhs: Identifier(
                                                 a(12),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "20",
                                                 value: 20,
                                             },
@@ -884,15 +884,15 @@ Program {
                                             lhs: Identifier(
                                                 a(12),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "30",
                                                 value: 30,
                                             },
@@ -968,8 +968,8 @@ Program {
                                             lhs: Identifier(
                                                 b(13),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -980,8 +980,8 @@ Program {
                                                 lhs: Identifier(
                                                     a(12),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -994,8 +994,8 @@ Program {
                                             lhs: Identifier(
                                                 b(13),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -1006,8 +1006,8 @@ Program {
                                                 lhs: Identifier(
                                                     a(12),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -1020,8 +1020,8 @@ Program {
                                             lhs: Identifier(
                                                 b(13),
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -1032,8 +1032,8 @@ Program {
                                                 lhs: Identifier(
                                                     a(12),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -1089,8 +1089,8 @@ Program {
                                                         lhs: Identifier(
                                                             a(12),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -1102,8 +1102,8 @@ Program {
                                                         lhs: Identifier(
                                                             b(13),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -1137,8 +1137,8 @@ Program {
                                                         lhs: Identifier(
                                                             a(12),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -1150,8 +1150,8 @@ Program {
                                                         lhs: Identifier(
                                                             b(13),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -1185,8 +1185,8 @@ Program {
                                                         lhs: Identifier(
                                                             a(12),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -1198,8 +1198,8 @@ Program {
                                                         lhs: Identifier(
                                                             b(13),
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -1381,8 +1381,8 @@ Program {
                                         lhs: Identifier(
                                             t(1),
                                         ),
-                                        index: IntegerLiteral(
-                                            IntegerLiteral {
+                                        index: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -1445,8 +1445,8 @@ Program {
                                                     lhs: Identifier(
                                                         t(4),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -1728,8 +1728,8 @@ Program {
                                                                 elements: Alias(
                                                                     object(0),
                                                                 ),
-                                                                length: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                length: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
@@ -1748,8 +1748,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(8),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -1766,8 +1766,8 @@ Program {
                                                 lhs: Identifier(
                                                     t(8),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -1791,8 +1791,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(8),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -1831,8 +1831,8 @@ Program {
                                                             lhs: Identifier(
                                                                 t(8),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -1995,8 +1995,8 @@ Program {
                                 elements: Alias(
                                     object(0),
                                 ),
-                                length: IntegerLiteral(
-                                    IntegerLiteral {
+                                length: Literal(
+                                    Integer {
                                         repr: "2",
                                         value: 2,
                                     },
@@ -2266,15 +2266,15 @@ Program {
                                                 lhs: Identifier(
                                                     a(12),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "10",
                                                     value: 10,
                                                 },
@@ -2285,15 +2285,15 @@ Program {
                                                 lhs: Identifier(
                                                     a(12),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "20",
                                                     value: 20,
                                                 },
@@ -2304,15 +2304,15 @@ Program {
                                                 lhs: Identifier(
                                                     a(12),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "30",
                                                     value: 30,
                                                 },
@@ -2388,8 +2388,8 @@ Program {
                                                 lhs: Identifier(
                                                     b(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -2400,8 +2400,8 @@ Program {
                                                     lhs: Identifier(
                                                         a(12),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -2414,8 +2414,8 @@ Program {
                                                 lhs: Identifier(
                                                     b(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -2426,8 +2426,8 @@ Program {
                                                     lhs: Identifier(
                                                         a(12),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -2440,8 +2440,8 @@ Program {
                                                 lhs: Identifier(
                                                     b(13),
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -2452,8 +2452,8 @@ Program {
                                                     lhs: Identifier(
                                                         a(12),
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -2509,8 +2509,8 @@ Program {
                                                             lhs: Identifier(
                                                                 a(12),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -2522,8 +2522,8 @@ Program {
                                                             lhs: Identifier(
                                                                 b(13),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -2557,8 +2557,8 @@ Program {
                                                             lhs: Identifier(
                                                                 a(12),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -2570,8 +2570,8 @@ Program {
                                                             lhs: Identifier(
                                                                 b(13),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -2605,8 +2605,8 @@ Program {
                                                             lhs: Identifier(
                                                                 a(12),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -2618,8 +2618,8 @@ Program {
                                                             lhs: Identifier(
                                                                 b(13),
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },

--- a/tests/ast/pass/shadow.txt
+++ b/tests/ast/pass/shadow.txt
@@ -6,8 +6,8 @@ Program {
                 VarDecl {
                     t: Int,
                     initialiser: Some(
-                        IntegerLiteral(
-                            IntegerLiteral {
+                        Literal(
+                            Integer {
                                 repr: "0",
                                 value: 0,
                             },
@@ -46,8 +46,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -68,8 +68,10 @@ Program {
                                         ),
                                     },
                                     If {
-                                        condition: BoolLiteral(
-                                            True,
+                                        condition: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                         on_true: Block {
                                             stmts: [
@@ -80,8 +82,10 @@ Program {
                                                             VarDecl {
                                                                 t: Bool,
                                                                 initialiser: Some(
-                                                                    BoolLiteral(
-                                                                        True,
+                                                                    Literal(
+                                                                        Bool {
+                                                                            value: true,
+                                                                        },
                                                                     ),
                                                                 ),
                                                                 relative_location: Local(
@@ -120,8 +124,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -160,8 +164,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -182,8 +186,10 @@ Program {
                                             ),
                                         },
                                         If {
-                                            condition: BoolLiteral(
-                                                True,
+                                            condition: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                             on_true: Block {
                                                 stmts: [
@@ -194,8 +200,10 @@ Program {
                                                                 VarDecl {
                                                                     t: Bool,
                                                                     initialiser: Some(
-                                                                        BoolLiteral(
-                                                                            True,
+                                                                        Literal(
+                                                                            Bool {
+                                                                                value: true,
+                                                                            },
                                                                         ),
                                                                     ),
                                                                     relative_location: Local(
@@ -231,8 +239,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "1",
                                     value: 1,
                                 },
@@ -250,8 +258,10 @@ Program {
                     VarDecl {
                         t: Bool,
                         initialiser: Some(
-                            BoolLiteral(
-                                True,
+                            Literal(
+                                Bool {
+                                    value: true,
+                                },
                             ),
                         ),
                         relative_location: Local(

--- a/tests/ast/pass/type_aliases.txt
+++ b/tests/ast/pass/type_aliases.txt
@@ -64,8 +64,8 @@ Program {
                                         ),
                                         target: Real,
                                     },
-                                    rhs: RealLiteral(
-                                        RealLiteral {
+                                    rhs: Literal(
+                                        Real {
                                             repr: "1.60934",
                                             value: 1.60934,
                                         },
@@ -103,8 +103,8 @@ Program {
                                                     ),
                                                     initialiser: Some(
                                                         Cast {
-                                                            operand: RealLiteral(
-                                                                RealLiteral {
+                                                            operand: Literal(
+                                                                Real {
                                                                     repr: "10.0",
                                                                     value: 10.0,
                                                                 },
@@ -244,8 +244,8 @@ Program {
                                             ),
                                             target: Real,
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "1.60934",
                                                 value: 1.60934,
                                             },
@@ -283,8 +283,8 @@ Program {
                                                         ),
                                                         initialiser: Some(
                                                             Cast {
-                                                                operand: RealLiteral(
-                                                                    RealLiteral {
+                                                                operand: Literal(
+                                                                    Real {
                                                                         repr: "10.0",
                                                                         value: 10.0,
                                                                     },
@@ -352,8 +352,8 @@ Program {
                         ),
                         initialiser: Some(
                             Cast {
-                                operand: RealLiteral(
-                                    RealLiteral {
+                                operand: Literal(
+                                    Real {
                                         repr: "10.0",
                                         value: 10.0,
                                     },

--- a/tests/ast/pass/type_conversions.txt
+++ b/tests/ast/pass/type_conversions.txt
@@ -59,8 +59,8 @@ Program {
                                         lhs: Identifier(
                                             i(1),
                                         ),
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "5",
                                                 value: 5,
                                             },
@@ -71,8 +71,8 @@ Program {
                                             i(1),
                                         ),
                                         rhs: RealToInt(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "3.7",
                                                     value: 3.7,
                                                 },
@@ -84,8 +84,10 @@ Program {
                                             i(1),
                                         ),
                                         rhs: BoolToInt(
-                                            BoolLiteral(
-                                                True,
+                                            Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                         ),
                                     },
@@ -94,8 +96,10 @@ Program {
                                             i(1),
                                         ),
                                         rhs: BoolToInt(
-                                            BoolLiteral(
-                                                False,
+                                            Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         ),
                                     },
@@ -103,8 +107,8 @@ Program {
                                         lhs: Identifier(
                                             r(2),
                                         ),
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "2.5",
                                                 value: 2.5,
                                             },
@@ -115,8 +119,8 @@ Program {
                                             r(2),
                                         ),
                                         rhs: IntToReal(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "10",
                                                     value: 10,
                                                 },
@@ -129,8 +133,10 @@ Program {
                                         ),
                                         rhs: IntToReal(
                                             BoolToInt(
-                                                BoolLiteral(
-                                                    True,
+                                                Literal(
+                                                    Bool {
+                                                        value: true,
+                                                    },
                                                 ),
                                             ),
                                         ),
@@ -141,8 +147,10 @@ Program {
                                         ),
                                         rhs: IntToReal(
                                             BoolToInt(
-                                                BoolLiteral(
-                                                    False,
+                                                Literal(
+                                                    Bool {
+                                                        value: false,
+                                                    },
                                                 ),
                                             ),
                                         ),
@@ -151,16 +159,20 @@ Program {
                                         lhs: Identifier(
                                             b(3),
                                         ),
-                                        rhs: BoolLiteral(
-                                            True,
+                                        rhs: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                     },
                                     Assignment {
                                         lhs: Identifier(
                                             b(3),
                                         ),
-                                        rhs: BoolLiteral(
-                                            False,
+                                        rhs: Literal(
+                                            Bool {
+                                                value: false,
+                                            },
                                         ),
                                     },
                                     Assignment {
@@ -168,8 +180,8 @@ Program {
                                             b(3),
                                         ),
                                         rhs: IntToBool(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -181,8 +193,8 @@ Program {
                                             b(3),
                                         ),
                                         rhs: IntToBool(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -280,8 +292,8 @@ Program {
                                             lhs: Identifier(
                                                 i(1),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },
@@ -292,8 +304,8 @@ Program {
                                                 i(1),
                                             ),
                                             rhs: RealToInt(
-                                                RealLiteral(
-                                                    RealLiteral {
+                                                Literal(
+                                                    Real {
                                                         repr: "3.7",
                                                         value: 3.7,
                                                     },
@@ -305,8 +317,10 @@ Program {
                                                 i(1),
                                             ),
                                             rhs: BoolToInt(
-                                                BoolLiteral(
-                                                    True,
+                                                Literal(
+                                                    Bool {
+                                                        value: true,
+                                                    },
                                                 ),
                                             ),
                                         },
@@ -315,8 +329,10 @@ Program {
                                                 i(1),
                                             ),
                                             rhs: BoolToInt(
-                                                BoolLiteral(
-                                                    False,
+                                                Literal(
+                                                    Bool {
+                                                        value: false,
+                                                    },
                                                 ),
                                             ),
                                         },
@@ -324,8 +340,8 @@ Program {
                                             lhs: Identifier(
                                                 r(2),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "2.5",
                                                     value: 2.5,
                                                 },
@@ -336,8 +352,8 @@ Program {
                                                 r(2),
                                             ),
                                             rhs: IntToReal(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "10",
                                                         value: 10,
                                                     },
@@ -350,8 +366,10 @@ Program {
                                             ),
                                             rhs: IntToReal(
                                                 BoolToInt(
-                                                    BoolLiteral(
-                                                        True,
+                                                    Literal(
+                                                        Bool {
+                                                            value: true,
+                                                        },
                                                     ),
                                                 ),
                                             ),
@@ -362,8 +380,10 @@ Program {
                                             ),
                                             rhs: IntToReal(
                                                 BoolToInt(
-                                                    BoolLiteral(
-                                                        False,
+                                                    Literal(
+                                                        Bool {
+                                                            value: false,
+                                                        },
                                                     ),
                                                 ),
                                             ),
@@ -372,16 +392,20 @@ Program {
                                             lhs: Identifier(
                                                 b(3),
                                             ),
-                                            rhs: BoolLiteral(
-                                                True,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                         },
                                         Assignment {
                                             lhs: Identifier(
                                                 b(3),
                                             ),
-                                            rhs: BoolLiteral(
-                                                False,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         },
                                         Assignment {
@@ -389,8 +413,8 @@ Program {
                                                 b(3),
                                             ),
                                             rhs: IntToBool(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -402,8 +426,8 @@ Program {
                                                 b(3),
                                             ),
                                             rhs: IntToBool(
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },

--- a/tests/ast/pass/variable_declarations.txt
+++ b/tests/ast/pass/variable_declarations.txt
@@ -6,8 +6,8 @@ Program {
                 VarDecl {
                     t: Int,
                     initialiser: Some(
-                        IntegerLiteral(
-                            IntegerLiteral {
+                        Literal(
+                            Integer {
                                 repr: "0",
                                 value: 0,
                             },
@@ -25,8 +25,8 @@ Program {
                 VarDecl {
                     t: Real,
                     initialiser: Some(
-                        RealLiteral(
-                            RealLiteral {
+                        Literal(
+                            Real {
                                 repr: "1.5",
                                 value: 1.5,
                             },
@@ -70,8 +70,10 @@ Program {
                                                 VarDecl {
                                                     t: Bool,
                                                     initialiser: Some(
-                                                        BoolLiteral(
-                                                            True,
+                                                        Literal(
+                                                            Bool {
+                                                                value: true,
+                                                            },
                                                         ),
                                                     ),
                                                     relative_location: Local(
@@ -85,8 +87,8 @@ Program {
                                         lhs: Identifier(
                                             c(2),
                                         ),
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -99,8 +101,8 @@ Program {
                                                 VarDecl {
                                                     t: Real,
                                                     initialiser: Some(
-                                                        RealLiteral(
-                                                            RealLiteral {
+                                                        Literal(
+                                                            Real {
                                                                 repr: "0.0",
                                                                 value: 0.0,
                                                             },
@@ -158,8 +160,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -177,8 +179,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "1.5",
                                     value: 1.5,
                                 },
@@ -222,8 +224,10 @@ Program {
                                                     VarDecl {
                                                         t: Bool,
                                                         initialiser: Some(
-                                                            BoolLiteral(
-                                                                True,
+                                                            Literal(
+                                                                Bool {
+                                                                    value: true,
+                                                                },
                                                             ),
                                                         ),
                                                         relative_location: Local(
@@ -237,8 +241,8 @@ Program {
                                             lhs: Identifier(
                                                 c(2),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -251,8 +255,8 @@ Program {
                                                     VarDecl {
                                                         t: Real,
                                                         initialiser: Some(
-                                                            RealLiteral(
-                                                                RealLiteral {
+                                                            Literal(
+                                                                Real {
                                                                     repr: "0.0",
                                                                     value: 0.0,
                                                                 },
@@ -307,8 +311,10 @@ Program {
                     VarDecl {
                         t: Bool,
                         initialiser: Some(
-                            BoolLiteral(
-                                True,
+                            Literal(
+                                Bool {
+                                    value: true,
+                                },
                             ),
                         ),
                         relative_location: Local(
@@ -323,8 +329,8 @@ Program {
                     VarDecl {
                         t: Real,
                         initialiser: Some(
-                            RealLiteral(
-                                RealLiteral {
+                            Literal(
+                                Real {
                                     repr: "0.0",
                                     value: 0.0,
                                 },

--- a/tests/ast/pass/while_loops.txt
+++ b/tests/ast/pass/while_loops.txt
@@ -36,8 +36,8 @@ Program {
                                                 VarDecl {
                                                     t: Int,
                                                     initialiser: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -60,8 +60,8 @@ Program {
                                                     n(1),
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -83,15 +83,15 @@ Program {
                                                                     n(1),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
                                                             ),
                                                         },
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -112,8 +112,8 @@ Program {
                                                                             n(1),
                                                                         ),
                                                                     ),
-                                                                    rhs: IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    rhs: Literal(
+                                                                        Integer {
                                                                             repr: "2",
                                                                             value: 2,
                                                                         },
@@ -138,8 +138,8 @@ Program {
                                                                             op: Int(
                                                                                 Mul,
                                                                             ),
-                                                                            lhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            lhs: Literal(
+                                                                                Integer {
                                                                                     repr: "3",
                                                                                     value: 3,
                                                                                 },
@@ -150,8 +150,8 @@ Program {
                                                                                 ),
                                                                             ),
                                                                         },
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "1",
                                                                                 value: 1,
                                                                             },
@@ -176,8 +176,8 @@ Program {
                                                                 steps(2),
                                                             ),
                                                         ),
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -220,8 +220,8 @@ Program {
                                         value: Call {
                                             callee: collatz(0),
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "7",
                                                         value: 7,
                                                     },
@@ -276,8 +276,8 @@ Program {
                                                     VarDecl {
                                                         t: Int,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -300,8 +300,8 @@ Program {
                                                         n(1),
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -323,15 +323,15 @@ Program {
                                                                         n(1),
                                                                     ),
                                                                 ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                rhs: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
                                                                 ),
                                                             },
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -352,8 +352,8 @@ Program {
                                                                                 n(1),
                                                                             ),
                                                                         ),
-                                                                        rhs: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        rhs: Literal(
+                                                                            Integer {
                                                                                 repr: "2",
                                                                                 value: 2,
                                                                             },
@@ -378,8 +378,8 @@ Program {
                                                                                 op: Int(
                                                                                     Mul,
                                                                                 ),
-                                                                                lhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                lhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "3",
                                                                                         value: 3,
                                                                                     },
@@ -390,8 +390,8 @@ Program {
                                                                                     ),
                                                                                 ),
                                                                             },
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -416,8 +416,8 @@ Program {
                                                                     steps(2),
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -461,8 +461,8 @@ Program {
                     VarDecl {
                         t: Int,
                         initialiser: Some(
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -491,8 +491,8 @@ Program {
                                             value: Call {
                                                 callee: collatz(0),
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "7",
                                                             value: 7,
                                                         },

--- a/tests/parser/pass/arithmetic_operations.txt
+++ b/tests/parser/pass/arithmetic_operations.txt
@@ -14,8 +14,8 @@ Program(
                                         name: r"a",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "7",
                                                     value: 7,
                                                 },
@@ -28,8 +28,8 @@ Program(
                                         name: r"b",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -42,8 +42,8 @@ Program(
                                         name: r"x",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "5.5",
                                                     value: 5.5,
                                                 },
@@ -56,8 +56,8 @@ Program(
                                         name: r"y",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "2.0",
                                                     value: 2.0,
                                                 },
@@ -154,14 +154,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Div,
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "-7",
                                                     value: -7,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -173,14 +173,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Mod,
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "-7",
                                                     value: -7,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -192,14 +192,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Div,
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "7",
                                                     value: 7,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "-3",
                                                     value: -3,
                                                 },
@@ -211,14 +211,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Mod,
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "7",
                                                     value: 7,
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "-3",
                                                     value: -3,
                                                 },

--- a/tests/parser/pass/array_slice_eq.txt
+++ b/tests/parser/pass/array_slice_eq.txt
@@ -58,8 +58,8 @@ Program(
                                                 ArrayDescription {
                                                     t: Int,
                                                     length: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },

--- a/tests/parser/pass/arrays_and_records.txt
+++ b/tests/parser/pass/arrays_and_records.txt
@@ -30,14 +30,14 @@ Program(
                         length: Some(
                             BinOp {
                                 op: Plus,
-                                lhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                lhs: Literal(
+                                    Integer {
                                         repr: "1",
                                         value: 1,
                                     },
                                 ),
-                                rhs: IntegerLiteral(
-                                    IntegerLiteral {
+                                rhs: Literal(
+                                    Integer {
                                         repr: "2",
                                         value: 2,
                                     },
@@ -53,8 +53,8 @@ Program(
                 name: r"EPS",
                 t: None,
                 initialiser: Some(
-                    RealLiteral(
-                        RealLiteral {
+                    Literal(
+                        Real {
                             repr: "0.0000001",
                             value: 1e-7,
                         },
@@ -281,8 +281,8 @@ Program(
                                                             lhs: Identifier(
                                                                 r"t",
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -294,8 +294,8 @@ Program(
                                                             lhs: Identifier(
                                                                 r"t",
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -312,8 +312,8 @@ Program(
                                                             lhs: Identifier(
                                                                 r"t",
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -325,8 +325,8 @@ Program(
                                                             lhs: Identifier(
                                                                 r"t",
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -344,8 +344,8 @@ Program(
                                                         lhs: Identifier(
                                                             r"t",
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -357,8 +357,8 @@ Program(
                                                         lhs: Identifier(
                                                             r"t",
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -387,8 +387,8 @@ Program(
                                                             lhs: Identifier(
                                                                 r"t",
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -400,8 +400,8 @@ Program(
                                                             lhs: Identifier(
                                                                 r"t",
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -418,8 +418,8 @@ Program(
                                                             lhs: Identifier(
                                                                 r"t",
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -431,8 +431,8 @@ Program(
                                                             lhs: Identifier(
                                                                 r"t",
                                                             ),
-                                                            index: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            index: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -450,8 +450,8 @@ Program(
                                                         lhs: Identifier(
                                                             r"t",
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -463,8 +463,8 @@ Program(
                                                         lhs: Identifier(
                                                             r"t",
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -494,8 +494,8 @@ Program(
                                                         lhs: Identifier(
                                                             r"t",
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -507,8 +507,8 @@ Program(
                                                         lhs: Identifier(
                                                             r"t",
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -525,8 +525,8 @@ Program(
                                                         lhs: Identifier(
                                                             r"t",
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -538,8 +538,8 @@ Program(
                                                         lhs: Identifier(
                                                             r"t",
                                                         ),
-                                                        index: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        index: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -557,8 +557,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"t",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -570,8 +570,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"t",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -626,8 +626,8 @@ Program(
                                             lhs: Identifier(
                                                 r"t",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -649,8 +649,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"t",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -658,8 +658,8 @@ Program(
                                             },
                                             member_name: r"x",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "0.0",
                                                 value: 0.0,
                                             },
@@ -673,8 +673,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"t",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -682,8 +682,8 @@ Program(
                                             },
                                             member_name: r"y",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "0.0",
                                                 value: 0.0,
                                             },
@@ -696,8 +696,8 @@ Program(
                                             lhs: Identifier(
                                                 r"t",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -719,8 +719,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"t",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -728,8 +728,8 @@ Program(
                                             },
                                             member_name: r"x",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "3.0",
                                                 value: 3.0,
                                             },
@@ -743,8 +743,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"t",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -752,8 +752,8 @@ Program(
                                             },
                                             member_name: r"y",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "0.0",
                                                 value: 0.0,
                                             },
@@ -766,8 +766,8 @@ Program(
                                             lhs: Identifier(
                                                 r"t",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -789,8 +789,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"t",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -798,8 +798,8 @@ Program(
                                             },
                                             member_name: r"x",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "0.0",
                                                 value: 0.0,
                                             },
@@ -813,8 +813,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"t",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -822,8 +822,8 @@ Program(
                                             },
                                             member_name: r"y",
                                         },
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "4.0",
                                                 value: 4.0,
                                             },

--- a/tests/parser/pass/assert.txt
+++ b/tests/parser/pass/assert.txt
@@ -15,8 +15,10 @@ Program(
                                             line: 2,
                                             column: 1,
                                         },
-                                        value: BoolLiteral(
-                                            True,
+                                        value: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                     },
                                 ),
@@ -26,8 +28,8 @@ Program(
                                             line: 3,
                                             column: 1,
                                         },
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -44,21 +46,21 @@ Program(
                                             op: Eq,
                                             lhs: BinOp {
                                                 op: Plus,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },

--- a/tests/parser/pass/comparison_operators.txt
+++ b/tests/parser/pass/comparison_operators.txt
@@ -14,8 +14,8 @@ Program(
                                         name: r"a",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },
@@ -28,8 +28,8 @@ Program(
                                         name: r"b",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -42,8 +42,8 @@ Program(
                                         name: r"x",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "2.5",
                                                     value: 2.5,
                                                 },
@@ -56,8 +56,8 @@ Program(
                                         name: r"y",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "5.0",
                                                     value: 5.0,
                                                 },
@@ -273,11 +273,15 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Eq,
-                                            lhs: BoolLiteral(
-                                                True,
+                                            lhs: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
-                                            rhs: BoolLiteral(
-                                                False,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         },
                                     },
@@ -286,11 +290,15 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Ne,
-                                            lhs: BoolLiteral(
-                                                True,
+                                            lhs: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
-                                            rhs: BoolLiteral(
-                                                False,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         },
                                     },

--- a/tests/parser/pass/complex_expressions.txt
+++ b/tests/parser/pass/complex_expressions.txt
@@ -25,8 +25,8 @@ Program(
                                                     r"n",
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -54,8 +54,8 @@ Program(
                                         name: r"a",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -68,8 +68,8 @@ Program(
                                         name: r"b",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -82,8 +82,8 @@ Program(
                                         name: r"c",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
@@ -95,22 +95,22 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Plus,
-                                            lhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            lhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
                                             ),
                                             rhs: BinOp {
                                                 op: Mul,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
@@ -125,21 +125,21 @@ Program(
                                             op: Mul,
                                             lhs: BinOp {
                                                 op: Plus,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
@@ -153,14 +153,14 @@ Program(
                                             op: Lt,
                                             lhs: BinOp {
                                                 op: Plus,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -168,14 +168,14 @@ Program(
                                             },
                                             rhs: BinOp {
                                                 op: Plus,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
@@ -190,14 +190,14 @@ Program(
                                             op: And,
                                             lhs: BinOp {
                                                 op: Lt,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -205,14 +205,14 @@ Program(
                                             },
                                             rhs: BinOp {
                                                 op: Lt,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
@@ -286,8 +286,8 @@ Program(
                                             lhs: Call {
                                                 callee: r"add_one",
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },
@@ -297,8 +297,8 @@ Program(
                                             rhs: Call {
                                                 callee: r"add_one",
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -316,8 +316,8 @@ Program(
                                                 Call {
                                                     callee: r"add_one",
                                                     args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },

--- a/tests/parser/pass/conditionals.txt
+++ b/tests/parser/pass/conditionals.txt
@@ -25,8 +25,8 @@ Program(
                                                     r"value",
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -41,8 +41,8 @@ Program(
                                                         ),
                                                         rhs: BinOp {
                                                             op: Minus,
-                                                            lhs: RealLiteral(
-                                                                RealLiteral {
+                                                            lhs: Literal(
+                                                                Real {
                                                                     repr: "0.0",
                                                                     value: 0.0,
                                                                 },
@@ -89,8 +89,8 @@ Program(
                                         name: r"a",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
@@ -109,15 +109,15 @@ Program(
                                                         r"a",
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -130,8 +130,8 @@ Program(
                                                         name: r"dummy",
                                                         t: None,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -141,8 +141,8 @@ Program(
                                                 ),
                                                 Stmt(
                                                     Print {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -165,8 +165,8 @@ Program(
                                                 [
                                                     Stmt(
                                                         Print {
-                                                            value: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            value: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },

--- a/tests/parser/pass/constant.txt
+++ b/tests/parser/pass/constant.txt
@@ -4,8 +4,8 @@ Program(
             ConstDecl {
                 name: r"LENGTH",
                 t: None,
-                initialiser: IntegerLiteral(
-                    IntegerLiteral {
+                initialiser: Literal(
+                    Integer {
                         repr: "100",
                         value: 100,
                     },
@@ -25,8 +25,8 @@ Program(
                             r"LENGTH",
                         ),
                     ),
-                    rhs: IntegerLiteral(
-                        IntegerLiteral {
+                    rhs: Literal(
+                        Integer {
                             repr: "2",
                             value: 2,
                         },
@@ -93,8 +93,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"arr",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -141,8 +141,8 @@ Program(
                                                             r"LENGTH",
                                                         ),
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -231,8 +231,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"t",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -245,8 +245,8 @@ Program(
                                     ConstDecl {
                                         name: r"LENGTH",
                                         t: None,
-                                        initialiser: IntegerLiteral(
-                                            IntegerLiteral {
+                                        initialiser: Literal(
+                                            Integer {
                                                 repr: "300",
                                                 value: 300,
                                             },
@@ -283,8 +283,8 @@ Program(
                                                     ConstDecl {
                                                         name: r"LENGTH",
                                                         t: None,
-                                                        initialiser: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        initialiser: Literal(
+                                                            Integer {
                                                                 repr: "400",
                                                                 value: 400,
                                                             },

--- a/tests/parser/pass/deep_conditionals.txt
+++ b/tests/parser/pass/deep_conditionals.txt
@@ -14,8 +14,8 @@ Program(
                                         name: r"a",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -28,8 +28,8 @@ Program(
                                         name: r"b",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -42,8 +42,8 @@ Program(
                                         name: r"c",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -56,8 +56,8 @@ Program(
                                         name: r"d",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -70,8 +70,8 @@ Program(
                                         name: r"e",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -84,8 +84,8 @@ Program(
                                         name: r"f",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -98,8 +98,8 @@ Program(
                                         name: r"g",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -116,8 +116,8 @@ Program(
                                                     r"a",
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -127,8 +127,8 @@ Program(
                                             [
                                                 Stmt(
                                                     Print {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -144,8 +144,8 @@ Program(
                                                                     r"b",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -155,8 +155,8 @@ Program(
                                                             [
                                                                 Stmt(
                                                                     Print {
-                                                                        value: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        value: Literal(
+                                                                            Integer {
                                                                                 repr: "2",
                                                                                 value: 2,
                                                                             },
@@ -172,8 +172,8 @@ Program(
                                                                                     r"c",
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -183,8 +183,8 @@ Program(
                                                                             [
                                                                                 Stmt(
                                                                                     Print {
-                                                                                        value: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        value: Literal(
+                                                                                            Integer {
                                                                                                 repr: "3",
                                                                                                 value: 3,
                                                                                             },
@@ -205,8 +205,8 @@ Program(
                                                                                                         r"d",
                                                                                                     ),
                                                                                                 ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                rhs: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "1",
                                                                                                         value: 1,
                                                                                                     },
@@ -216,8 +216,8 @@ Program(
                                                                                                 [
                                                                                                     Stmt(
                                                                                                         Print {
-                                                                                                            value: IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            value: Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "0",
                                                                                                                     value: 0,
                                                                                                                 },
@@ -248,8 +248,8 @@ Program(
                                                                                         r"e",
                                                                                     ),
                                                                                 ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                rhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "1",
                                                                                         value: 1,
                                                                                     },
@@ -259,8 +259,8 @@ Program(
                                                                                 [
                                                                                     Stmt(
                                                                                         Print {
-                                                                                            value: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            value: Literal(
+                                                                                                Integer {
                                                                                                     repr: "0",
                                                                                                     value: 0,
                                                                                                 },
@@ -281,8 +281,8 @@ Program(
                                                                                                             r"f",
                                                                                                         ),
                                                                                                     ),
-                                                                                                    rhs: IntegerLiteral(
-                                                                                                        IntegerLiteral {
+                                                                                                    rhs: Literal(
+                                                                                                        Integer {
                                                                                                             repr: "1",
                                                                                                             value: 1,
                                                                                                         },
@@ -292,8 +292,8 @@ Program(
                                                                                                     [
                                                                                                         Stmt(
                                                                                                             Print {
-                                                                                                                value: IntegerLiteral(
-                                                                                                                    IntegerLiteral {
+                                                                                                                value: Literal(
+                                                                                                                    Integer {
                                                                                                                         repr: "0",
                                                                                                                         value: 0,
                                                                                                                     },
@@ -324,8 +324,8 @@ Program(
                                                                     r"d",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -335,8 +335,8 @@ Program(
                                                             [
                                                                 Stmt(
                                                                     Print {
-                                                                        value: IntegerLiteral(
-                                                                            IntegerLiteral {
+                                                                        value: Literal(
+                                                                            Integer {
                                                                                 repr: "4",
                                                                                 value: 4,
                                                                             },
@@ -352,8 +352,8 @@ Program(
                                                                                     r"e",
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -363,8 +363,8 @@ Program(
                                                                             [
                                                                                 Stmt(
                                                                                     Print {
-                                                                                        value: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        value: Literal(
+                                                                                            Integer {
                                                                                                 repr: "5",
                                                                                                 value: 5,
                                                                                             },
@@ -380,8 +380,8 @@ Program(
                                                                                                     r"f",
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "1",
                                                                                                     value: 1,
                                                                                                 },
@@ -391,8 +391,8 @@ Program(
                                                                                             [
                                                                                                 Stmt(
                                                                                                     Print {
-                                                                                                        value: IntegerLiteral(
-                                                                                                            IntegerLiteral {
+                                                                                                        value: Literal(
+                                                                                                            Integer {
                                                                                                                 repr: "6",
                                                                                                                 value: 6,
                                                                                                             },
@@ -408,8 +408,8 @@ Program(
                                                                                                                     r"g",
                                                                                                                 ),
                                                                                                             ),
-                                                                                                            rhs: IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            rhs: Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "1",
                                                                                                                     value: 1,
                                                                                                                 },
@@ -419,8 +419,8 @@ Program(
                                                                                                             [
                                                                                                                 Stmt(
                                                                                                                     Print {
-                                                                                                                        value: IntegerLiteral(
-                                                                                                                            IntegerLiteral {
+                                                                                                                        value: Literal(
+                                                                                                                            Integer {
                                                                                                                                 repr: "7",
                                                                                                                                 value: 7,
                                                                                                                             },
@@ -434,8 +434,8 @@ Program(
                                                                                                                 [
                                                                                                                     Stmt(
                                                                                                                         Print {
-                                                                                                                            value: IntegerLiteral(
-                                                                                                                                IntegerLiteral {
+                                                                                                                            value: Literal(
+                                                                                                                                Integer {
                                                                                                                                     repr: "0",
                                                                                                                                     value: 0,
                                                                                                                                 },
@@ -454,8 +454,8 @@ Program(
                                                                                                 [
                                                                                                     Stmt(
                                                                                                         Print {
-                                                                                                            value: IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            value: Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "0",
                                                                                                                     value: 0,
                                                                                                                 },
@@ -474,8 +474,8 @@ Program(
                                                                                 [
                                                                                     Stmt(
                                                                                         Print {
-                                                                                            value: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            value: Literal(
+                                                                                                Integer {
                                                                                                     repr: "0",
                                                                                                     value: 0,
                                                                                                 },
@@ -501,8 +501,8 @@ Program(
                                                                                         r"b",
                                                                                     ),
                                                                                 ),
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                rhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "1",
                                                                                         value: 1,
                                                                                     },
@@ -512,8 +512,8 @@ Program(
                                                                                 [
                                                                                     Stmt(
                                                                                         Print {
-                                                                                            value: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            value: Literal(
+                                                                                                Integer {
                                                                                                     repr: "0",
                                                                                                     value: 0,
                                                                                                 },
@@ -534,8 +534,8 @@ Program(
                                                                                                             r"c",
                                                                                                         ),
                                                                                                     ),
-                                                                                                    rhs: IntegerLiteral(
-                                                                                                        IntegerLiteral {
+                                                                                                    rhs: Literal(
+                                                                                                        Integer {
                                                                                                             repr: "1",
                                                                                                             value: 1,
                                                                                                         },
@@ -545,8 +545,8 @@ Program(
                                                                                                     [
                                                                                                         Stmt(
                                                                                                             Print {
-                                                                                                                value: IntegerLiteral(
-                                                                                                                    IntegerLiteral {
+                                                                                                                value: Literal(
+                                                                                                                    Integer {
                                                                                                                         repr: "0",
                                                                                                                         value: 0,
                                                                                                                     },
@@ -582,8 +582,8 @@ Program(
                                                                         r"e",
                                                                     ),
                                                                 ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                rhs: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -593,8 +593,8 @@ Program(
                                                                 [
                                                                     Stmt(
                                                                         Print {
-                                                                            value: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            value: Literal(
+                                                                                Integer {
                                                                                     repr: "0",
                                                                                     value: 0,
                                                                                 },
@@ -615,8 +615,8 @@ Program(
                                                                                             r"g",
                                                                                         ),
                                                                                     ),
-                                                                                    rhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    rhs: Literal(
+                                                                                        Integer {
                                                                                             repr: "1",
                                                                                             value: 1,
                                                                                         },
@@ -626,8 +626,8 @@ Program(
                                                                                     [
                                                                                         Stmt(
                                                                                             Print {
-                                                                                                value: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                value: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "0",
                                                                                                         value: 0,
                                                                                                     },

--- a/tests/parser/pass/default_init.txt
+++ b/tests/parser/pass/default_init.txt
@@ -68,8 +68,8 @@ Program(
                                                     r"i",
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -99,8 +99,8 @@ Program(
                                                     r"r",
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -130,8 +130,10 @@ Program(
                                                     r"b",
                                                 ),
                                             ),
-                                            rhs: BoolLiteral(
-                                                False,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         },
                                     },
@@ -144,8 +146,8 @@ Program(
                                                 ArrayDescription {
                                                     t: Int,
                                                     length: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -230,8 +232,8 @@ Program(
                                                 ),
                                             ),
                                             rhs: Cast {
-                                                operand: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                operand: Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },

--- a/tests/parser/pass/for_loops.txt
+++ b/tests/parser/pass/for_loops.txt
@@ -140,8 +140,8 @@ Program(
                                         name: r"result",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -173,8 +173,8 @@ Program(
                                                                     r"result",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -227,8 +227,8 @@ Program(
                                 Stmt(
                                     For {
                                         counter: r"i",
-                                        from: IntegerLiteral(
-                                            IntegerLiteral {
+                                        from: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -246,8 +246,8 @@ Program(
                                                 Stmt(
                                                     For {
                                                         counter: r"j",
-                                                        from: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        from: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -278,8 +278,8 @@ Program(
                                                                                                 r"j",
                                                                                             ),
                                                                                         ),
-                                                                                        rhs: IntegerLiteral(
-                                                                                            IntegerLiteral {
+                                                                                        rhs: Literal(
+                                                                                            Integer {
                                                                                                 repr: "1",
                                                                                                 value: 1,
                                                                                             },
@@ -346,8 +346,8 @@ Program(
                                                                                                             r"j",
                                                                                                         ),
                                                                                                     ),
-                                                                                                    rhs: IntegerLiteral(
-                                                                                                        IntegerLiteral {
+                                                                                                    rhs: Literal(
+                                                                                                        Integer {
                                                                                                             repr: "1",
                                                                                                             value: 1,
                                                                                                         },
@@ -370,8 +370,8 @@ Program(
                                                                                                         r"j",
                                                                                                     ),
                                                                                                 ),
-                                                                                                rhs: IntegerLiteral(
-                                                                                                    IntegerLiteral {
+                                                                                                rhs: Literal(
+                                                                                                    Integer {
                                                                                                         repr: "1",
                                                                                                         value: 1,
                                                                                                     },
@@ -427,8 +427,8 @@ Program(
                                             ),
                                         ),
                                         to: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -473,8 +473,8 @@ Program(
                                 Stmt(
                                     For {
                                         counter: r"i",
-                                        from: IntegerLiteral(
-                                            IntegerLiteral {
+                                        from: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -525,8 +525,8 @@ Program(
                                                 ArrayDescription {
                                                     t: Int,
                                                     length: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "5",
                                                                 value: 5,
                                                             },
@@ -541,8 +541,8 @@ Program(
                                                     ArrayDescription {
                                                         t: Int,
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "5",
                                                                     value: 5,
                                                                 },
@@ -562,15 +562,15 @@ Program(
                                             lhs: Identifier(
                                                 r"arr",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "3",
                                                 value: 3,
                                             },
@@ -583,15 +583,15 @@ Program(
                                             lhs: Identifier(
                                                 r"arr",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "5",
                                                 value: 5,
                                             },
@@ -604,15 +604,15 @@ Program(
                                             lhs: Identifier(
                                                 r"arr",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -625,15 +625,15 @@ Program(
                                             lhs: Identifier(
                                                 r"arr",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "2",
                                                 value: 2,
                                             },
@@ -646,15 +646,15 @@ Program(
                                             lhs: Identifier(
                                                 r"arr",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "4",
                                                 value: 4,
                                             },
@@ -680,8 +680,8 @@ Program(
                                         Call {
                                             callee: r"count",
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -695,8 +695,8 @@ Program(
                                         Call {
                                             callee: r"countdown",
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },

--- a/tests/parser/pass/function_parameters.txt
+++ b/tests/parser/pass/function_parameters.txt
@@ -55,14 +55,14 @@ Program(
                                         Call {
                                             callee: r"a_plus_b",
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
                                                 ),
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },

--- a/tests/parser/pass/function_return.txt
+++ b/tests/parser/pass/function_return.txt
@@ -54,8 +54,8 @@ Program(
                                         value: Call {
                                             callee: r"echo",
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "42",
                                                         value: 42,
                                                     },

--- a/tests/parser/pass/identifiers.txt
+++ b/tests/parser/pass/identifiers.txt
@@ -14,8 +14,8 @@ Program(
                                         name: r"кошка",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -28,8 +28,8 @@ Program(
                                         name: r"ねこ",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -42,8 +42,8 @@ Program(
                                         name: r"π",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -56,8 +56,8 @@ Program(
                                         name: r"α",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -70,8 +70,8 @@ Program(
                                         name: r"值",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "4",
                                                     value: 4,
                                                 },
@@ -84,8 +84,8 @@ Program(
                                         name: r"变量",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },
@@ -98,8 +98,8 @@ Program(
                                         name: r"고양이",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "6",
                                                     value: 6,
                                                 },
@@ -112,8 +112,8 @@ Program(
                                         name: r"pequeño_pingüino",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "7",
                                                     value: 7,
                                                 },
@@ -126,8 +126,8 @@ Program(
                                         name: r"'no_strings",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "8",
                                                     value: 8,
                                                 },
@@ -140,8 +140,8 @@ Program(
                                         name: r"_",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "9",
                                                     value: 9,
                                                 },

--- a/tests/parser/pass/invalid_array_length.txt
+++ b/tests/parser/pass/invalid_array_length.txt
@@ -19,8 +19,8 @@ Program(
                                                     length: Some(
                                                         UnOp {
                                                             op: Minus,
-                                                            operand: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            operand: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },

--- a/tests/parser/pass/invalid_new_array_length.txt
+++ b/tests/parser/pass/invalid_new_array_length.txt
@@ -25,8 +25,8 @@ Program(
                                                 array_length: Some(
                                                     UnOp {
                                                         op: Minus,
-                                                        operand: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        operand: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },

--- a/tests/parser/pass/lazy_operators.txt
+++ b/tests/parser/pass/lazy_operators.txt
@@ -16,8 +16,10 @@ Program(
                                         name: r"result",
                                         t: None,
                                         initialiser: Some(
-                                            BoolLiteral(
-                                                False,
+                                            Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         ),
                                     },
@@ -62,8 +64,10 @@ Program(
                                         name: r"result",
                                         t: None,
                                         initialiser: Some(
-                                            BoolLiteral(
-                                                True,
+                                            Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                         ),
                                     },
@@ -103,8 +107,8 @@ Program(
                             [
                                 Stmt(
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -128,8 +132,8 @@ Program(
                                 ),
                                 Stmt(
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -153,8 +157,8 @@ Program(
                                 ),
                                 Stmt(
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "2",
                                                 value: 2,
                                             },
@@ -178,8 +182,8 @@ Program(
                                 ),
                                 Stmt(
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "3",
                                                 value: 3,
                                             },
@@ -203,8 +207,8 @@ Program(
                                 ),
                                 Stmt(
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "4",
                                                 value: 4,
                                             },
@@ -228,8 +232,8 @@ Program(
                                 ),
                                 Stmt(
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "5",
                                                 value: 5,
                                             },

--- a/tests/parser/pass/length.txt
+++ b/tests/parser/pass/length.txt
@@ -89,8 +89,8 @@ Program(
                                                     ArrayDescription {
                                                         t: Int,
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "5",
                                                                     value: 5,
                                                                 },
@@ -117,8 +117,8 @@ Program(
                                                     [
                                                         (
                                                             r"length",
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "10",
                                                                     value: 10,
                                                                 },

--- a/tests/parser/pass/local_type.txt
+++ b/tests/parser/pass/local_type.txt
@@ -44,8 +44,8 @@ Program(
                                                 [
                                                     (
                                                         r"x",
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -53,8 +53,8 @@ Program(
                                                     ),
                                                     (
                                                         r"y",
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },

--- a/tests/parser/pass/logical_operators.txt
+++ b/tests/parser/pass/logical_operators.txt
@@ -14,8 +14,10 @@ Program(
                                         name: r"a",
                                         t: None,
                                         initialiser: Some(
-                                            BoolLiteral(
-                                                True,
+                                            Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                         ),
                                     },
@@ -25,8 +27,10 @@ Program(
                                         name: r"b",
                                         t: None,
                                         initialiser: Some(
-                                            BoolLiteral(
-                                                False,
+                                            Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                         ),
                                     },
@@ -36,8 +40,8 @@ Program(
                                         name: r"x",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },
@@ -50,8 +54,8 @@ Program(
                                         name: r"y",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -85,8 +89,10 @@ Program(
                                                     r"a",
                                                 ),
                                             ),
-                                            rhs: BoolLiteral(
-                                                True,
+                                            rhs: Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                         },
                                     },
@@ -112,8 +118,10 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Or,
-                                            lhs: BoolLiteral(
-                                                False,
+                                            lhs: Literal(
+                                                Bool {
+                                                    value: false,
+                                                },
                                             ),
                                             rhs: LvalueToRvalue(
                                                 Identifier(

--- a/tests/parser/pass/nested_control.txt
+++ b/tests/parser/pass/nested_control.txt
@@ -14,8 +14,8 @@ Program(
                                         name: r"i",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -32,8 +32,8 @@ Program(
                                                     r"i",
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -46,8 +46,8 @@ Program(
                                                         name: r"j",
                                                         t: None,
                                                         initialiser: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -64,8 +64,8 @@ Program(
                                                                     r"j",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -78,8 +78,8 @@ Program(
                                                                         name: r"k",
                                                                         t: None,
                                                                         initialiser: Some(
-                                                                            IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            Literal(
+                                                                                Integer {
                                                                                     repr: "0",
                                                                                     value: 0,
                                                                                 },
@@ -96,8 +96,8 @@ Program(
                                                                                     r"k",
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "2",
                                                                                     value: 2,
                                                                                 },
@@ -110,8 +110,8 @@ Program(
                                                                                         name: r"w",
                                                                                         t: None,
                                                                                         initialiser: Some(
-                                                                                            IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            Literal(
+                                                                                                Integer {
                                                                                                     repr: "0",
                                                                                                     value: 0,
                                                                                                 },
@@ -128,8 +128,8 @@ Program(
                                                                                                     r"w",
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "2",
                                                                                                     value: 2,
                                                                                                 },
@@ -142,8 +142,8 @@ Program(
                                                                                                         name: r"v",
                                                                                                         t: None,
                                                                                                         initialiser: Some(
-                                                                                                            IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "0",
                                                                                                                     value: 0,
                                                                                                                 },
@@ -160,8 +160,8 @@ Program(
                                                                                                                     r"v",
                                                                                                                 ),
                                                                                                             ),
-                                                                                                            rhs: IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            rhs: Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "2",
                                                                                                                     value: 2,
                                                                                                                 },
@@ -226,8 +226,8 @@ Program(
                                                                                                                                     r"v",
                                                                                                                                 ),
                                                                                                                             ),
-                                                                                                                            rhs: IntegerLiteral(
-                                                                                                                                IntegerLiteral {
+                                                                                                                            rhs: Literal(
+                                                                                                                                Integer {
                                                                                                                                     repr: "1",
                                                                                                                                     value: 1,
                                                                                                                                 },
@@ -251,8 +251,8 @@ Program(
                                                                                                                     r"w",
                                                                                                                 ),
                                                                                                             ),
-                                                                                                            rhs: IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            rhs: Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "1",
                                                                                                                     value: 1,
                                                                                                                 },
@@ -276,8 +276,8 @@ Program(
                                                                                                     r"k",
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "1",
                                                                                                     value: 1,
                                                                                                 },
@@ -301,8 +301,8 @@ Program(
                                                                                     r"j",
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -326,8 +326,8 @@ Program(
                                                                     r"i",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },

--- a/tests/parser/pass/new_array.txt
+++ b/tests/parser/pass/new_array.txt
@@ -66,8 +66,8 @@ Program(
                                                     r"n",
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -84,8 +84,8 @@ Program(
                                                     r"n",
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -95,8 +95,8 @@ Program(
                                             [
                                                 Stmt(
                                                     Return {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -127,8 +127,8 @@ Program(
                                                                                     r"n",
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -176,8 +176,8 @@ Program(
                                                         Call {
                                                             callee: r"factorial",
                                                             args: [
-                                                                IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                Literal(
+                                                                    Integer {
                                                                         repr: "5",
                                                                         value: 5,
                                                                     },
@@ -204,8 +204,8 @@ Program(
                                                     ),
                                                     fields: None,
                                                     array_length: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },

--- a/tests/parser/pass/new_array_fixed.txt
+++ b/tests/parser/pass/new_array_fixed.txt
@@ -19,8 +19,8 @@ Program(
                                                     ArrayDescription {
                                                         t: Real,
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "5",
                                                                     value: 5,
                                                                 },
@@ -30,8 +30,8 @@ Program(
                                                 ),
                                                 fields: None,
                                                 array_length: Some(
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },

--- a/tests/parser/pass/oob_big.txt
+++ b/tests/parser/pass/oob_big.txt
@@ -19,8 +19,8 @@ Program(
                                                     ArrayDescription {
                                                         t: Bool,
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -41,8 +41,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"a",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "10",
                                                         value: 10,
                                                     },

--- a/tests/parser/pass/oob_neg.txt
+++ b/tests/parser/pass/oob_neg.txt
@@ -19,8 +19,8 @@ Program(
                                                     ArrayDescription {
                                                         t: Bool,
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -43,8 +43,8 @@ Program(
                                                 ),
                                                 index: UnOp {
                                                     op: Minus,
-                                                    operand: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    operand: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },

--- a/tests/parser/pass/oob_zero.txt
+++ b/tests/parser/pass/oob_zero.txt
@@ -19,8 +19,8 @@ Program(
                                                     ArrayDescription {
                                                         t: Bool,
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -41,8 +41,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"a",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },

--- a/tests/parser/pass/operator_precedence.txt
+++ b/tests/parser/pass/operator_precedence.txt
@@ -7,8 +7,8 @@ Program(
                 return_type: None,
                 body: Some(
                     Expression(
-                        IntegerLiteral(
-                            IntegerLiteral {
+                        Literal(
+                            Integer {
                                 repr: "3",
                                 value: 3,
                             },
@@ -24,8 +24,8 @@ Program(
                 return_type: None,
                 body: Some(
                     Expression(
-                        IntegerLiteral(
-                            IntegerLiteral {
+                        Literal(
+                            Integer {
                                 repr: "4",
                                 value: 4,
                             },
@@ -41,8 +41,8 @@ Program(
                 return_type: None,
                 body: Some(
                     Expression(
-                        IntegerLiteral(
-                            IntegerLiteral {
+                        Literal(
+                            Integer {
                                 repr: "5",
                                 value: 5,
                             },
@@ -66,14 +66,14 @@ Program(
                                             op: And,
                                             lhs: BinOp {
                                                 op: Lt,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -81,14 +81,14 @@ Program(
                                             },
                                             rhs: BinOp {
                                                 op: Gt,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "4",
                                                         value: 4,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -103,23 +103,27 @@ Program(
                                             op: Or,
                                             lhs: BinOp {
                                                 op: And,
-                                                lhs: BoolLiteral(
-                                                    True,
+                                                lhs: Literal(
+                                                    Bool {
+                                                        value: true,
+                                                    },
                                                 ),
-                                                rhs: BoolLiteral(
-                                                    False,
+                                                rhs: Literal(
+                                                    Bool {
+                                                        value: false,
+                                                    },
                                                 ),
                                             },
                                             rhs: BinOp {
                                                 op: Eq,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -156,21 +160,21 @@ Program(
                                             op: Mod,
                                             lhs: BinOp {
                                                 op: Mod,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "17",
                                                         value: 17,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "5",
                                                         value: 5,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -208,14 +212,14 @@ Program(
                                                 op: And,
                                                 lhs: BinOp {
                                                     op: Gt,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "5",
                                                             value: 5,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -223,14 +227,14 @@ Program(
                                                 },
                                                 rhs: BinOp {
                                                     op: Lt,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
                                                     ),
-                                                    rhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    rhs: Literal(
+                                                        Integer {
                                                             repr: "4",
                                                             value: 4,
                                                         },
@@ -239,8 +243,8 @@ Program(
                                             },
                                             rhs: UnOp {
                                                 op: Not,
-                                                operand: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                operand: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -255,21 +259,21 @@ Program(
                                             op: Div,
                                             lhs: BinOp {
                                                 op: Div,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "100",
                                                         value: 100,
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
                                                 ),
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "5",
                                                     value: 5,
                                                 },

--- a/tests/parser/pass/panic.txt
+++ b/tests/parser/pass/panic.txt
@@ -11,8 +11,8 @@ Program(
                             [
                                 Stmt(
                                     Print {
-                                        value: IntegerLiteral(
-                                            IntegerLiteral {
+                                        value: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -21,8 +21,10 @@ Program(
                                 ),
                                 Stmt(
                                     If {
-                                        condition: BoolLiteral(
-                                            True,
+                                        condition: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                         on_true: Block(
                                             [
@@ -41,8 +43,8 @@ Program(
                                                 [
                                                     Stmt(
                                                         Print {
-                                                            value: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            value: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },

--- a/tests/parser/pass/parse_minus.txt
+++ b/tests/parser/pass/parse_minus.txt
@@ -5,8 +5,8 @@ Program(
                 name: r"a",
                 t: None,
                 initialiser: Some(
-                    IntegerLiteral(
-                        IntegerLiteral {
+                    Literal(
+                        Integer {
                             repr: "-1",
                             value: -1,
                         },
@@ -21,14 +21,14 @@ Program(
                 initialiser: Some(
                     BinOp {
                         op: Minus,
-                        lhs: IntegerLiteral(
-                            IntegerLiteral {
+                        lhs: Literal(
+                            Integer {
                                 repr: "-1",
                                 value: -1,
                             },
                         ),
-                        rhs: IntegerLiteral(
-                            IntegerLiteral {
+                        rhs: Literal(
+                            Integer {
                                 repr: "-2",
                                 value: -2,
                             },
@@ -44,14 +44,14 @@ Program(
                 initialiser: Some(
                     BinOp {
                         op: Minus,
-                        lhs: IntegerLiteral(
-                            IntegerLiteral {
+                        lhs: Literal(
+                            Integer {
                                 repr: "-1",
                                 value: -1,
                             },
                         ),
-                        rhs: IntegerLiteral(
-                            IntegerLiteral {
+                        rhs: Literal(
+                            Integer {
                                 repr: "-2",
                                 value: -2,
                             },
@@ -67,22 +67,22 @@ Program(
                 initialiser: Some(
                     BinOp {
                         op: Plus,
-                        lhs: IntegerLiteral(
-                            IntegerLiteral {
+                        lhs: Literal(
+                            Integer {
                                 repr: "-5",
                                 value: -5,
                             },
                         ),
                         rhs: BinOp {
                             op: Plus,
-                            lhs: IntegerLiteral(
-                                IntegerLiteral {
+                            lhs: Literal(
+                                Integer {
                                     repr: "-7",
                                     value: -7,
                                 },
                             ),
-                            rhs: IntegerLiteral(
-                                IntegerLiteral {
+                            rhs: Literal(
+                                Integer {
                                     repr: "-8",
                                     value: -8,
                                 },
@@ -99,8 +99,8 @@ Program(
                 initialiser: Some(
                     UnOp {
                         op: Minus,
-                        operand: IntegerLiteral(
-                            IntegerLiteral {
+                        operand: Literal(
+                            Integer {
                                 repr: "-7",
                                 value: -7,
                             },

--- a/tests/parser/pass/print.txt
+++ b/tests/parser/pass/print.txt
@@ -111,8 +111,8 @@ Program(
                                                     [
                                                         (
                                                             r"id",
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -131,8 +131,8 @@ Program(
                                                                 ),
                                                                 fields: None,
                                                                 array_length: Some(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "3",
                                                                             value: 3,
                                                                         },
@@ -193,8 +193,8 @@ Program(
                                                     [
                                                         (
                                                             r"id",
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -221,8 +221,8 @@ Program(
                                                                 ),
                                                                 fields: None,
                                                                 array_length: Some(
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "3",
                                                                             value: 3,
                                                                         },
@@ -270,8 +270,8 @@ Program(
                                                 ),
                                                 member_name: r"links",
                                             },
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -293,8 +293,8 @@ Program(
                                                 ),
                                                 member_name: r"links",
                                             },
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },

--- a/tests/parser/pass/raytracer.txt
+++ b/tests/parser/pass/raytracer.txt
@@ -7,8 +7,8 @@ Program(
                     Real,
                 ),
                 initialiser: Some(
-                    RealLiteral(
-                        RealLiteral {
+                    Literal(
+                        Real {
                             repr: "0.0001",
                             value: 0.0001,
                         },
@@ -283,8 +283,8 @@ Program(
                                 ),
                                 rhs: BinOp {
                                     op: Minus,
-                                    lhs: IntegerLiteral(
-                                        IntegerLiteral {
+                                    lhs: Literal(
+                                        Integer {
                                             repr: "1",
                                             value: 1,
                                         },
@@ -362,8 +362,8 @@ Program(
                                                     ),
                                                 ),
                                             },
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.5",
                                                     value: 0.5,
                                                 },
@@ -383,8 +383,8 @@ Program(
                                                                     r"res",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -437,8 +437,8 @@ Program(
                                                     r"s",
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -448,8 +448,8 @@ Program(
                                             [
                                                 Stmt(
                                                     Return {
-                                                        value: RealLiteral(
-                                                            RealLiteral {
+                                                        value: Literal(
+                                                            Real {
                                                                 repr: "NaN",
                                                                 value: NaN,
                                                             },
@@ -468,8 +468,8 @@ Program(
                                             Real,
                                         ),
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "1.0",
                                                     value: 1.0,
                                                 },
@@ -486,8 +486,8 @@ Program(
                                                     r"s",
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "1.0",
                                                     value: 1.0,
                                                 },
@@ -507,8 +507,8 @@ Program(
                                                                     r"s",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -524,15 +524,15 @@ Program(
                                 Stmt(
                                     For {
                                         counter: r"i",
-                                        from: IntegerLiteral(
-                                            IntegerLiteral {
+                                        from: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
                                         ),
                                         to: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "100",
                                                     value: 100,
                                                 },
@@ -582,8 +582,8 @@ Program(
                                                                     ),
                                                                 },
                                                             },
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -1183,8 +1183,8 @@ Program(
                             args: [
                                 BinOp {
                                     op: Div,
-                                    lhs: IntegerLiteral(
-                                        IntegerLiteral {
+                                    lhs: Literal(
+                                        Integer {
                                             repr: "1",
                                             value: 1,
                                         },
@@ -1391,8 +1391,8 @@ Program(
                                                         r"val",
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },
@@ -1405,8 +1405,8 @@ Program(
                                                         r"val",
                                                     ),
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "256",
                                                         value: 256,
                                                     },
@@ -1689,20 +1689,20 @@ Program(
                     Call {
                         callee: r"colour_of",
                         args: [
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "255",
                                     value: 255,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -1720,20 +1720,20 @@ Program(
                     Call {
                         callee: r"colour_of",
                         args: [
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "255",
                                     value: 255,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -1751,20 +1751,20 @@ Program(
                     Call {
                         callee: r"colour_of",
                         args: [
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "255",
                                     value: 255,
                                 },
@@ -1782,20 +1782,20 @@ Program(
                     Call {
                         callee: r"colour_of",
                         args: [
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "0",
                                     value: 0,
                                 },
@@ -1813,20 +1813,20 @@ Program(
                     Call {
                         callee: r"colour_of",
                         args: [
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "255",
                                     value: 255,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "255",
                                     value: 255,
                                 },
                             ),
-                            IntegerLiteral(
-                                IntegerLiteral {
+                            Literal(
+                                Integer {
                                     repr: "255",
                                     value: 255,
                                 },
@@ -1922,8 +1922,8 @@ Program(
                                             ),
                                         ),
                                     },
-                                    rhs: IntegerLiteral(
-                                        IntegerLiteral {
+                                    rhs: Literal(
+                                        Integer {
                                             repr: "1",
                                             value: 1,
                                         },
@@ -2000,8 +2000,8 @@ Program(
                                                         ),
                                                     ),
                                                 },
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -2115,8 +2115,8 @@ Program(
                                 Stmt(
                                     For {
                                         counter: r"x",
-                                        from: IntegerLiteral(
-                                            IntegerLiteral {
+                                        from: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -2132,8 +2132,8 @@ Program(
                                                         member_name: r"width",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -2146,8 +2146,8 @@ Program(
                                                 Stmt(
                                                     For {
                                                         counter: r"y",
-                                                        from: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        from: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -2163,8 +2163,8 @@ Program(
                                                                         member_name: r"height",
                                                                     },
                                                                 ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                rhs: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -2279,16 +2279,16 @@ Program(
                                                     member_name: r"height",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
                                             ),
                                         },
                                         to: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -2300,8 +2300,8 @@ Program(
                                                 Stmt(
                                                     For {
                                                         counter: r"x",
-                                                        from: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        from: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -2317,8 +2317,8 @@ Program(
                                                                         member_name: r"width",
                                                                     },
                                                                 ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                rhs: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -2471,8 +2471,8 @@ Program(
                                 [
                                     (
                                         r"kind",
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -2520,8 +2520,8 @@ Program(
                                 [
                                     (
                                         r"kind",
-                                        IntegerLiteral(
-                                            IntegerLiteral {
+                                        Literal(
+                                            Integer {
                                                 repr: "2",
                                                 value: 2,
                                             },
@@ -2611,8 +2611,8 @@ Program(
                                         initialiser: Some(
                                             BinOp {
                                                 op: Mul,
-                                                lhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                lhs: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -2760,8 +2760,8 @@ Program(
                                                     op: Mul,
                                                     lhs: BinOp {
                                                         op: Mul,
-                                                        lhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        lhs: Literal(
+                                                            Integer {
                                                                 repr: "4",
                                                                 value: 4,
                                                             },
@@ -2791,8 +2791,8 @@ Program(
                                                     r"discriminant",
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -2802,8 +2802,8 @@ Program(
                                             [
                                                 Stmt(
                                                     Return {
-                                                        value: RealLiteral(
-                                                            RealLiteral {
+                                                        value: Literal(
+                                                            Real {
                                                                 repr: "NaN",
                                                                 value: NaN,
                                                             },
@@ -2847,8 +2847,8 @@ Program(
                                                 },
                                                 rhs: BinOp {
                                                     op: Mul,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -2895,8 +2895,8 @@ Program(
                                                 },
                                                 rhs: BinOp {
                                                     op: Mul,
-                                                    lhs: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    lhs: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -2930,8 +2930,8 @@ Program(
                                                     ),
                                                 ],
                                             },
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -2982,8 +2982,8 @@ Program(
                                                                         ),
                                                                     ],
                                                                 },
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                rhs: Literal(
+                                                                    Integer {
                                                                         repr: "0",
                                                                         value: 0,
                                                                     },
@@ -3017,8 +3017,8 @@ Program(
                                                                     [
                                                                         Stmt(
                                                                             Return {
-                                                                                value: RealLiteral(
-                                                                                    RealLiteral {
+                                                                                value: Literal(
+                                                                                    Real {
                                                                                         repr: "NaN",
                                                                                         value: NaN,
                                                                                     },
@@ -3091,8 +3091,8 @@ Program(
                                                         ),
                                                     ],
                                                 },
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "0",
                                                         value: 0,
                                                     },
@@ -3103,8 +3103,8 @@ Program(
                                             [
                                                 Stmt(
                                                     Return {
-                                                        value: RealLiteral(
-                                                            RealLiteral {
+                                                        value: Literal(
+                                                            Real {
                                                                 repr: "NaN",
                                                                 value: NaN,
                                                             },
@@ -3217,8 +3217,8 @@ Program(
                                                 [
                                                     Stmt(
                                                         Return {
-                                                            value: RealLiteral(
-                                                                RealLiteral {
+                                                            value: Literal(
+                                                                Real {
                                                                     repr: "NaN",
                                                                     value: NaN,
                                                                 },
@@ -3272,8 +3272,8 @@ Program(
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -3320,8 +3320,8 @@ Program(
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -3358,8 +3358,8 @@ Program(
                                 ),
                                 Stmt(
                                     Return {
-                                        value: RealLiteral(
-                                            RealLiteral {
+                                        value: Literal(
+                                            Real {
                                                 repr: "NaN",
                                                 value: NaN,
                                             },
@@ -3497,8 +3497,8 @@ Program(
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -3545,8 +3545,8 @@ Program(
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -3630,8 +3630,8 @@ Program(
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -3671,8 +3671,8 @@ Program(
                                                     member_name: r"kind",
                                                 },
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -3747,8 +3747,8 @@ Program(
                                 [
                                     (
                                         r"t",
-                                        RealLiteral(
-                                            RealLiteral {
+                                        Literal(
+                                            Real {
                                                 repr: "NaN",
                                                 value: NaN,
                                             },
@@ -4029,8 +4029,8 @@ Program(
                                             Real,
                                         ),
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -4081,20 +4081,20 @@ Program(
                                             Call {
                                                 callee: r"vector_of",
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
                                                     ),
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
                                                     ),
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "-2",
                                                             value: -2,
                                                         },
@@ -4116,20 +4116,20 @@ Program(
                                             Call {
                                                 callee: r"vector_of",
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
                                                     ),
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
                                                     ),
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -4151,20 +4151,20 @@ Program(
                                             Call {
                                                 callee: r"vector_of",
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
                                                     ),
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
                                                     ),
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -4196,8 +4196,8 @@ Program(
                                                                 ),
                                                             ),
                                                         },
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
@@ -4213,15 +4213,15 @@ Program(
                                                                 ),
                                                             ),
                                                         },
-                                                        rhs: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        rhs: Literal(
+                                                            Integer {
                                                                 repr: "2",
                                                                 value: 2,
                                                             },
                                                         ),
                                                     },
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "0",
                                                             value: 0,
                                                         },
@@ -4234,8 +4234,8 @@ Program(
                                 Stmt(
                                     For {
                                         counter: r"x",
-                                        from: IntegerLiteral(
-                                            IntegerLiteral {
+                                        from: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -4251,8 +4251,8 @@ Program(
                                                         member_name: r"width",
                                                     },
                                                 ),
-                                                rhs: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                rhs: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -4265,8 +4265,8 @@ Program(
                                                 Stmt(
                                                     For {
                                                         counter: r"y",
-                                                        from: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        from: Literal(
+                                                            Integer {
                                                                 repr: "0",
                                                                 value: 0,
                                                             },
@@ -4282,8 +4282,8 @@ Program(
                                                                         member_name: r"height",
                                                                     },
                                                                 ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                rhs: Literal(
+                                                                    Integer {
                                                                         repr: "1",
                                                                         value: 1,
                                                                     },
@@ -4333,8 +4333,8 @@ Program(
                                                                                                         },
                                                                                                         rhs: BinOp {
                                                                                                             op: Mul,
-                                                                                                            lhs: RealLiteral(
-                                                                                                                RealLiteral {
+                                                                                                            lhs: Literal(
+                                                                                                                Real {
                                                                                                                     repr: "1.0",
                                                                                                                     value: 1.0,
                                                                                                                 },
@@ -4376,8 +4376,8 @@ Program(
                                                                                                         },
                                                                                                         rhs: BinOp {
                                                                                                             op: Mul,
-                                                                                                            lhs: RealLiteral(
-                                                                                                                RealLiteral {
+                                                                                                            lhs: Literal(
+                                                                                                                Real {
                                                                                                                     repr: "1.0",
                                                                                                                     value: 1.0,
                                                                                                                 },
@@ -4516,8 +4516,8 @@ Program(
                                                                                                     Call {
                                                                                                         callee: r"vector_mul",
                                                                                                         args: [
-                                                                                                            IntegerLiteral(
-                                                                                                                IntegerLiteral {
+                                                                                                            Literal(
+                                                                                                                Integer {
                                                                                                                     repr: "-1",
                                                                                                                     value: -1,
                                                                                                                 },
@@ -4546,8 +4546,8 @@ Program(
                                                                                                     r"colour_ratio",
                                                                                                 ),
                                                                                             ),
-                                                                                            rhs: IntegerLiteral(
-                                                                                                IntegerLiteral {
+                                                                                            rhs: Literal(
+                                                                                                Integer {
                                                                                                     repr: "0",
                                                                                                     value: 0,
                                                                                                 },
@@ -4560,8 +4560,8 @@ Program(
                                                                                                         lhs: Identifier(
                                                                                                             r"colour_ratio",
                                                                                                         ),
-                                                                                                        rhs: IntegerLiteral(
-                                                                                                            IntegerLiteral {
+                                                                                                        rhs: Literal(
+                                                                                                            Integer {
                                                                                                                 repr: "1",
                                                                                                                 value: 1,
                                                                                                             },
@@ -4709,20 +4709,20 @@ Program(
                                                             Call {
                                                                 callee: r"vector_of",
                                                                 args: [
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "0.5",
                                                                             value: 0.5,
                                                                         },
                                                                     ),
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "0.5",
                                                                             value: 0.5,
                                                                         },
                                                                     ),
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "3",
                                                                             value: 3,
                                                                         },
@@ -4732,8 +4732,8 @@ Program(
                                                         ),
                                                         (
                                                             r"radius",
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -4770,20 +4770,20 @@ Program(
                                                             Call {
                                                                 callee: r"vector_of",
                                                                 args: [
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "-0.8",
                                                                             value: -0.8,
                                                                         },
                                                                     ),
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "-0.5",
                                                                             value: -0.5,
                                                                         },
                                                                     ),
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "4",
                                                                             value: 4,
                                                                         },
@@ -4793,8 +4793,8 @@ Program(
                                                         ),
                                                         (
                                                             r"radius",
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "2",
                                                                     value: 2,
                                                                 },
@@ -4831,20 +4831,20 @@ Program(
                                                             Call {
                                                                 callee: r"vector_of",
                                                                 args: [
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "0",
                                                                             value: 0,
                                                                         },
                                                                     ),
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "-1.5",
                                                                             value: -1.5,
                                                                         },
                                                                     ),
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "5",
                                                                             value: 5,
                                                                         },
@@ -4857,20 +4857,20 @@ Program(
                                                             Call {
                                                                 callee: r"vector_of",
                                                                 args: [
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "0.2",
                                                                             value: 0.2,
                                                                         },
                                                                     ),
-                                                                    IntegerLiteral(
-                                                                        IntegerLiteral {
+                                                                    Literal(
+                                                                        Integer {
                                                                             repr: "1",
                                                                             value: 1,
                                                                         },
                                                                     ),
-                                                                    RealLiteral(
-                                                                        RealLiteral {
+                                                                    Literal(
+                                                                        Real {
                                                                             repr: "-0.1",
                                                                             value: -0.1,
                                                                         },
@@ -4905,8 +4905,8 @@ Program(
                                                             r"object",
                                                         ),
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -4926,8 +4926,8 @@ Program(
                                             lhs: Identifier(
                                                 r"scene",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -4951,8 +4951,8 @@ Program(
                                             lhs: Identifier(
                                                 r"scene",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -4976,8 +4976,8 @@ Program(
                                             lhs: Identifier(
                                                 r"scene",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -5003,14 +5003,14 @@ Program(
                                                 Call {
                                                     callee: r"trace_rays",
                                                     args: [
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "36",
                                                                 value: 36,
                                                             },
                                                         ),
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "64",
                                                                 value: 64,
                                                             },

--- a/tests/parser/pass/real_comparisons.txt
+++ b/tests/parser/pass/real_comparisons.txt
@@ -13,14 +13,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Eq,
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -32,14 +32,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Ne,
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -51,14 +51,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Lt,
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -70,14 +70,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Le,
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -89,14 +89,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Gt,
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -108,14 +108,14 @@ Program(
                                     Print {
                                         value: BinOp {
                                             op: Ge,
-                                            lhs: RealLiteral(
-                                                RealLiteral {
+                                            lhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -134,21 +134,21 @@ Program(
                                                 op: Plus,
                                                 lhs: BinOp {
                                                     op: Plus,
-                                                    lhs: RealLiteral(
-                                                        RealLiteral {
+                                                    lhs: Literal(
+                                                        Real {
                                                             repr: "0.1",
                                                             value: 0.1,
                                                         },
                                                     ),
-                                                    rhs: RealLiteral(
-                                                        RealLiteral {
+                                                    rhs: Literal(
+                                                        Real {
                                                             repr: "0.1",
                                                             value: 0.1,
                                                         },
                                                     ),
                                                 },
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.1",
                                                         value: 0.1,
                                                     },
@@ -175,8 +175,8 @@ Program(
                                                     r"a",
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.3",
                                                     value: 0.3,
                                                 },
@@ -193,14 +193,14 @@ Program(
                                         initialiser: Some(
                                             BinOp {
                                                 op: Plus,
-                                                lhs: RealLiteral(
-                                                    RealLiteral {
+                                                lhs: Literal(
+                                                    Real {
                                                         repr: "0.1",
                                                         value: 0.1,
                                                     },
                                                 ),
-                                                rhs: RealLiteral(
-                                                    RealLiteral {
+                                                rhs: Literal(
+                                                    Real {
                                                         repr: "0.2",
                                                         value: 0.2,
                                                     },
@@ -227,8 +227,8 @@ Program(
                                                     r"b",
                                                 ),
                                             ),
-                                            rhs: RealLiteral(
-                                                RealLiteral {
+                                            rhs: Literal(
+                                                Real {
                                                     repr: "0.3",
                                                     value: 0.3,
                                                 },

--- a/tests/parser/pass/real_literals.txt
+++ b/tests/parser/pass/real_literals.txt
@@ -14,8 +14,8 @@ Program(
                                         name: r"a",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },
@@ -37,8 +37,8 @@ Program(
                                         name: r"b",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "3.14",
                                                     value: 3.14,
                                                 },
@@ -60,8 +60,8 @@ Program(
                                         name: r"c",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "1.5",
                                                     value: 1.5,
                                                 },
@@ -83,8 +83,8 @@ Program(
                                         name: r"d",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "0.5",
                                                     value: 0.5,
                                                 },
@@ -106,8 +106,8 @@ Program(
                                         name: r"e",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "10.25",
                                                     value: 10.25,
                                                 },
@@ -129,8 +129,8 @@ Program(
                                         name: r"f",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "0.001",
                                                     value: 0.001,
                                                 },
@@ -152,8 +152,8 @@ Program(
                                         name: r"g",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "999.999999999999",
                                                     value: 999.999999999999,
                                                 },
@@ -175,8 +175,8 @@ Program(
                                         name: r"h",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "0.12345678901234",
                                                     value: 0.12345678901234,
                                                 },
@@ -198,8 +198,8 @@ Program(
                                         name: r"i",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "2.71828182845904",
                                                     value: 2.71828182845904,
                                                 },
@@ -221,8 +221,8 @@ Program(
                                         name: r"j",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "1.11111111111111",
                                                     value: 1.11111111111111,
                                                 },
@@ -244,8 +244,8 @@ Program(
                                         name: r"k",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "0.00000000000001",
                                                     value: 1e-14,
                                                 },
@@ -267,8 +267,8 @@ Program(
                                         name: r"l",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "12345.6789012345",
                                                     value: 12345.6789012345,
                                                 },
@@ -290,8 +290,8 @@ Program(
                                         name: r"m",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "NaN",
                                                     value: NaN,
                                                 },
@@ -313,8 +313,8 @@ Program(
                                         name: r"n",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: ".5",
                                                     value: 0.5,
                                                 },
@@ -336,8 +336,8 @@ Program(
                                         name: r"o",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "-.5",
                                                     value: -0.5,
                                                 },
@@ -359,8 +359,8 @@ Program(
                                         name: r"p",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "+.5",
                                                     value: 0.5,
                                                 },
@@ -384,8 +384,8 @@ Program(
                                         initialiser: Some(
                                             UnOp {
                                                 op: Minus,
-                                                operand: RealLiteral(
-                                                    RealLiteral {
+                                                operand: Literal(
+                                                    Real {
                                                         repr: "NaN",
                                                         value: NaN,
                                                     },
@@ -408,8 +408,8 @@ Program(
                                         name: r"r",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "Inf",
                                                     value: inf,
                                                 },
@@ -433,8 +433,8 @@ Program(
                                         initialiser: Some(
                                             UnOp {
                                                 op: Minus,
-                                                operand: RealLiteral(
-                                                    RealLiteral {
+                                                operand: Literal(
+                                                    Real {
                                                         repr: "Inf",
                                                         value: inf,
                                                     },

--- a/tests/parser/pass/records.txt
+++ b/tests/parser/pass/records.txt
@@ -228,8 +228,8 @@ Program(
                                             },
                                         ),
                                     },
-                                    rhs: IntegerLiteral(
-                                        IntegerLiteral {
+                                    rhs: Literal(
+                                        Integer {
                                             repr: "2",
                                             value: 2,
                                         },
@@ -256,8 +256,8 @@ Program(
                                             },
                                         ),
                                     },
-                                    rhs: IntegerLiteral(
-                                        IntegerLiteral {
+                                    rhs: Literal(
+                                        Integer {
                                             repr: "2",
                                             value: 2,
                                         },
@@ -286,14 +286,14 @@ Program(
                                             Call {
                                                 callee: r"point_of",
                                                 args: [
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "0.0",
                                                             value: 0.0,
                                                         },
                                                     ),
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "0.0",
                                                             value: 0.0,
                                                         },
@@ -311,14 +311,14 @@ Program(
                                             Call {
                                                 callee: r"point_of",
                                                 args: [
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "3.0",
                                                             value: 3.0,
                                                         },
                                                     ),
-                                                    RealLiteral(
-                                                        RealLiteral {
+                                                    Literal(
+                                                        Real {
                                                             repr: "4.0",
                                                             value: 4.0,
                                                         },

--- a/tests/parser/pass/recursive_function.txt
+++ b/tests/parser/pass/recursive_function.txt
@@ -25,8 +25,8 @@ Program(
                                                     r"n",
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -36,8 +36,8 @@ Program(
                                             [
                                                 Stmt(
                                                     Return {
-                                                        value: IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        value: Literal(
+                                                            Integer {
                                                                 repr: "1",
                                                                 value: 1,
                                                             },
@@ -63,8 +63,8 @@ Program(
                                                                                     r"n",
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "1",
                                                                                     value: 1,
                                                                                 },
@@ -82,8 +82,8 @@ Program(
                                                                                     r"n",
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "2",
                                                                                     value: 2,
                                                                                 },
@@ -119,8 +119,8 @@ Program(
                                         value: Call {
                                             callee: r"fibonacci",
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "10",
                                                         value: 10,
                                                     },

--- a/tests/parser/pass/recursive_types.txt
+++ b/tests/parser/pass/recursive_types.txt
@@ -150,8 +150,8 @@ Program(
                                         name: r"result",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -188,8 +188,8 @@ Program(
                                                                     r"result",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -367,8 +367,8 @@ Program(
                                             Call {
                                                 callee: r"singleton",
                                                 args: [
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },

--- a/tests/parser/pass/references.txt
+++ b/tests/parser/pass/references.txt
@@ -38,8 +38,8 @@ Program(
                                 lhs: Identifier(
                                     r"t",
                                 ),
-                                index: IntegerLiteral(
-                                    IntegerLiteral {
+                                index: Literal(
+                                    Integer {
                                         repr: "1",
                                         value: 1,
                                     },
@@ -82,8 +82,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"t",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -272,8 +272,8 @@ Program(
                                                 ),
                                                 fields: None,
                                                 array_length: Some(
-                                                    IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -289,8 +289,8 @@ Program(
                                             lhs: Identifier(
                                                 r"t",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -309,8 +309,8 @@ Program(
                                             lhs: Identifier(
                                                 r"t",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -336,8 +336,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"t",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -365,8 +365,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"t",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -497,8 +497,8 @@ Program(
                                                 ArrayDescription {
                                                     t: Int,
                                                     length: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -537,8 +537,8 @@ Program(
                                                 ArrayDescription {
                                                     t: Int,
                                                     length: Some(
-                                                        IntegerLiteral(
-                                                            IntegerLiteral {
+                                                        Literal(
+                                                            Integer {
                                                                 repr: "3",
                                                                 value: 3,
                                                             },
@@ -607,8 +607,8 @@ Program(
                                                     ArrayDescription {
                                                         t: Int,
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -628,15 +628,15 @@ Program(
                                             lhs: Identifier(
                                                 r"a",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "10",
                                                 value: 10,
                                             },
@@ -649,15 +649,15 @@ Program(
                                             lhs: Identifier(
                                                 r"a",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "20",
                                                 value: 20,
                                             },
@@ -670,15 +670,15 @@ Program(
                                             lhs: Identifier(
                                                 r"a",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
                                             ),
                                         },
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "30",
                                                 value: 30,
                                             },
@@ -695,8 +695,8 @@ Program(
                                                     ArrayDescription {
                                                         t: Int,
                                                         length: Some(
-                                                            IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            Literal(
+                                                                Integer {
                                                                     repr: "3",
                                                                     value: 3,
                                                                 },
@@ -737,8 +737,8 @@ Program(
                                             lhs: Identifier(
                                                 r"b",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -749,8 +749,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"a",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "1",
                                                         value: 1,
                                                     },
@@ -765,8 +765,8 @@ Program(
                                             lhs: Identifier(
                                                 r"b",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "2",
                                                     value: 2,
                                                 },
@@ -777,8 +777,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"a",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "2",
                                                         value: 2,
                                                     },
@@ -793,8 +793,8 @@ Program(
                                             lhs: Identifier(
                                                 r"b",
                                             ),
-                                            index: IntegerLiteral(
-                                                IntegerLiteral {
+                                            index: Literal(
+                                                Integer {
                                                     repr: "3",
                                                     value: 3,
                                                 },
@@ -805,8 +805,8 @@ Program(
                                                 lhs: Identifier(
                                                     r"a",
                                                 ),
-                                                index: IntegerLiteral(
-                                                    IntegerLiteral {
+                                                index: Literal(
+                                                    Integer {
                                                         repr: "3",
                                                         value: 3,
                                                     },
@@ -855,8 +855,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"a",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -868,8 +868,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"b",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "1",
                                                             value: 1,
                                                         },
@@ -892,8 +892,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"a",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -905,8 +905,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"b",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "2",
                                                             value: 2,
                                                         },
@@ -929,8 +929,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"a",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },
@@ -942,8 +942,8 @@ Program(
                                                     lhs: Identifier(
                                                         r"b",
                                                     ),
-                                                    index: IntegerLiteral(
-                                                        IntegerLiteral {
+                                                    index: Literal(
+                                                        Integer {
                                                             repr: "3",
                                                             value: 3,
                                                         },

--- a/tests/parser/pass/shadow.txt
+++ b/tests/parser/pass/shadow.txt
@@ -7,8 +7,8 @@ Program(
                     Int,
                 ),
                 initialiser: Some(
-                    IntegerLiteral(
-                        IntegerLiteral {
+                    Literal(
+                        Integer {
                             repr: "0",
                             value: 0,
                         },
@@ -39,8 +39,8 @@ Program(
                                         name: r"x",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -59,8 +59,10 @@ Program(
                                 ),
                                 Stmt(
                                     If {
-                                        condition: BoolLiteral(
-                                            True,
+                                        condition: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                         on_true: Block(
                                             [
@@ -69,8 +71,10 @@ Program(
                                                         name: r"x",
                                                         t: None,
                                                         initialiser: Some(
-                                                            BoolLiteral(
-                                                                True,
+                                                            Literal(
+                                                                Bool {
+                                                                    value: true,
+                                                                },
                                                             ),
                                                         ),
                                                     },

--- a/tests/parser/pass/type_aliases.txt
+++ b/tests/parser/pass/type_aliases.txt
@@ -37,8 +37,8 @@ Program(
                                     ),
                                     target: Real,
                                 },
-                                rhs: RealLiteral(
-                                    RealLiteral {
+                                rhs: Literal(
+                                    Real {
                                         repr: "1.60934",
                                         value: 1.60934,
                                     },
@@ -67,8 +67,8 @@ Program(
                                         t: None,
                                         initialiser: Some(
                                             Cast {
-                                                operand: RealLiteral(
-                                                    RealLiteral {
+                                                operand: Literal(
+                                                    Real {
                                                         repr: "10.0",
                                                         value: 10.0,
                                                     },

--- a/tests/parser/pass/type_conversions.txt
+++ b/tests/parser/pass/type_conversions.txt
@@ -41,8 +41,8 @@ Program(
                                         lhs: Identifier(
                                             r"i",
                                         ),
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "5",
                                                 value: 5,
                                             },
@@ -54,8 +54,8 @@ Program(
                                         lhs: Identifier(
                                             r"i",
                                         ),
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "3.7",
                                                 value: 3.7,
                                             },
@@ -67,8 +67,10 @@ Program(
                                         lhs: Identifier(
                                             r"i",
                                         ),
-                                        rhs: BoolLiteral(
-                                            True,
+                                        rhs: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                     },
                                 ),
@@ -77,8 +79,10 @@ Program(
                                         lhs: Identifier(
                                             r"i",
                                         ),
-                                        rhs: BoolLiteral(
-                                            False,
+                                        rhs: Literal(
+                                            Bool {
+                                                value: false,
+                                            },
                                         ),
                                     },
                                 ),
@@ -87,8 +91,8 @@ Program(
                                         lhs: Identifier(
                                             r"r",
                                         ),
-                                        rhs: RealLiteral(
-                                            RealLiteral {
+                                        rhs: Literal(
+                                            Real {
                                                 repr: "2.5",
                                                 value: 2.5,
                                             },
@@ -100,8 +104,8 @@ Program(
                                         lhs: Identifier(
                                             r"r",
                                         ),
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "10",
                                                 value: 10,
                                             },
@@ -113,8 +117,10 @@ Program(
                                         lhs: Identifier(
                                             r"r",
                                         ),
-                                        rhs: BoolLiteral(
-                                            True,
+                                        rhs: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                     },
                                 ),
@@ -123,8 +129,10 @@ Program(
                                         lhs: Identifier(
                                             r"r",
                                         ),
-                                        rhs: BoolLiteral(
-                                            False,
+                                        rhs: Literal(
+                                            Bool {
+                                                value: false,
+                                            },
                                         ),
                                     },
                                 ),
@@ -133,8 +141,10 @@ Program(
                                         lhs: Identifier(
                                             r"b",
                                         ),
-                                        rhs: BoolLiteral(
-                                            True,
+                                        rhs: Literal(
+                                            Bool {
+                                                value: true,
+                                            },
                                         ),
                                     },
                                 ),
@@ -143,8 +153,10 @@ Program(
                                         lhs: Identifier(
                                             r"b",
                                         ),
-                                        rhs: BoolLiteral(
-                                            False,
+                                        rhs: Literal(
+                                            Bool {
+                                                value: false,
+                                            },
                                         ),
                                     },
                                 ),
@@ -153,8 +165,8 @@ Program(
                                         lhs: Identifier(
                                             r"b",
                                         ),
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "1",
                                                 value: 1,
                                             },
@@ -166,8 +178,8 @@ Program(
                                         lhs: Identifier(
                                             r"b",
                                         ),
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },

--- a/tests/parser/pass/variable_declarations.txt
+++ b/tests/parser/pass/variable_declarations.txt
@@ -7,8 +7,8 @@ Program(
                     Int,
                 ),
                 initialiser: Some(
-                    IntegerLiteral(
-                        IntegerLiteral {
+                    Literal(
+                        Integer {
                             repr: "0",
                             value: 0,
                         },
@@ -21,8 +21,8 @@ Program(
                 name: r"b",
                 t: None,
                 initialiser: Some(
-                    RealLiteral(
-                        RealLiteral {
+                    Literal(
+                        Real {
                             repr: "1.5",
                             value: 1.5,
                         },
@@ -53,8 +53,10 @@ Program(
                                         name: r"local",
                                         t: None,
                                         initialiser: Some(
-                                            BoolLiteral(
-                                                True,
+                                            Literal(
+                                                Bool {
+                                                    value: true,
+                                                },
                                             ),
                                         ),
                                     },
@@ -64,8 +66,8 @@ Program(
                                         lhs: Identifier(
                                             r"c",
                                         ),
-                                        rhs: IntegerLiteral(
-                                            IntegerLiteral {
+                                        rhs: Literal(
+                                            Integer {
                                                 repr: "0",
                                                 value: 0,
                                             },
@@ -77,8 +79,8 @@ Program(
                                         name: r"another_local",
                                         t: None,
                                         initialiser: Some(
-                                            RealLiteral(
-                                                RealLiteral {
+                                            Literal(
+                                                Real {
                                                     repr: "0.0",
                                                     value: 0.0,
                                                 },

--- a/tests/parser/pass/while_loops.txt
+++ b/tests/parser/pass/while_loops.txt
@@ -21,8 +21,8 @@ Program(
                                         name: r"steps",
                                         t: None,
                                         initialiser: Some(
-                                            IntegerLiteral(
-                                                IntegerLiteral {
+                                            Literal(
+                                                Integer {
                                                     repr: "0",
                                                     value: 0,
                                                 },
@@ -39,8 +39,8 @@ Program(
                                                     r"n",
                                                 ),
                                             ),
-                                            rhs: IntegerLiteral(
-                                                IntegerLiteral {
+                                            rhs: Literal(
+                                                Integer {
                                                     repr: "1",
                                                     value: 1,
                                                 },
@@ -59,15 +59,15 @@ Program(
                                                                         r"n",
                                                                     ),
                                                                 ),
-                                                                rhs: IntegerLiteral(
-                                                                    IntegerLiteral {
+                                                                rhs: Literal(
+                                                                    Integer {
                                                                         repr: "2",
                                                                         value: 2,
                                                                     },
                                                                 ),
                                                             },
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "0",
                                                                     value: 0,
                                                                 },
@@ -87,8 +87,8 @@ Program(
                                                                                     r"n",
                                                                                 ),
                                                                             ),
-                                                                            rhs: IntegerLiteral(
-                                                                                IntegerLiteral {
+                                                                            rhs: Literal(
+                                                                                Integer {
                                                                                     repr: "2",
                                                                                     value: 2,
                                                                                 },
@@ -110,8 +110,8 @@ Program(
                                                                                 op: Plus,
                                                                                 lhs: BinOp {
                                                                                     op: Mul,
-                                                                                    lhs: IntegerLiteral(
-                                                                                        IntegerLiteral {
+                                                                                    lhs: Literal(
+                                                                                        Integer {
                                                                                             repr: "3",
                                                                                             value: 3,
                                                                                         },
@@ -122,8 +122,8 @@ Program(
                                                                                         ),
                                                                                     ),
                                                                                 },
-                                                                                rhs: IntegerLiteral(
-                                                                                    IntegerLiteral {
+                                                                                rhs: Literal(
+                                                                                    Integer {
                                                                                         repr: "1",
                                                                                         value: 1,
                                                                                     },
@@ -148,8 +148,8 @@ Program(
                                                                     r"steps",
                                                                 ),
                                                             ),
-                                                            rhs: IntegerLiteral(
-                                                                IntegerLiteral {
+                                                            rhs: Literal(
+                                                                Integer {
                                                                     repr: "1",
                                                                     value: 1,
                                                                 },
@@ -190,8 +190,8 @@ Program(
                                         value: Call {
                                             callee: r"collatz",
                                             args: [
-                                                IntegerLiteral(
-                                                    IntegerLiteral {
+                                                Literal(
+                                                    Integer {
                                                         repr: "7",
                                                         value: 7,
                                                     },


### PR DESCRIPTION
... and also `ConstDecl`s

Also fixes parser recovery for integer literals (it would try to recover from `MalformedReal` instead of `MalformedInteger`)

- #112 
- #97