### PR TITLE
ci: also run doctests, lmao

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Gather data
-        run: cargo llvm-cov test --workspace --all-targets --lcov --output-path coverage.lcov
+        run: cargo llvm-cov test --workspace --lcov --output-path coverage.lcov
 
       - name: Upload report
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -82,7 +82,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Gather data
-        run: cargo llvm-cov test --workspace --all-targets --lcov --output-path baseline.lcov
+        run: cargo llvm-cov test --workspace --lcov --output-path baseline.lcov
 
       - name: Upload report
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,4 +57,4 @@ jobs:
         with:
           rustflags: ""
       - name: Run tests
-        run: cargo test --workspace --all-targets --no-fail-fast
+        run: cargo test --workspace --no-fail-fast


### PR DESCRIPTION
Very intuitively, passing `--all-targets` to `cargo test` means that it will not run doctets.

We don't currently have any doctets, but damn is this funny.